### PR TITLE
fix(chat): stop stuck streaming dots via incremental A2UI rendering + timeout

### DIFF
--- a/src/components/dashboard/sections/chat/a2ui/a2ui-chat-content.tsx
+++ b/src/components/dashboard/sections/chat/a2ui/a2ui-chat-content.tsx
@@ -15,7 +15,7 @@ import {
   thinkingToA2uiMessages,
   type ParsedA2uiBlock,
 } from '@/lib/a2ui/parser';
-import { A2uiSurfaceRenderer } from './a2ui-surface-renderer';
+import { IncrementalA2uiRenderer } from './a2ui-surface-renderer';
 
 // ─── Code Block Component ────────────────────────────────────────────────────
 
@@ -267,7 +267,7 @@ const A2uiBlocks = memo(function A2uiBlocks({
         switch (block.type) {
           case 'a2ui':
             return (
-              <A2uiSurfaceRenderer
+              <IncrementalA2uiRenderer
                 key={key}
                 messages={block.messages || []}
                 messageKey={key}
@@ -305,7 +305,7 @@ const LegacyBlocks = memo(function LegacyBlocks({
         switch (block.type) {
           case 'thinking':
             return block.content ? (
-              <A2uiSurfaceRenderer
+              <IncrementalA2uiRenderer
                 key={key}
                 messages={thinkingToA2uiMessages(block.content, key, isStreaming)}
                 messageKey={key}
@@ -315,7 +315,7 @@ const LegacyBlocks = memo(function LegacyBlocks({
 
           case 'tool_call':
             return block.payload ? (
-              <A2uiSurfaceRenderer
+              <IncrementalA2uiRenderer
                 key={key}
                 messages={legacyToA2uiMessages(block.payload, key, true)}
                 messageKey={key}
@@ -334,7 +334,7 @@ const LegacyBlocks = memo(function LegacyBlocks({
 
           case 'card':
             return block.payload ? (
-              <A2uiSurfaceRenderer
+              <IncrementalA2uiRenderer
                 key={key}
                 messages={legacyToA2uiMessages(block.payload, key, false)}
                 messageKey={key}

--- a/src/components/dashboard/sections/chat/a2ui/a2ui-surface-renderer.tsx
+++ b/src/components/dashboard/sections/chat/a2ui/a2ui-surface-renderer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, memo } from 'react';
+import { AlertCircle } from 'lucide-react';
 import { MessageProcessor, Catalog } from '@a2ui/web_core/v0_9';
 import { A2uiSurface, basicCatalog, type ReactComponentImplementation } from '@a2ui/react/v0_9';
 import type { A2uiMessage } from '@a2ui/web_core/v0_9';
@@ -23,88 +24,6 @@ const chatCatalog = new Catalog<ReactComponentImplementation>(
   Array.from(mergedFunctions.values())
 );
 
-// ─── A2uiSurfaceRenderer ─────────────────────────────────────────────────────
-
-interface A2uiSurfaceRendererProps {
-  /** A2UI protocol messages to render */
-  messages: A2uiMessage[];
-  /** Unique key for this message block (used as surface ID prefix) */
-  messageKey: string;
-  /** Whether new messages may arrive (streaming mode) */
-  isStreaming?: boolean;
-}
-
-/**
- * Renders A2UI protocol messages as React surfaces inline in chat bubbles.
- * Each message block gets its own MessageProcessor and surface.
- */
-export const A2uiSurfaceRenderer = memo(function A2uiSurfaceRenderer({
-  messages,
-  messageKey,
-  isStreaming = false,
-}: A2uiSurfaceRendererProps) {
-  const processorRef = useRef<MessageProcessor<ReactComponentImplementation> | null>(null);
-  const [surfaces, setSurfaces] = useState<Array<{ id: string; surface: any }>>([]);
-
-  // Initialize processor and process messages
-  useEffect(() => {
-    if (!messages || messages.length === 0) return;
-
-    // Create processor if not exists
-    if (!processorRef.current) {
-      processorRef.current = new MessageProcessor<ReactComponentImplementation>([chatCatalog]);
-    }
-
-    const processor = processorRef.current;
-
-    // Process all messages
-    try {
-      processor.processMessages(messages);
-    } catch (err) {
-      console.error('[A2UI] Failed to process messages:', err);
-    }
-
-    // Sync surfaces
-    const sync = () => {
-      const list: Array<{ id: string; surface: any }> = [];
-      processor.model.surfacesMap.forEach((surface: unknown, id: string) => {
-        if (surface) list.push({ id, surface });
-      });
-      setSurfaces(list);
-    };
-
-    sync();
-
-    // Subscribe to surface changes
-    const createdSub = processor.onSurfaceCreated(sync);
-    const deletedSub = processor.onSurfaceDeleted(sync);
-
-    return () => {
-      createdSub.unsubscribe();
-      deletedSub.unsubscribe();
-    };
-  }, [messages]);
-
-  if (!messages || messages.length === 0) return null;
-
-  return (
-    <div className="a2ui-chat-content">
-      {surfaces.map(({ id, surface }) => (
-        <div key={`${messageKey}-${id}`} className="a2ui-surface-container">
-          <A2uiSurface surface={surface} />
-        </div>
-      ))}
-      {isStreaming && surfaces.length === 0 && (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2 animate-pulse">
-          <div className="w-2 h-2 rounded-full bg-foreground/40 animate-bounce" style={{ animationDelay: '0ms' }} />
-          <div className="w-2 h-2 rounded-full bg-foreground/40 animate-bounce" style={{ animationDelay: '150ms' }} />
-          <div className="w-2 h-2 rounded-full bg-foreground/40 animate-bounce" style={{ animationDelay: '300ms' }} />
-        </div>
-      )}
-    </div>
-  );
-});
-
 // ─── IncrementalA2uiRenderer ─────────────────────────────────────────────────
 
 interface IncrementalA2uiRendererProps {
@@ -112,19 +31,28 @@ interface IncrementalA2uiRendererProps {
   messages: A2uiMessage[];
   /** Unique key for this message block */
   messageKey: string;
+  /** Whether new messages may arrive (streaming mode) */
+  isStreaming?: boolean;
 }
+
+/** How long to keep showing the streaming dots before declaring the stream stuck. */
+const STREAM_STUCK_TIMEOUT_MS = 30_000;
 
 /**
  * Incremental A2UI renderer for streaming scenarios.
- * Processes messages incrementally as they arrive, without re-creating the processor.
+ * Processes messages incrementally as they arrive, without re-creating the
+ * processor or re-processing already-seen messages (which would corrupt the
+ * processor's internal surface state).
  */
 export const IncrementalA2uiRenderer = memo(function IncrementalA2uiRenderer({
   messages,
   messageKey,
+  isStreaming = false,
 }: IncrementalA2uiRendererProps) {
   const processorRef = useRef<MessageProcessor<ReactComponentImplementation> | null>(null);
   const processedCountRef = useRef(0);
   const [surfaces, setSurfaces] = useState<Array<{ id: string; surface: any }>>([]);
+  const [streamStuck, setStreamStuck] = useState(false);
 
   useEffect(() => {
     if (!messages || messages.length === 0) return;
@@ -173,7 +101,21 @@ export const IncrementalA2uiRenderer = memo(function IncrementalA2uiRenderer({
     processorRef.current = null;
     processedCountRef.current = 0;
     setSurfaces([]);
+    setStreamStuck(false);
   }, [messageKey]);
+
+  // Guard against a stream that never yields a surface: if we stay streaming
+  // with zero surfaces past the timeout, stop the animated dots so they don't
+  // render forever (e.g. the final edit still carries a streaming marker or
+  // A2UI parsing fails silently).
+  useEffect(() => {
+    if (!isStreaming || surfaces.length > 0) {
+      setStreamStuck(false);
+      return;
+    }
+    const timer = setTimeout(() => setStreamStuck(true), STREAM_STUCK_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [isStreaming, surfaces.length]);
 
   return (
     <div className="a2ui-chat-content">
@@ -182,6 +124,19 @@ export const IncrementalA2uiRenderer = memo(function IncrementalA2uiRenderer({
           <A2uiSurface surface={surface} />
         </div>
       ))}
+      {isStreaming && surfaces.length === 0 && !streamStuck && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2 animate-pulse">
+          <div className="w-2 h-2 rounded-full bg-foreground/40 animate-bounce" style={{ animationDelay: '0ms' }} />
+          <div className="w-2 h-2 rounded-full bg-foreground/40 animate-bounce" style={{ animationDelay: '150ms' }} />
+          <div className="w-2 h-2 rounded-full bg-foreground/40 animate-bounce" style={{ animationDelay: '300ms' }} />
+        </div>
+      )}
+      {isStreaming && surfaces.length === 0 && streamStuck && (
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground py-2">
+          <AlertCircle className="w-3.5 h-3.5 text-amber-500" />
+          <span>仍在等待内容，若长时间无响应请刷新消息</span>
+        </div>
+      )}
     </div>
   );
 });

--- a/src/components/dashboard/sections/chat/a2ui/index.ts
+++ b/src/components/dashboard/sections/chat/a2ui/index.ts
@@ -1,2 +1,2 @@
-export { A2uiSurfaceRenderer, IncrementalA2uiRenderer } from './a2ui-surface-renderer';
+export { IncrementalA2uiRenderer } from './a2ui-surface-renderer';
 export { A2uiChatContent } from './a2ui-chat-content';


### PR DESCRIPTION
## Problem\nStreaming output ends but the three gray bouncing dots keep rendering forever.\n\n## Root cause\n- `A2uiSurfaceRenderer` called `processor.processMessages(messages)` with the **full** message list on every change, corrupting the shared `MessageProcessor`'s internal surface state; if processing failed (caught and swallowed), `surfacesMap` stayed empty so the dots never disappeared.\n- The final edited message can still carry a streaming marker, and with polling-based refetch there was no timeout to stop the animation.\n\n## Fix\n1. **Incremental rendering**: `A2uiBlocks`/`LegacyBlocks` now use `IncrementalA2uiRenderer`, which only feeds newly-arrived messages to the processor (`messages.slice(startIndex)`) and resets on `messageKey` change. Removed the old full-reprocessing renderer.\n2. **Timeout guard**: if `isStreaming` is true with zero surfaces for 30s, the animated dots are replaced by a static stale-stream hint (AlertCircle) so the UI never shows a permanent loading state.\n3. `formatMatrixEvents` already derives `isStreaming` from the latest edit revision, which is correct; the remaining "final message still streaming" case is now covered by the timeout.\n\nVerified: tsc clean, eslint clean, vitest 255 passed.