### PR TITLE
fix: 绕过Controller端点直接处理技能包上传

### DIFF
--- a/src/app/api/agentteams/packages/route.test.ts
+++ b/src/app/api/agentteams/packages/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { zipSync } from 'fflate';
+
+// Build a minimal valid ZIP once.
+const validSkillMd = new TextEncoder().encode(
+  '---\nname: test-package\ndescription: A test package.\n---\n',
+);
+const validZip = zipSync({ 'SKILL.md': validSkillMd });
+
+// An invalid ZIP (no SKILL.md) that parseSkillPackage rejects.
+const noSkillMdZip = zipSync({ 'README.md': new TextEncoder().encode('hello') });
+
+// Mock minio-client.
+vi.mock('@/lib/minio-client', () => {
+  const mockClient = {
+    listObjects: () => ({
+      on: (event: string, _cb: (..._args: unknown[]) => void) => {
+        if (event === 'end') setTimeout(_cb, 0);
+        return mockClient;
+      },
+    }),
+    putObject: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    createMinioClient: () => mockClient,
+    getMinioBucket: () => 'agentteams-fs',
+  };
+});
+
+/** Build a NextRequest that pretends to be multipart by mocking formData. */
+function buildMultipartRequest(zipBytes: Uint8Array<ArrayBuffer>): NextRequest {
+  const req = new NextRequest('http://localhost/api/agentteams/packages', {
+    method: 'POST',
+    headers: { 'content-type': 'multipart/form-data; boundary=----TestBoundary' },
+  });
+  req.formData = async () => {
+    const form = new FormData();
+    form.append('file', new Blob([zipBytes], { type: 'application/zip' }), 'pkg.zip');
+    return form;
+  };
+  return req;
+}
+
+describe('POST /packages', () => {
+  it('rejects non-multipart requests', async () => {
+    const req = new NextRequest('http://localhost/api/agentteams/packages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when file is missing', async () => {
+    const req = new NextRequest('http://localhost/api/agentteams/packages', {
+      method: 'POST',
+      headers: { 'content-type': 'multipart/form-data; boundary=----TestBoundary' },
+    });
+    req.formData = async () => new FormData();
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-zip files', async () => {
+    const req = new NextRequest('http://localhost/api/agentteams/packages', {
+      method: 'POST',
+      headers: { 'content-type': 'multipart/form-data; boundary=----TestBoundary' },
+    });
+    req.formData = async () => {
+      const form = new FormData();
+      form.append('file', new Blob(['hello'], { type: 'text/plain' }), 'pkg.txt');
+      return form;
+    };
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a ZIP missing SKILL.md', async () => {
+    const req = buildMultipartRequest(noSkillMdZip);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts a valid multipart request and returns success', async () => {
+    const req = buildMultipartRequest(validZip);
+    const res = await POST(req);
+    const text = await res.text();
+    console.log('DEBUG status:', res.status, 'body:', text);
+    expect(res.status).toBe(200);
+    const json = JSON.parse(text);
+    expect(json).toHaveProperty('success', true);
+    expect(json).toHaveProperty('skillName', 'test-package');
+    expect(json).toHaveProperty('description', 'A test package.');
+    expect(json).toHaveProperty('filesCount', 1);
+    expect(json).toHaveProperty('packageUri');
+  });
+});

--- a/src/app/api/agentteams/packages/route.ts
+++ b/src/app/api/agentteams/packages/route.ts
@@ -1,8 +1,67 @@
-import { NextRequest } from 'next/server';
-import { getControllerUrl, proxyToAgentTeams } from '../proxy-helper';
+import { NextRequest, NextResponse } from 'next/server';
+import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+import {
+  parseSkillPackage,
+  skillObjectKey,
+  workerSkillsPrefix,
+  SKILL_PACKAGE_MAX_BYTES,
+} from '@/lib/skill-package';
 
 export async function POST(request: NextRequest) {
-  return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/packages', {
-    contentType: 'multipart/form-data',
-  });
+  const contentType = request.headers.get('content-type') || '';
+  if (!contentType.includes('multipart/form-data')) {
+    return NextResponse.json(
+      { error: '需要 multipart/form-data 请求' },
+      { status: 400 }
+    );
+  }
+
+  const client = createMinioClient();
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  try {
+    const form = await request.formData();
+    const file = form.get('file') as File | null;
+    if (!file || !file.name) {
+      return NextResponse.json({ error: '缺少技能包文件' }, { status: 400 });
+    }
+    if (!file.name.toLowerCase().endsWith('.zip')) {
+      return NextResponse.json({ error: '技能包须为 .zip 文件' }, { status: 400 });
+    }
+    if (file.size > SKILL_PACKAGE_MAX_BYTES) {
+      return NextResponse.json({ error: '技能包超过 64 MB 大小限制' }, { status: 400 });
+    }
+
+    const bytes = new Uint8Array(await file.arrayBuffer());
+
+    let parsed;
+    try {
+      parsed = parseSkillPackage(bytes);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '技能包校验失败';
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    for (const f of parsed.files) {
+      const key = skillObjectKey('global', parsed.skillName, f.relativePath);
+      await client.putObject(bucket, key, f.data, f.data.byteLength, {
+        'Content-Type': 'application/octet-stream',
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      skillName: parsed.skillName,
+      description: parsed.description,
+      filesCount: parsed.files.length,
+      packageUri: `global:${parsed.skillName}`,
+      note: '技能包已上传，可在 Worker 详情对话框中分发',
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown storage error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
 }

--- a/src/components/dashboard/sections/workers-section.tsx
+++ b/src/components/dashboard/sections/workers-section.tsx
@@ -146,6 +146,7 @@ export function WorkersSection() {
   const [uploadOpen, setUploadOpen] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<{ skillName: string; description: string; filesCount: number; note?: string } | null>(null);
   const [configText, setConfigText] = useState('');
   const [configError, setConfigError] = useState<string | null>(null);
 
@@ -309,10 +310,18 @@ export function WorkersSection() {
   const handleUpload = useCallback(
     async (file: File | null) => {
       if (!file) return;
+      setUploadResult(null);
       setUploading(true);
       try {
-        await agentteamsApi.uploadPackage(file);
-        setUploadOpen(false);
+        const result = await agentteamsApi.uploadPackage(file);
+        setUploadResult({
+          skillName: result.skillName,
+          description: result.description,
+          filesCount: result.filesCount,
+          note: result.note,
+        });
+      } catch {
+        // error is handled by the API layer
       } finally {
         setUploading(false);
       }
@@ -594,9 +603,10 @@ export function WorkersSection() {
 
       <WorkerUploadDialog
         open={uploadOpen}
-        onOpenChange={setUploadOpen}
+        onOpenChange={(open) => { if (!open) setUploadResult(null); setUploadOpen(open); }}
         isUploading={uploading}
         onFileChange={handleUpload}
+        result={uploadResult}
       />
 
       <ConfirmDeleteDialog

--- a/src/components/dashboard/sections/workers/worker-upload-dialog.tsx
+++ b/src/components/dashboard/sections/workers/worker-upload-dialog.tsx
@@ -10,32 +10,71 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Check } from 'lucide-react';
+
+export interface WorkerUploadResult {
+  skillName: string;
+  description: string;
+  filesCount: number;
+  note?: string;
+}
 
 export function WorkerUploadDialog({
   open,
   onOpenChange,
   isUploading,
   onFileChange,
+  result,
 }: {
   open: boolean;
   onOpenChange: (_open: boolean) => void;
   isUploading: boolean;
   onFileChange: (_file: File | null) => void;
+  result: WorkerUploadResult | null;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md max-w-[95vw]">
         <DialogHeader>
-          <DialogTitle>上传包</DialogTitle>
+          <DialogTitle>上传技能包</DialogTitle>
         </DialogHeader>
-        <div className="py-4">
-          <Label className="block mb-2">选择文件</Label>
-          <Input
-            type="file"
-            onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
-            disabled={isUploading}
-          />
-          {isUploading && <p className="text-sm text-muted-foreground mt-2">上传中...</p>}
+        <div className="py-4 space-y-4">
+          <div>
+            <Label className="block mb-2">选择文件</Label>
+            <Input
+              type="file"
+              accept=".zip"
+              onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+              disabled={isUploading}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              须包含 SKILL.md（含 name / description 字段）
+            </p>
+          </div>
+
+          {isUploading && (
+            <p className="text-sm text-muted-foreground">上传中...</p>
+          )}
+
+          {result && (
+            <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300">
+              <Check className="h-4 w-4 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium">{result.skillName}</p>
+                <p className="text-xs opacity-80">{result.description}</p>
+                <p className="text-xs opacity-75 mt-1">{result.filesCount} 个文件已上传</p>
+                {result.note && <p className="text-xs opacity-75 mt-1">{result.note}</p>}
+              </div>
+            </div>
+          )}
+
+          {!isUploading && !result && (
+            <div className="rounded-md border border-dashed border-border p-4 text-center">
+              <p className="text-xs text-muted-foreground">
+                技能包将直接写入 MinIO 存储，可在「技能」页面查看
+              </p>
+            </div>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/src/lib/agentteams-api.ts
+++ b/src/lib/agentteams-api.ts
@@ -555,7 +555,7 @@ export const agentteamsApi = {
     proxyRequest<void>(`/gateway/consumers/${encodeURIComponent(id)}`, { method: 'DELETE' }),
 
   // Packages
-  uploadPackage: async (file: File): Promise<{ packageUri: string }> => {
+  uploadPackage: async (file: File): Promise<WorkerSkillUploadResponse> => {
     const formData = new FormData();
     formData.append('file', file);
     const res = await fetch(apiUrl('/api/agentteams/packages'), {
@@ -566,7 +566,7 @@ export const agentteamsApi = {
       const text = await res.text().catch(() => '');
       throw new ApiError(`Upload failed ${res.status}: ${text}`, res.status, '/packages');
     }
-    return res.json();
+    return res.json() as Promise<WorkerSkillUploadResponse>;
   },
 
   // Infrastructure


### PR DESCRIPTION
## 问题描述

上传技能包时收到 502 错误，错误信息：

```json
{
  "error": "third argument should be of type \"stream.Readable\" or \"Buffer\" or \"string\""
}
```

## 根因

Controller 的 `/api/v1/packages` 端点在调用 MinIO `putObject` 时，将 `Uint8Array` 直接作为第三个参数传入，而 MinIO SDK 要求该参数类型为 `stream.Readable | Buffer | string`，导致类型校验失败。

## 修复方案

绕过有 bug 的 Controller 端点，改为 Dashboard 端本地处理技能包上传：

1. 接收 multipart 表单数据
2. 解析 ZIP 文件，校验 SKILL.md frontmatter
3. 将文件直接写入 MinIO

## 变更内容

| 文件 | 变更 |
|------|------|
| `src/app/api/agentteams/packages/route.ts` | 重写为本地处理逻辑 |
| `src/app/api/agentteams/packages/route.test.ts` | 新增 5 个测试用例 |
| `src/lib/agentteams-api.ts` | 更新 `uploadPackage` 返回类型 |
| `src/components/dashboard/sections/workers/worker-upload-dialog.tsx` | 显示上传结果 |
| `src/components/dashboard/sections/workers-section.tsx` | 更新上传处理逻辑 |

## 验证

- typecheck：通过
- 测试：353/353 全绿（新增 5 个）
- lint：无新增错误

## 关联 Issue

- 修复 https://github.com/agentteams-group/agentteams-dashboard/issues/25