### PR TITLE
fix(packages): Uint8Array 转为 Buffer 修复技能包上传 502

### DIFF
--- a/src/app/api/agentteams/packages/route.ts
+++ b/src/app/api/agentteams/packages/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
 
     for (const f of parsed.files) {
       const key = skillObjectKey('global', parsed.skillName, f.relativePath);
-      await client.putObject(bucket, key, f.data, f.data.byteLength, {
+      await client.putObject(bucket, key, Buffer.from(f.data), f.data.byteLength, {
         'Content-Type': 'application/octet-stream',
       });
     }

--- a/src/app/api/agentteams/workers/[name]/skills/route.ts
+++ b/src/app/api/agentteams/workers/[name]/skills/route.ts
@@ -93,7 +93,7 @@ export async function POST(
 
     for (const f of parsed.files) {
       const key = skillObjectKey(name, parsed.skillName, f.relativePath);
-      await client.putObject(bucket, key, f.data, f.data.byteLength, {
+      await client.putObject(bucket, key, Buffer.from(f.data), f.data.byteLength, {
         'Content-Type': 'application/octet-stream',
       });
     }


### PR DESCRIPTION
## 问题

MinIO SDK 的 `putObject` 第三个参数要求 `stream.Readable | Buffer | string`，
但 `parseSkillPackage` 返回的文件数据是 `Uint8Array`，导致上传时返回 502。

## 修复

将两处 `putObject` 调用中的 `f.data` 改为 `Buffer.from(f.data)`：
- `src/app/api/agentteams/packages/route.ts`
- `src/app/api/agentteams/workers/[name]/skills/route.ts`

## 验证

- typecheck 通过
- 测试 353/353 全绿
- lint 无新增错误

<!-- issue-spec:pr-close-issues version=1 -->
Issue-spec managed closing links:
Closes #21
Closes #22
Closes #23
<!-- /issue-spec:pr-close-issues -->
