### PR TITLE
fix(chat): forward Matrix formatted_body mentions

### DIFF
--- a/src/app/api/matrix/rooms/[roomId]/send/route.test.ts
+++ b/src/app/api/matrix/rooms/[roomId]/send/route.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { PUT } from './route';
+
+describe('Matrix room message send route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards Matrix formatted_body used by visible mentions', async () => {
+    const matrixFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ event_id: '$event' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const userId = '@smoke-openclaw:matrix-local.agentteams.io:18080';
+    const formattedBody = `<a href="https://matrix.to/#/${encodeURIComponent(userId)}">@smoke-openclaw</a> hello`;
+    const request = new NextRequest(
+      'http://dashboard.test/api/matrix/rooms/room/send?homeserver=http%3A%2F%2F127.0.0.1%3A6167',
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          msgtype: 'm.text',
+          body: '@smoke-openclaw hello',
+          format: 'org.matrix.custom.html',
+          formatted_body: formattedBody,
+          'm.mentions': { user_ids: [userId] },
+        }),
+      }
+    );
+
+    const response = await PUT(request, { params: Promise.resolve({ roomId: '!room:test' }) });
+
+    expect(response.status).toBe(200);
+    expect(matrixFetch).toHaveBeenCalledOnce();
+    const options = matrixFetch.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(options.body as string)).toEqual({
+      msgtype: 'm.text',
+      body: '@smoke-openclaw hello',
+      format: 'org.matrix.custom.html',
+      formatted_body: formattedBody,
+      'm.mentions': { user_ids: [userId] },
+    });
+  });
+});

--- a/src/app/api/matrix/rooms/[roomId]/send/route.ts
+++ b/src/app/api/matrix/rooms/[roomId]/send/route.ts
@@ -12,7 +12,7 @@ export async function PUT(
     const accessToken = getAccessToken(request);
 
     const body = await request.json();
-    const { msgtype = 'm.text', body: messageBody, format, formattedBody, url: mediaUrl, info, 'm.mentions': mentions } = body;
+    const { msgtype = 'm.text', body: messageBody, format, formatted_body: formattedBody, url: mediaUrl, info, 'm.mentions': mentions } = body;
 
     if (!messageBody) {
       return NextResponse.json({ error: 'Missing message body' }, { status: 400 });


### PR DESCRIPTION
## What changed

- Read the Matrix-standard `formatted_body` field in the room message send proxy.
- Add a route regression test that verifies `format`, `formatted_body`, and `m.mentions` are all forwarded to the homeserver.

## Why

The chat composer correctly sends `formatted_body`, but the API route attempted to read a camelCase `formattedBody` property. The proxy therefore silently dropped the visible Matrix mention link while retaining `m.mentions`. OpenClaw intentionally rejects metadata-only mentions, so Worker messages sent from Dashboard appeared successful but received no response.

## Impact

Dashboard mentions now retain their visible Matrix link and wake OpenClaw Workers as expected.

## Validation

- `npm test -- 'src/app/api/matrix/rooms/[roomId]/send/route.test.ts'`
- Targeted ESLint on the changed route and test
- Production Docker image build
- Local Dashboard → Matrix → OpenClaw smoke test; Worker replied `DASHBOARD_MENTION_FIX_OK_20260730`

Note: repository-wide `npm run typecheck` currently reports the pre-existing `toBeInTheDocument` matcher type error in `src/components/dashboard/sections/shared/model-selector.test.tsx`.
