### PR TITLE
feat(skills): 内置技能扫描与 MCP 并入技能中心表格

### DIFF
--- a/src/app/api/agentteams/packages/route.test.ts
+++ b/src/app/api/agentteams/packages/route.test.ts
@@ -95,4 +95,17 @@ describe('POST /packages', () => {
     expect(json).toHaveProperty('filesCount', 1);
     expect(json).toHaveProperty('packageUri');
   });
+
+  it('writes the custom marker after uploading', async () => {
+    const { createMinioClient } = await import('@/lib/minio-client');
+    const client = createMinioClient();
+    const req = buildMultipartRequest(validZip);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const putObject = client.putObject as ReturnType<typeof vi.fn>;
+    const markerCall = putObject.mock.calls.find(
+      ([, key]) => String(key).endsWith('.agentteams-custom')
+    );
+    expect(markerCall).toBeDefined();
+  });
 });

--- a/src/app/api/agentteams/packages/route.ts
+++ b/src/app/api/agentteams/packages/route.ts
@@ -5,6 +5,7 @@ import {
   skillObjectKey,
   SKILL_PACKAGE_MAX_BYTES,
 } from '@/lib/skill-package';
+import { GLOBAL_SKILLS_PREFIX, CUSTOM_SKILL_MARKER } from '@/lib/skill-center-types';
 
 export async function POST(request: NextRequest) {
   const contentType = request.headers.get('content-type') || '';
@@ -50,6 +51,11 @@ export async function POST(request: NextRequest) {
         'Content-Type': 'application/octet-stream',
       });
     }
+
+    // Write the custom marker so the skills catalog can tag this upload as
+    // source='custom' rather than treating it as a built-in skill.
+    const markerKey = `${GLOBAL_SKILLS_PREFIX}${parsed.skillName}/${CUSTOM_SKILL_MARKER}`;
+    await client.putObject(bucket, markerKey, Buffer.alloc(0), 0);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/agentteams/skills/route.test.ts
+++ b/src/app/api/agentteams/skills/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+vi.mock('@/lib/minio-client', () => ({
+  createMinioClient: () => ({ bucketExists: () => Promise.resolve(true) }),
+  getMinioBucket: () => 'agentteams-fs',
+}));
+
+vi.mock('@/lib/skill-center-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/skill-center-storage')>();
+  return {
+    ...actual,
+    ensureSkillsBucket: vi.fn().mockResolvedValue(undefined),
+    listSkills: vi.fn(),
+    listGlobalSkills: vi.fn(),
+  };
+});
+
+import { listSkills as listSkillsActual, listGlobalSkills as listGlobalSkillsActual } from '@/lib/skill-center-storage';
+
+const meta = (name: string, description: string, source: 'custom' | 'nacos' | 'builtin') => ({
+  name,
+  description,
+  source,
+  createdAt: '',
+  updatedAt: '',
+  fileCount: 1,
+});
+
+describe('GET /api/agentteams/skills', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listSkillsActual).mockResolvedValue([]);
+    vi.mocked(listGlobalSkillsActual).mockResolvedValue([]);
+  });
+
+  it('merges metadata and global skills, metadata takes precedence', async () => {
+    vi.mocked(listSkillsActual).mockResolvedValue([meta('custom-skill', '自定义', 'custom')]);
+    vi.mocked(listGlobalSkillsActual).mockResolvedValue([
+      meta('builtin-skill', '内置', 'builtin'),
+      meta('custom-skill', '全局旧条目', 'builtin'),
+    ]);
+    const req = new NextRequest('http://localhost/api/agentteams/skills');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skills).toHaveLength(2);
+    const custom = body.skills.find((s: { name: string }) => s.name === 'custom-skill');
+    expect(custom.source).toBe('custom');
+    expect(custom.description).toBe('自定义');
+    const builtin = body.skills.find((s: { name: string }) => s.name === 'builtin-skill');
+    expect(builtin.source).toBe('builtin');
+  });
+
+  it('filters by source param', async () => {
+    vi.mocked(listSkillsActual).mockResolvedValue([meta('a', 'A', 'custom'), meta('b', 'B', 'nacos')]);
+    vi.mocked(listGlobalSkillsActual).mockResolvedValue([]);
+    const req = new NextRequest('http://localhost/api/agentteams/skills?source=builtin');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.skills).toHaveLength(0);
+    expect(body.total).toBe(0);
+  });
+});

--- a/src/app/api/agentteams/skills/route.ts
+++ b/src/app/api/agentteams/skills/route.ts
@@ -9,6 +9,7 @@ import {
   getSkillMetadata,
   saveSkillMetadata,
   listSkills,
+  listGlobalSkills,
 } from '@/lib/skill-center-storage';
 import {
   SkillEntry,
@@ -31,7 +32,19 @@ export async function GET(request: NextRequest) {
     const client = createMinioClient();
     await ensureSkillsBucket(client);
 
-    const allSkills = await listSkills(client);
+    const [metadataSkills, globalSkills] = await Promise.all([
+      listSkills(client),
+      listGlobalSkills(client, bucket),
+    ]);
+
+    // Merge: metadata (custom/nacos) takes precedence over global (builtin)
+    // entries with the same name.
+    const byName = new Map<string, SkillEntry>();
+    for (const s of globalSkills) byName.set(s.name, s);
+    for (const s of metadataSkills) byName.set(s.name, s);
+    const allSkills = Array.from(byName.values()).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
 
     // Filter by source
     let filtered = allSkills;

--- a/src/components/dashboard/sections/skills-section.tsx
+++ b/src/components/dashboard/sections/skills-section.tsx
@@ -91,7 +91,7 @@ export function SkillsSection() {
         }
       />
 
-      <SkillCenter onRefresh={handleRefresh} />
+      <SkillCenter onRefresh={handleRefresh} mcpServers={mcpServerList || []} />
 
       {/* Worker Skill Map */}
       {workerSkillMap.size > 0 && (

--- a/src/components/dashboard/sections/skills/skill-center.tsx
+++ b/src/components/dashboard/sections/skills/skill-center.tsx
@@ -23,11 +23,12 @@ import { NacosConfigDialog } from './nacos-config-dialog';
 
 interface SkillCenterProps {
   onRefresh?: () => void;
+  mcpServers?: { name: string; url: string; transport: string }[];
 }
 
-export function SkillCenter({ onRefresh }: SkillCenterProps) {
+export function SkillCenter({ onRefresh, mcpServers = [] }: SkillCenterProps) {
   const [search, setSearch] = useState('');
-  const [sourceFilter, setSourceFilter] = useState<'all' | 'custom' | 'nacos'>('all');
+  const [sourceFilter, setSourceFilter] = useState<'all' | 'custom' | 'nacos' | 'builtin'>('all');
   const [uploadOpen, setUploadOpen] = useState(false);
   const [nacosConfigOpen, setNacosConfigOpen] = useState(false);
   const [_editingSkill, _setEditingSkill] = useState<SkillEntry | null>(null);
@@ -60,6 +61,14 @@ export function SkillCenter({ onRefresh }: SkillCenterProps) {
     return skills.filter((s) => s.source === sourceFilter);
   }, [skills, sourceFilter]);
 
+  const filteredMcp = useMemo(() => {
+    const q = search.toLowerCase();
+    if (!q) return mcpServers;
+    return mcpServers.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.url.toLowerCase().includes(q)
+    );
+  }, [mcpServers, search]);
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -90,20 +99,21 @@ export function SkillCenter({ onRefresh }: SkillCenterProps) {
         </div>
         <select
           value={sourceFilter}
-          onChange={(e) => setSourceFilter(e.target.value as 'all' | 'custom' | 'nacos')}
+          onChange={(e) => setSourceFilter(e.target.value as 'all' | 'custom' | 'nacos' | 'builtin')}
           className="rounded-md border border-input bg-background px-3 py-2 text-sm"
         >
           <option value="all">全部</option>
+          <option value="builtin">内置</option>
           <option value="custom">自定义</option>
           <option value="nacos">Nacos</option>
         </select>
       </div>
 
-      {filteredSkills.length === 0 ? (
+      {filteredSkills.length === 0 && filteredMcp.length === 0 ? (
         <Card>
           <CardContent className="p-8 text-center">
             <p className="text-sm text-muted-foreground">
-              {skills.length === 0 ? '暂无技能，点击"上传技能"添加' : '没有匹配的技能'}
+              {skills.length === 0 && mcpServers.length === 0 ? '暂无技能，点击"上传技能"添加' : '没有匹配的技能'}
             </p>
           </CardContent>
         </Card>
@@ -128,6 +138,10 @@ export function SkillCenter({ onRefresh }: SkillCenterProps) {
                     {skill.source === 'nacos' ? (
                       <Badge variant="outline" className="text-xs">
                         {skill.sourceAlias || 'Nacos'}
+                      </Badge>
+                    ) : skill.source === 'builtin' ? (
+                      <Badge variant="outline" className="text-xs">
+                        内置
                       </Badge>
                     ) : (
                       <Badge variant="secondary" className="text-xs">
@@ -159,6 +173,21 @@ export function SkillCenter({ onRefresh }: SkillCenterProps) {
                         </>
                       )}
                     </div>
+                  </td>
+                </tr>
+              ))}
+              {filteredMcp.map((mcp) => (
+                <tr key={`mcp-${mcp.name}`} className="border-b last:border-0 hover:bg-muted/30">
+                  <td className="p-3 font-mono font-medium">{mcp.name}</td>
+                  <td className="p-3 max-w-xs truncate font-mono text-muted-foreground" title={mcp.url}>
+                    {mcp.url}
+                  </td>
+                  <td className="p-3">
+                    <Badge variant="outline" className="text-xs">MCP</Badge>
+                  </td>
+                  <td className="p-3 text-muted-foreground">—</td>
+                  <td className="p-3 text-right">
+                    <span className="text-xs text-muted-foreground">{mcp.transport}</span>
                   </td>
                 </tr>
               ))}

--- a/src/hooks/use-skill-center.ts
+++ b/src/hooks/use-skill-center.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { agentteamsApi } from '@/lib/agentteams-api';
 import type { SkillEntry } from '@/lib/skill-center-types';
 
-export function useSkills(search?: string, source?: 'custom' | 'nacos' | null) {
+export function useSkills(search?: string, source?: 'custom' | 'nacos' | 'builtin' | null) {
   const params = new URLSearchParams();
   if (search) params.set('search', search);
   if (source) params.set('source', source);

--- a/src/lib/skill-center-storage.test.ts
+++ b/src/lib/skill-center-storage.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { listGlobalSkills } from './skill-center-storage';
+import { GLOBAL_SKILLS_PREFIX, CUSTOM_SKILL_MARKER } from './skill-center-types';
+
+function makeClient(objects: Record<string, string>) {
+  const prefixes = new Set<string>();
+  for (const key of Object.keys(objects)) {
+    const parts = key.split('/');
+    for (let i = 1; i < parts.length; i += 1) {
+      prefixes.add(`${parts.slice(0, i).join('/')}/`);
+    }
+  }
+  const emitter = (events: string[]) => {
+    let idx = 0;
+    let done = false;
+    return {
+      on: (event: string, cb: (_arg: unknown) => void) => {
+        if (event === 'data') {
+          while (idx < events.length) {
+            cb({ prefix: events[idx] });
+            idx += 1;
+          }
+        }
+        if (event === 'end' && !done) {
+          done = true;
+          setTimeout(() => cb(null), 0);
+        }
+        return undefined;
+      },
+    };
+  };
+  const streamEmitter = (events: string[]) => {
+    let idx = 0;
+    let done = false;
+    return {
+      on: (event: string, cb: (_arg: unknown) => void) => {
+        if (event === 'data') {
+          while (idx < events.length) {
+            cb({ objectName: events[idx] });
+            idx += 1;
+          }
+        }
+        if (event === 'end' && !done) {
+          done = true;
+          setTimeout(() => cb(null), 0);
+        }
+        return undefined;
+      },
+    };
+  };
+  return {
+    listObjects: (_bucket: string, prefix: string, recursive: boolean) => {
+      if (recursive) {
+        return streamEmitter(Object.keys(objects).filter((k) => k.startsWith(prefix)));
+      }
+      return emitter(Array.from(prefixes).filter((p) => p.startsWith(prefix)));
+    },
+    getObject: async (_bucket: string, key: string) => {
+      const content = objects[key];
+      if (content === undefined) throw new Error('Not found');
+      let yielded = false;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => {
+              if (!yielded) {
+                yielded = true;
+                return Promise.resolve({ value: Buffer.from(content), done: false });
+              }
+              return Promise.resolve({ value: undefined, done: true });
+            },
+          };
+        },
+        resume: () => undefined,
+      };
+    },
+  };
+}
+
+describe('listGlobalSkills', () => {
+  it('returns builtin skills from the global prefix', async () => {
+    const client = makeClient({
+      [`${GLOBAL_SKILLS_PREFIX}coord/SKILL.md`]: '---\nname: coord\ndescription: 协调\n---\n',
+      [`${GLOBAL_SKILLS_PREFIX}coord/run.sh`]: '#!/bin/sh\n',
+      [`${GLOBAL_SKILLS_PREFIX}monitor/SKILL.md`]: '---\nname: monitor\ndescription: 监控\n---\n',
+      'agents/w1/skills/coord/SKILL.md': 'x',
+    });
+    const skills = await listGlobalSkills(client, 'agentteams-fs');
+    expect(skills).toHaveLength(2);
+    const coord = skills.find((s) => s.name === 'coord');
+    expect(coord?.source).toBe('builtin');
+    expect(coord?.description).toBe('协调');
+    expect(coord?.fileCount).toBe(2);
+  });
+
+  it('tags skills with the custom marker as custom', async () => {
+    const client = makeClient({
+      [`${GLOBAL_SKILLS_PREFIX}uploaded/SKILL.md`]: '---\nname: uploaded\ndescription: 用户上传\n---\n',
+      [`${GLOBAL_SKILLS_PREFIX}uploaded/${CUSTOM_SKILL_MARKER}`]: '',
+    });
+    const skills = await listGlobalSkills(client, 'agentteams-fs');
+    const uploaded = skills.find((s) => s.name === 'uploaded');
+    expect(uploaded?.source).toBe('custom');
+  });
+
+  it('skips invalid skill names', async () => {
+    const client = makeClient({
+      [`${GLOBAL_SKILLS_PREFIX}../evil/SKILL.md`]: 'x',
+    });
+    const skills = await listGlobalSkills(client, 'agentteams-fs');
+    expect(skills).toHaveLength(0);
+  });
+});

--- a/src/lib/skill-center-storage.ts
+++ b/src/lib/skill-center-storage.ts
@@ -5,10 +5,12 @@ import {
   SKILLS_BUCKET,
   SKILLS_METADATA_PREFIX,
   SKILL_NAME_PATTERN,
+  GLOBAL_SKILLS_PREFIX,
+  CUSTOM_SKILL_MARKER,
 } from './skill-center-types';
-import { isValidNameSegment } from './skill-package';
+import { isValidNameSegment, parseSkillFrontmatter } from './skill-package';
 
-export { SKILLS_BUCKET, SKILLS_METADATA_PREFIX, SKILL_NAME_PATTERN };
+export { SKILLS_BUCKET, SKILLS_METADATA_PREFIX, SKILL_NAME_PATTERN, GLOBAL_SKILLS_PREFIX, CUSTOM_SKILL_MARKER };
 
 /**
  * Ensure the skills bucket exists, creating it if necessary
@@ -73,6 +75,126 @@ export async function listSkills(client: any): Promise<SkillEntry[]> {
   }
 
   return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Collects immediate "directory" prefixes under a base prefix. Returns a
+ * unique sorted list of the first path segment after the base prefix.
+ */
+export function collectFirstLevelPrefixes(
+  client: any,
+  bucket: string,
+  basePrefix: string
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const names = new Set<string>();
+    const stream = client.listObjects(bucket, basePrefix, false);
+    stream.on('data', (obj: Record<string, unknown>) => {
+      if (typeof obj.prefix === 'string' && obj.prefix.startsWith(basePrefix)) {
+        const remainder = obj.prefix.slice(basePrefix.length).replace(/\/+$/, '');
+        const first = remainder.split('/')[0];
+        if (first) names.add(first);
+      }
+    });
+    stream.on('error', reject);
+    stream.on('end', () => resolve(Array.from(names).sort()));
+  });
+}
+
+/** Counts objects under a prefix by listing them. */
+export function countObjectsUnderPrefix(
+  client: any,
+  bucket: string,
+  prefix: string
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let count = 0;
+    const stream = client.listObjects(bucket, prefix, true);
+    stream.on('data', () => {
+      count += 1;
+    });
+    stream.on('error', reject);
+    stream.on('end', () => resolve(count));
+  });
+}
+
+async function readObjectText(
+  client: any,
+  bucket: string,
+  key: string
+): Promise<string | null> {
+  try {
+    const data = await client.getObject(bucket, key);
+    const chunks: Buffer[] = [];
+    for await (const chunk of data as AsyncIterable<Buffer>) {
+      chunks.push(chunk as Buffer);
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Returns true when the skill prefix carries the "uploaded by dashboard" marker. */
+async function isCustomSkill(
+  client: any,
+  bucket: string,
+  skillPrefix: string
+): Promise<boolean> {
+  try {
+    const data = await client.getObject(bucket, `${skillPrefix}${CUSTOM_SKILL_MARKER}`);
+    await data.resume?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Reads description from a skill's SKILL.md if present, otherwise undefined. */
+async function readSkillDescription(
+  client: any,
+  bucket: string,
+  skillPrefix: string
+): Promise<string> {
+  const skillMd = await readObjectText(client, bucket, `${skillPrefix}SKILL.md`);
+  if (!skillMd) return '';
+  try {
+    return parseSkillFrontmatter(skillMd).description ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Lists globally-distributed skills stored under `agents/global/skills/` in
+ * the main bucket. Each skill name is a first-level directory prefix. Skills
+ * carrying the custom marker are tagged source='custom', otherwise 'builtin'.
+ */
+export async function listGlobalSkills(
+  client: any,
+  bucket: string
+): Promise<SkillEntry[]> {
+  const names = await collectFirstLevelPrefixes(client, bucket, GLOBAL_SKILLS_PREFIX);
+  const now = new Date().toISOString();
+  const entries: SkillEntry[] = [];
+  for (const name of names) {
+    if (!isValidNameSegment(name)) continue;
+    const prefix = `${GLOBAL_SKILLS_PREFIX}${name}/`;
+    const [description, fileCount, custom] = await Promise.all([
+      readSkillDescription(client, bucket, prefix),
+      countObjectsUnderPrefix(client, bucket, prefix),
+      isCustomSkill(client, bucket, prefix),
+    ]);
+    entries.push({
+      name,
+      description,
+      source: custom ? 'custom' : 'builtin',
+      createdAt: now,
+      updatedAt: now,
+      fileCount,
+    });
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/src/lib/skill-center-types.ts
+++ b/src/lib/skill-center-types.ts
@@ -5,7 +5,7 @@
 export interface SkillEntry {
   name: string;
   description: string;
-  source: 'custom' | 'nacos';
+  source: 'custom' | 'nacos' | 'builtin';
   sourceAlias?: string;
   version?: string;
   createdAt: string;
@@ -51,3 +51,7 @@ export const SKILL_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 export const SKILL_PACKAGE_MAX_BYTES = 64 * 1024 * 1024; // 64 MB
 export const SKILLS_BUCKET = 'skills';
 export const SKILLS_METADATA_PREFIX = 'skills/';
+/** Prefix in the main bucket that stores globally-distributed skills. */
+export const GLOBAL_SKILLS_PREFIX = 'agents/global/skills/';
+/** Marker object written by the upload route inside a skill prefix to record that the skill is user-uploaded (source='custom'). */
+export const CUSTOM_SKILL_MARKER = '.agentteams-custom';


### PR DESCRIPTION
## 概述

基于上游 Skill Center 实现整合 issue #38 的增量能力，解决"上传技能后无法确认"问题。

## 变更内容

- **内置技能扫描**：`src/lib/skill-center-storage.ts` 新增 `listGlobalSkills`，扫描主 bucket `agents/global/skills/` 一级目录，读取 SKILL.md 描述与文件数，标注 `source='builtin'`
- **技能列表合并**：`GET /api/agentteams/skills` 合并内置技能与 skills bucket 元数据（custom/nacos 优先级更高）
- **上传 marker**：`packages/route.ts` 上传成功写入 `.agentteams-custom` marker，扫描时检测判定 `source='custom'`
- **MCP 并入表格**：`SkillCenter` 组件接收 `mcpServers` prop，表格渲染 MCP 行（来源徽标 MCP + url/transport）；来源过滤新增「内置」选项
- **类型扩展**：`SkillEntry.source` 增加 `'builtin'`；新增 `GLOBAL_SKILLS_PREFIX` / `CUSTOM_SKILL_MARKER` 常量
- **测试**：storage 3 个、skills route 2 个、packages marker 1 个（共 6 个新增）

## 验证

- typecheck ✅
- lint ✅
- 测试 356 全过 ✅
- build ✅

## 相关 issue

Closes #38