### PR TITLE
feat(mcp): 添加 MCP 服务器增删改查完整功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.84.0",
         "react-markdown": "^10.1.0",
         "react-virtuoso": "^4.18.11",
         "recharts": "^3.8.1",
@@ -11862,6 +11863,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.84.0.tgz",
+      "integrity": "sha512-+hWvQP6GLco56mDwrbU4XnHix8t1z90ltZsDIrREl+jnQFQxYLX8oAzqe/Xn8nHpmoXTY5M6oEXrAhbP1qevNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.84.0",
     "react-markdown": "^10.1.0",
     "react-virtuoso": "^4.18.11",
     "recharts": "^3.8.1",

--- a/src/app/api/agentteams/mcps/[name]/route.ts
+++ b/src/app/api/agentteams/mcps/[name]/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+
+const MCP_SERVERS_PREFIX = 'mcp-servers/';
+
+interface McpServerConfig {
+  name: string;
+  url: string;
+  transport: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function isValidMcpName(name: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name);
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  const { name } = await params;
+  if (!isValidMcpName(name)) {
+    return NextResponse.json({ error: 'Invalid MCP server name' }, { status: 400 });
+  }
+
+  const key = `${MCP_SERVERS_PREFIX}${name}.json`;
+
+  try {
+    const client = createMinioClient();
+    const stream = await client.getObject(bucket, key);
+    const data = await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      stream.on('error', reject);
+    });
+    const config = JSON.parse(data.toString('utf-8')) as McpServerConfig;
+    return NextResponse.json(config);
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes('NoSuchKey')) {
+      return NextResponse.json({ error: 'MCP 服务器不存在' }, { status: 404 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  const { name } = await params;
+  if (!isValidMcpName(name)) {
+    return NextResponse.json({ error: 'Invalid MCP server name' }, { status: 400 });
+  }
+
+  let body: { url?: string; transport?: string; description?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: '请求体格式错误' }, { status: 400 });
+  }
+
+  const key = `${MCP_SERVERS_PREFIX}${name}.json`;
+
+  let existing: McpServerConfig;
+  try {
+    const client = createMinioClient();
+    const stream = await client.getObject(bucket, key);
+    const data = await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      stream.on('error', reject);
+    });
+    existing = JSON.parse(data.toString('utf-8')) as McpServerConfig;
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes('NoSuchKey')) {
+      return NextResponse.json({ error: 'MCP 服务器不存在' }, { status: 404 });
+    }
+    return NextResponse.json({ error: '读取失败' }, { status: 502 });
+  }
+
+  const url = body.url ?? existing.url;
+  const transport = body.transport ?? existing.transport;
+  const description = body.description !== undefined ? body.description : existing.description;
+
+  if (!url || typeof url !== 'string' || !url.startsWith('http')) {
+    return NextResponse.json({ error: 'URL 须为有效的 HTTP(S) 地址' }, { status: 400 });
+  }
+  if (!transport || !['sse', 'streaminghttp'].includes(transport)) {
+    return NextResponse.json({ error: 'transport 须为 "sse" 或 "streaminghttp"' }, { status: 400 });
+  }
+
+  const config: McpServerConfig = {
+    ...existing,
+    url,
+    transport,
+    description,
+    updatedAt: new Date().toISOString(),
+  };
+
+  try {
+    const client = createMinioClient();
+    const data = Buffer.from(JSON.stringify(config, null, 2));
+    await client.putObject(bucket, key, data, data.length, {
+      'Content-Type': 'application/json',
+    });
+    return NextResponse.json({ success: true, ...config });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown storage error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  const { name } = await params;
+  if (!isValidMcpName(name)) {
+    return NextResponse.json({ error: 'Invalid MCP server name' }, { status: 400 });
+  }
+
+  const key = `${MCP_SERVERS_PREFIX}${name}.json`;
+
+  try {
+    const client = createMinioClient();
+    await client.removeObject(bucket, key);
+    return NextResponse.json({ success: true });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes('NoSuchKey')) {
+      return NextResponse.json({ error: 'MCP 服务器不存在' }, { status: 404 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/agentteams/mcps/route.ts
+++ b/src/app/api/agentteams/mcps/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+
+const MCP_SERVERS_PREFIX = 'mcp-servers/';
+
+interface McpServerConfig {
+  name: string;
+  url: string;
+  transport: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function isValidMcpName(name: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name);
+}
+
+async function listAllObjects(client: any, bucket: string, prefix: string): Promise<any[]> {
+  const objects: any[] = [];
+  const stream = client.listObjects(bucket, prefix, true);
+  for await (const obj of stream) {
+    objects.push(obj);
+  }
+  return objects;
+}
+
+export async function GET() {
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  try {
+    const client = createMinioClient();
+    const objects = await listAllObjects(client, bucket, MCP_SERVERS_PREFIX);
+    const servers: McpServerConfig[] = [];
+
+    for (const obj of objects) {
+      const key = obj.objectName;
+      if (!key.endsWith('.json')) continue;
+      const name = key.slice(MCP_SERVERS_PREFIX.length, -5);
+      if (!isValidMcpName(name)) continue;
+
+      try {
+        const stream = await client.getObject(bucket, key);
+        const data = await new Promise<Buffer>((resolve, reject) => {
+          const chunks: Buffer[] = [];
+          stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+          stream.on('end', () => resolve(Buffer.concat(chunks)));
+          stream.on('error', reject);
+        });
+        const config = JSON.parse(data.toString('utf-8')) as McpServerConfig;
+        if (config.name && config.url && config.transport) {
+          servers.push(config);
+        }
+      } catch {
+        // skip corrupted entries
+      }
+    }
+
+    return NextResponse.json({ servers: servers.sort((a, b) => a.name.localeCompare(b.name)) });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  let body: { name?: string; url?: string; transport?: string; description?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: '请求体格式错误' }, { status: 400 });
+  }
+
+  const { name, url, transport, description } = body;
+
+  if (!name || !isValidMcpName(name)) {
+    return NextResponse.json({ error: 'MCP 服务器名称不合法（仅允许字母、数字、点、下划线、连字符）' }, { status: 400 });
+  }
+  if (!url || typeof url !== 'string' || !url.startsWith('http')) {
+    return NextResponse.json({ error: 'MCP 服务器 URL 须为有效的 HTTP(S) 地址' }, { status: 400 });
+  }
+  if (!transport || !['sse', 'streaminghttp'].includes(transport)) {
+    return NextResponse.json({ error: 'transport 须为 "sse" 或 "streaminghttp"' }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const config: McpServerConfig = {
+    name,
+    url,
+    transport,
+    description: description || undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  try {
+    const client = createMinioClient();
+    const key = `${MCP_SERVERS_PREFIX}${name}.json`;
+    const data = Buffer.from(JSON.stringify(config, null, 2));
+    await client.putObject(bucket, key, data, data.length, {
+      'Content-Type': 'application/json',
+    });
+    return NextResponse.json({ success: true, ...config }, { status: 201 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown storage error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/components/dashboard/sections/mcps/mcp-server-dialog.tsx
+++ b/src/components/dashboard/sections/mcps/mcp-server-dialog.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCreateMcpServer, useUpdateMcpServer } from '@/hooks/use-agentteams-mcps';
+
+interface McpServerFormValues {
+  name: string;
+  url: string;
+  transport: 'sse' | 'streaminghttp';
+  description?: string;
+}
+
+const TRANSPORT_OPTIONS: { value: 'sse' | 'streaminghttp'; label: string }[] = [
+  { value: 'sse', label: 'SSE' },
+  { value: 'streaminghttp', label: 'Streaming HTTP' },
+];
+
+export function McpServerDialog({
+  open: dialogOpen,
+  onOpenChange,
+  server,
+  onSuccess,
+}: {
+  open: boolean;
+  onOpenChange: (_open: boolean) => void;
+  server?: McpServerFormValues & { name: string };
+  onSuccess?: () => void;
+}) {
+  const isEdit = !!server;
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<McpServerFormValues>({
+    defaultValues: server || { name: '', url: '', transport: 'sse' },
+  });
+  const createMutation = useCreateMcpServer();
+  const updateMutation = useUpdateMcpServer();
+
+  const handleClose = () => {
+    reset({ name: '', url: '', transport: 'sse' });
+    onOpenChange(false);
+  };
+
+  const onSubmit = async (data: McpServerFormValues) => {
+    if (isEdit) {
+      await updateMutation.mutateAsync({
+        name: data.name,
+        data: { url: data.url, transport: data.transport, description: data.description },
+      });
+    } else {
+      await createMutation.mutateAsync(data);
+    }
+    onSuccess?.();
+    handleClose();
+  };
+
+  return (
+    <Dialog open={dialogOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md max-w-[95vw]">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? '编辑 MCP 服务器' : '添加 MCP 服务器'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {isEdit ? (
+            <div className="space-y-2">
+              <Label htmlFor="name">服务器名称</Label>
+              <Input id="name" {...register('name', { required: '请输入服务器名称' })} disabled />
+              {errors.name && <p className="text-sm text-destructive">{errors.name.message}</p>}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label htmlFor="name">服务器名称</Label>
+              <Input
+                id="name"
+                {...register('name', {
+                  required: '请输入服务器名称',
+                  pattern: {
+                    value: /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
+                    message: '仅允许字母、数字、点、下划线、连字符',
+                  },
+                })}
+                placeholder="my-mcp-server"
+              />
+              {errors.name && <p className="text-sm text-destructive">{errors.name.message}</p>}
+            </div>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="url">服务端点 URL</Label>
+            <Input
+              id="url"
+              {...register('url', {
+                required: '请输入服务端点 URL',
+                pattern: {
+                  value: /^https?:\/\/.+/,
+                  message: '须为有效的 HTTP(S) 地址',
+                },
+              })}
+              placeholder="https://example.com/mcp"
+            />
+            {errors.url && <p className="text-sm text-destructive">{errors.url.message}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="transport">传输方式</Label>
+            <Select
+              value={server?.transport || 'sse'}
+              onValueChange={(v) => {
+                const el = document.getElementById('transport') as HTMLSelectElement;
+                if (el) el.value = v;
+              }}
+            >
+              <SelectTrigger id="transport">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TRANSPORT_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <input type="hidden" {...register('transport', { required: true })} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="description">描述（可选）</Label>
+            <Textarea
+              id="description"
+              {...register('description')}
+              placeholder="MCP 服务器描述..."
+              rows={2}
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleClose}>
+              取消
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+              {createMutation.isPending || updateMutation.isPending ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/sections/skills-section.tsx
+++ b/src/components/dashboard/sections/skills-section.tsx
@@ -13,17 +13,32 @@ import {
   Link2,
   Wifi,
   Upload,
+  Plus,
+  Pencil,
+  Trash2,
 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { useWorkers } from '@/hooks/use-agentteams-workers';
 import { useManagers } from '@/hooks/use-agentteams-managers';
+import { useMcpServers, useDeleteMcpServer } from '@/hooks/use-agentteams-mcps';
 import { useSearch } from '@/lib/search-context';
 import { SectionHeader } from '@/components/dashboard/section-header';
 import { WORKER_PHASE_BADGE_CLASSES, MANAGER_PHASE_BADGE_CLASSES } from '@/lib/phase-colors';
 import { SkillDistributeDialog } from '@/components/dashboard/sections/skills/skill-distribute-dialog';
 import { Button } from '@/components/ui/button';
+import { McpServerDialog } from '@/components/dashboard/sections/mcps/mcp-server-dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 
 interface SkillInfo {
@@ -31,13 +46,6 @@ interface SkillInfo {
   workers: { name: string; phase: string; runtime: string }[];
   managers: { name: string; phase: string }[];
   totalCount: number;
-}
-
-interface MCPServerInfo {
-  name: string;
-  url: string;
-  transport: string;
-  workers: string[];
 }
 
 function SkillCard({ skill, isExpanded, onToggle }: {
@@ -161,11 +169,16 @@ function SkillCard({ skill, isExpanded, onToggle }: {
 export function SkillsSection() {
   const { data: workers, refetch, isRefetching } = useWorkers();
   const { data: managers } = useManagers();
+  const { data: mcpServerList } = useMcpServers();
+  const deleteMcp = useDeleteMcpServer();
   const { searchQuery } = useSearch();
   const [localFilter, setLocalFilter] = useState('');
   const [expandedSkills, setExpandedSkills] = useState<Set<string>>(new Set());
   const [mcpExpanded, setMcpExpanded] = useState<Set<string>>(new Set());
   const [distributeOpen, setDistributeOpen] = useState(false);
+  const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
+  const [editingMcp, setEditingMcp] = useState<{ name: string; url: string; transport: 'sse' | 'streaminghttp' } | undefined>();
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   const handleRefresh = useCallback(() => {
     refetch();
@@ -240,25 +253,24 @@ export function SkillsSection() {
     return Array.from(skillMap.values()).sort((a, b) => b.totalCount - a.totalCount);
   }, [workers, managers]);
 
-  // Extract MCP server configurations from workers
+  // MCP servers from API
   const mcpServers = useMemo(() => {
-    const serverMap = new Map<string, MCPServerInfo>();
-
-    workers?.forEach((w) => {
-      const mcpConfigs = w.mcpServers;
-      if (mcpConfigs && Array.isArray(mcpConfigs)) {
-        mcpConfigs.forEach((mcp) => {
-          const key = `${mcp.name}-${mcp.url}`;
-          if (!serverMap.has(key)) {
-            serverMap.set(key, { name: mcp.name, url: mcp.url, transport: mcp.transport, workers: [] });
-          }
-          serverMap.get(key)!.workers.push(w.name);
-        });
-      }
+    const serverMap = new Map<string, { name: string; url: string; transport: string; workers: string[]; description?: string }>();
+    mcpServerList?.forEach((s) => {
+      serverMap.set(s.name, { name: s.name, url: s.url, transport: s.transport, workers: [], description: s.description });
     });
-
+    workers?.forEach((w) => {
+      w.mcpServers?.forEach((mcp) => {
+        const existing = serverMap.get(mcp.name);
+        if (existing) {
+          if (!existing.workers.includes(w.name)) {
+            existing.workers.push(w.name);
+          }
+        }
+      });
+    });
     return Array.from(serverMap.values());
-  }, [workers]);
+  }, [mcpServerList, workers]);
 
   // Worker skills summary (which worker has which skill)
   const workerSkillMap = useMemo(() => {
@@ -446,6 +458,15 @@ export function SkillsSection() {
           <Server className="w-5 h-5 text-emerald-500" />
           MCP 服务器配置
           <Badge variant="outline" className="text-[10px]">{filteredMcp.length}</Badge>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto h-7 text-xs"
+            onClick={() => { setEditingMcp(undefined); setMcpDialogOpen(true); }}
+          >
+            <Plus className="w-3.5 h-3.5 mr-1" />
+            添加
+          </Button>
         </h2>
         {filteredMcp.length === 0 ? (
           <Card className="glass-card">
@@ -453,7 +474,7 @@ export function SkillsSection() {
               <Server className="w-10 h-10 text-muted-foreground mx-auto mb-3" />
               <p className="text-sm text-muted-foreground">
                 {mcpServers.length === 0
-                  ? '暂无 MCP 服务器配置。可在创建/编辑 Worker 时添加 MCP 服务器。'
+                  ? '暂无 MCP 服务器配置。点击"添加"按钮创建新的 MCP 服务器。'
                   : '没有匹配的 MCP 服务器'}
               </p>
             </CardContent>
@@ -484,12 +505,29 @@ export function SkillsSection() {
                             <Link2 className="w-3 h-3 inline mr-1" />
                             {mcp.url}
                           </p>
+                          {mcp.description && (
+                            <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-[400px]">{mcp.description}</p>
+                          )}
                         </div>
                       </div>
-                      <div className="flex items-center gap-2 shrink-0">
+                      <div className="flex items-center gap-1 shrink-0">
                         <Badge variant="outline" className="text-[10px]">
                           {mcp.workers.length} Worker
                         </Badge>
+                        <button
+                          onClick={() => setEditingMcp({ name: mcp.name, url: mcp.url, transport: mcp.transport as 'sse' | 'streaminghttp' })}
+                          className="p-1.5 hover:bg-accent rounded"
+                          title="编辑"
+                        >
+                          <Pencil className="w-3.5 h-3.5 text-muted-foreground" />
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(mcp.name)}
+                          className="p-1.5 hover:bg-destructive/10 rounded"
+                          title="删除"
+                        >
+                          <Trash2 className="w-3.5 h-3.5 text-muted-foreground" />
+                        </button>
                         <button
                           onClick={() => toggleMcp(mcp.name)}
                           className="p-1 hover:bg-accent rounded"
@@ -523,6 +561,35 @@ export function SkillsSection() {
         )}
       </div>
       <SkillDistributeDialog dialogOpen={distributeOpen} onOpenChange={setDistributeOpen} />
+      <McpServerDialog
+        open={mcpDialogOpen}
+        onOpenChange={setMcpDialogOpen}
+        server={editingMcp}
+      />
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除</AlertDialogTitle>
+            <AlertDialogDescription>
+              确定要删除 MCP 服务器"{deleteTarget}"吗？此操作不可撤销。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (deleteTarget) {
+                  await deleteMcp.mutateAsync(deleteTarget);
+                  setDeleteTarget(null);
+                }
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              删除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/hooks/use-agentteams-mcps.ts
+++ b/src/hooks/use-agentteams-mcps.ts
@@ -1,0 +1,58 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { agentteamsApi } from '@/lib/agentteams-api';
+import type { McpServerConfig } from '@/lib/agentteams-api';
+
+export function useMcpServers(): UseQueryResult<McpServerConfig[], Error> {
+  return useQuery<McpServerConfig[], Error>({
+    queryKey: ['agentteams-mcps'],
+    queryFn: async () => {
+      const data = await agentteamsApi.listMcpServers();
+      return data.servers;
+    },
+    placeholderData: [] as McpServerConfig[],
+    throwOnError: false,
+  });
+}
+
+export function useMcpServer(name: string) {
+  return useQuery<McpServerConfig | null>({
+    queryKey: ['agentteams-mcp', name],
+    queryFn: () => agentteamsApi.getMcpServer(name).catch(() => null),
+    enabled: !!name,
+    placeholderData: null,
+    throwOnError: false,
+  });
+}
+
+export function useCreateMcpServer() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; url: string; transport: string; description?: string }) =>
+      agentteamsApi.createMcpServer(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['agentteams-mcps'] });
+    },
+  });
+}
+
+export function useUpdateMcpServer() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ name, data }: { name: string; data: { url?: string; transport?: string; description?: string } }) =>
+      agentteamsApi.updateMcpServer(name, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['agentteams-mcps'] });
+    },
+  });
+}
+
+export function useDeleteMcpServer() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => agentteamsApi.deleteMcpServer(name),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['agentteams-mcps'] });
+    },
+  });
+}

--- a/src/lib/agentteams-api.ts
+++ b/src/lib/agentteams-api.ts
@@ -322,6 +322,19 @@ export interface PresignDownloadResponse {
   url: string;
 }
 
+export interface McpServerConfig {
+  name: string;
+  url: string;
+  transport: 'sse' | 'streaminghttp';
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpServerListResponse {
+  servers: McpServerConfig[];
+}
+
 export interface WorkerSkillsListResponse {
   skills: string[];
 }
@@ -702,4 +715,55 @@ export const agentteamsApi = {
   // Setup
   ensureAiGateway: (): Promise<{ success: boolean; message?: string }> =>
     proxyRequest<{ success: boolean; message?: string }>('/setup/ensure-ai', { method: 'POST' }),
+
+  // MCP Servers
+  listMcpServers: (): Promise<McpServerListResponse> =>
+    proxyRequest<McpServerListResponse>('/api/agentteams/mcps'),
+
+  getMcpServer: (name: string): Promise<McpServerConfig> =>
+    proxyRequest<McpServerConfig>(`/api/agentteams/mcps/${encodeURIComponent(name)}`),
+
+  createMcpServer: (data: { name: string; url: string; transport: string; description?: string }): Promise<McpServerConfig & { success: boolean }> => {
+    const res = fetch(apiUrl('/api/agentteams/mcps'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    return res.then(async (r) => {
+      if (!r.ok) {
+        const text = await r.text().catch(() => '');
+        throw new ApiError(`创建 MCP 服务器失败: ${r.status} ${text}`, r.status, '/mcps');
+      }
+      return r.json() as Promise<McpServerConfig & { success: boolean }>;
+    });
+  },
+
+  updateMcpServer: (name: string, data: { url?: string; transport?: string; description?: string }): Promise<McpServerConfig & { success: boolean }> => {
+    const res = fetch(apiUrl(`/api/agentteams/mcps/${encodeURIComponent(name)}`), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    return res.then(async (r) => {
+      if (!r.ok) {
+        const text = await r.text().catch(() => '');
+        throw new ApiError(`更新 MCP 服务器失败: ${r.status} ${text}`, r.status, `/mcps/${name}`);
+      }
+      return r.json() as Promise<McpServerConfig & { success: boolean }>;
+    });
+  },
+
+  deleteMcpServer: (name: string): Promise<void> => {
+    const res = fetch(apiUrl(`/api/agentteams/mcps/${encodeURIComponent(name)}`), {
+      method: 'DELETE',
+    });
+    return res.then(async (r) => {
+      if (!r.ok) {
+        const text = await r.text().catch(() => '');
+        throw new ApiError(`删除 MCP 服务器失败: ${r.status} ${text}`, r.status, `/mcps/${name}`);
+      }
+      await r.json();
+      return undefined;
+    });
+  },
 };


### PR DESCRIPTION
## 变更内容

- 新增 API 路由：GET/POST /api/agentteams/mcps 和 GET/PUT/DELETE /api/agentteams/mcps/[name]
- 新增 hooks：useMcpServers、useCreateMcpServer、useUpdateMcpServer、useDeleteMcpServer
- 新增 McpServerDialog 组件（含表单验证）
- 更新 SkillsSection 集成 MCP 管理：添加/编辑/删除按钮、删除确认对话框
- MCP 数据持久化到 MinIO（mcp-servers/{name}.json）
- 新增 agentteamsApi mcps CRUD 方法

## 验证

- typecheck 通过
- 测试 353/353 全绿
- lint 仅遗留 3 个无关错误（mermaid-renderer、route.test、packages/route）

<!-- issue-spec:pr-close-issues version=1 -->
Issue-spec managed closing links:
Closes #21
Closes #22
Closes #23
<!-- /issue-spec:pr-close-issues -->
