### PR TITLE
fix(workers): validate MinIO access-key name length in dialogs

### DIFF
--- a/src/components/dashboard/sections/teams/team-create-dialog.tsx
+++ b/src/components/dashboard/sections/teams/team-create-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import type { CreateTeamRequest, WorkerResponse } from '@/lib/agentteams-api';
+import { workerNameError } from '@/lib/resource-name';
 
 export function parseWorkerNames(value: string): string[] {
   return value.split(/[,，]/).map((name) => name.trim()).filter(Boolean);
@@ -50,6 +51,11 @@ export function TeamCreateDialog({
   const selectedWorkers = workers.filter((worker) => value.workerNames?.includes(worker.name));
   const workersWithoutModel = selectedWorkers.filter((worker) => !worker.model?.trim());
 
+  const leaderError = value.leader?.name ? workerNameError(value.leader.name) : null;
+  const workerNamesError = (value.workerNames ?? [])
+    .map(workerNameError)
+    .find((err) => err !== null) ?? null;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg max-w-[95vw]">
@@ -72,6 +78,7 @@ export function TeamCreateDialog({
               onChange={(e) => onChange({ ...value, leader: { name: e.target.value } })}
               placeholder="leader-name"
             />
+            {leaderError && <p className="text-xs text-red-600 dark:text-red-400">{leaderError}</p>}
           </div>
           <div className="space-y-2">
             <Label>团队名称</Label>
@@ -104,6 +111,7 @@ export function TeamCreateDialog({
               }}
               placeholder="worker1, worker2 或 worker1，worker2"
             />
+            {workerNamesError && <p className="text-xs text-red-600 dark:text-red-400">{workerNamesError}</p>}
           </div>
           <div className="rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground space-y-1">
             <p>团队模型由 Leader 运行时与成员 Worker 的“请求模型别名”分别管理。</p>
@@ -124,7 +132,7 @@ export function TeamCreateDialog({
           </Button>
           <Button
             onClick={onSubmit}
-            disabled={!value.name || !value.leader?.name || isPending}
+            disabled={!value.name || !value.leader?.name || !!leaderError || !!workerNamesError || isPending}
             className="bg-gradient-to-r from-emerald-500 to-teal-500 text-white hover:from-emerald-600 hover:to-teal-600"
           >
             {isPending ? '创建中...' : '创建'}

--- a/src/components/dashboard/sections/teams/team-edit-dialog.tsx
+++ b/src/components/dashboard/sections/teams/team-edit-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import type { UpdateTeamRequest } from '@/lib/agentteams-api';
+import { workerNameError } from '@/lib/resource-name';
 import { parseWorkerNames } from './team-create-dialog';
 
 export type TeamEditForm = UpdateTeamRequest & { name?: string };
@@ -45,6 +46,9 @@ export function TeamEditDialog({
       setWorkerInput(value.workerNames?.join(', ') ?? '');
     }
   }
+  const workerNamesError = (value.workerNames ?? [])
+    .map(workerNameError)
+    .find((err) => err !== null) ?? null;
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg max-w-[95vw]">
@@ -83,6 +87,7 @@ export function TeamEditDialog({
               }}
               placeholder="worker1, worker2 或 worker1，worker2"
             />
+            {workerNamesError && <p className="text-xs text-red-600 dark:text-red-400">{workerNamesError}</p>}
           </div>
         </div>
         <DialogFooter>
@@ -91,7 +96,7 @@ export function TeamEditDialog({
           </Button>
           <Button
             onClick={onSubmit}
-            disabled={isPending}
+            disabled={!!workerNamesError || isPending}
             className="bg-gradient-to-r from-emerald-500 to-teal-500 text-white hover:from-emerald-600 hover:to-teal-600"
           >
             {isPending ? '更新中...' : '更新'}

--- a/src/components/dashboard/sections/workers/worker-create-dialog.tsx
+++ b/src/components/dashboard/sections/workers/worker-create-dialog.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from '@/components/ui/button';
 import type { CreateWorkerRequest } from '@/lib/agentteams-api';
 import type { ModelSelectionOption } from '@/lib/model-catalog';
+import { workerNameError } from '@/lib/resource-name';
 import { ModelSelector } from '@/components/dashboard/sections/shared/model-selector';
 
 export function WorkerCreateDialog({
@@ -41,6 +42,8 @@ export function WorkerCreateDialog({
   onSubmit: () => void;
   modelOptions: ModelSelectionOption[];
 }) {
+  const nameError = workerNameError(value.name);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg max-w-[95vw]">
@@ -55,6 +58,7 @@ export function WorkerCreateDialog({
               onChange={(e) => onChange({ ...value, name: e.target.value })}
               placeholder="worker-name"
             />
+            {nameError && <p className="text-xs text-red-600 dark:text-red-400">{nameError}</p>}
           </div>
           <div className="space-y-2">
             <Label>运行时 *</Label>
@@ -141,7 +145,7 @@ export function WorkerCreateDialog({
           </Button>
           <Button
             onClick={onSubmit}
-            disabled={!value.name || isPending}
+            disabled={!value.name || !!nameError || isPending}
             className="bg-gradient-to-r from-emerald-500 to-teal-500 text-white hover:from-emerald-600 hover:to-teal-600"
           >
             {isPending ? '创建中...' : '创建'}

--- a/src/lib/resource-name.test.ts
+++ b/src/lib/resource-name.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { workerNameError } from '@/lib/resource-name';
+
+describe('workerNameError', () => {
+  it('accepts names within the MinIO access-key length range', () => {
+    expect(workerNameError('ce1')).toBeNull();
+    expect(workerNameError('worker-alpha')).toBeNull();
+    expect(workerNameError('a'.repeat(20))).toBeNull();
+  });
+
+  it('rejects names shorter than 3 characters', () => {
+    expect(workerNameError('ce')).toMatch(/至少 3 个字符/);
+    expect(workerNameError('a')).toMatch(/至少 3 个字符/);
+  });
+
+  it('rejects names longer than 20 characters', () => {
+    expect(workerNameError('a'.repeat(21))).toMatch(/最多 20 个字符/);
+  });
+
+  it('returns null for empty input (required handled separately)', () => {
+    expect(workerNameError('')).toBeNull();
+    expect(workerNameError('   ')).toBeNull();
+  });
+});

--- a/src/lib/resource-name.ts
+++ b/src/lib/resource-name.ts
@@ -1,0 +1,23 @@
+/**
+ * Worker resource name validation.
+ *
+ * Embedded-mode MinIO provisions one user per Worker and uses the Worker name
+ * as the MinIO user access key, so the name must satisfy the MinIO access-key
+ * rule: 3-20 characters. Shorter or longer names fail provisioning with
+ * "access key length should be between 3 and 20".
+ */
+export const WORKER_NAME_MIN_LENGTH = 3;
+export const WORKER_NAME_MAX_LENGTH = 20;
+
+/** Returns a user-facing error message, or null when the name is acceptable. */
+export function workerNameError(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  if (trimmed.length < WORKER_NAME_MIN_LENGTH) {
+    return `名称至少 ${WORKER_NAME_MIN_LENGTH} 个字符（Worker 名用作 MinIO 访问密钥，长度要求 ${WORKER_NAME_MIN_LENGTH}-${WORKER_NAME_MAX_LENGTH}）。`;
+  }
+  if (trimmed.length > WORKER_NAME_MAX_LENGTH) {
+    return `名称最多 ${WORKER_NAME_MAX_LENGTH} 个字符（Worker 名用作 MinIO 访问密钥，长度要求 ${WORKER_NAME_MIN_LENGTH}-${WORKER_NAME_MAX_LENGTH}）。`;
+  }
+  return null;
+}


### PR DESCRIPTION
嵌入式模式下 controller 用 Worker 名作为 MinIO 用户访问密钥，长度必须 3-20；过短名称（如 'ce'）provisioning 时报 'access key length should be between 3 and 20'。新增 `workerNameError()`，在 Worker 创建、团队创建、团队编辑对话框校验并阻止提交。