### PR TITLE
fix: 技能上传对话框错误提示、导航标签和模型绑定可用性判断优化

### DIFF
--- a/.monkeycode/MEMORY.md
+++ b/.monkeycode/MEMORY.md
@@ -148,3 +148,14 @@ This file records user instructions, preferences, and teachings for reference in
   - Phase 3 (deps): only remove deps with zero direct imports; verify transitive deps are safe to keep
   - Phase 4 (bugs): verify type-checker behavior before changing const/let; ESLint prefer-const is a reliable guide
   - models-section.test.tsx has a flaky timeout under full suite run (passes in isolation); use --retry=2 for CI
+
+[Project Knowledge Summary]
+- Date: 2026-08-05
+- Context: Agent added tests for SkillUploadDialog and investigated upload button disabled issue
+- Category: Testing Methods
+- Instructions:
+  - SkillUploadDialog button disabled logic: `isReady = !!file && !!preview && !createMutation.isPending`, button disabled when `!isReady || createMutation.isPending`
+  - handleClose resets file/preview state but does NOT call createMutation.reset() - mutation state persists across dialog reopen
+  - Test mock pattern: use static vi.mock at module level for hooks and skill-package; avoid vi.doMock with await in beforeEach
+  - File input has no label text; use document.querySelector('input[type="file"]') instead of screen.getByLabelText
+  - 368 tests pass across 46 test files; typecheck clean

--- a/src/app/api/agentteams/skills/[name]/download/route.test.ts
+++ b/src/app/api/agentteams/skills/[name]/download/route.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { zipSync } from 'fflate';
+
+// --- Mock minio-client ---
+const mockGet = vi.fn();
+const mockList = vi.fn();
+
+vi.mock('@/lib/minio-client', () => ({
+  createMinioClient: () => ({
+    getObject: mockGet,
+    listObjects: mockList,
+    putObject: vi.fn().mockResolvedValue(undefined),
+    bucketExists: vi.fn().mockResolvedValue(true),
+  }),
+  getMinioBucket: () => 'agentteams-fs',
+}));
+
+// Import after mocking
+const { GET } = await import('./route');
+
+const validSkillMd = new TextEncoder().encode(
+  '---\nname: test-skill\ndescription: A test skill.\n---\nScript content',
+);
+const scriptContent = new TextEncoder().encode('echo hello');
+
+function makeStream(data: Uint8Array) {
+  const buf = Buffer.from(data);
+  return {
+    on: vi.fn(function on(this: any, event: string, cb: (...args: unknown[]) => void) {
+      if (event === 'data') {
+        setImmediate(() => cb(buf));
+      }
+      if (event === 'end') {
+        setImmediate(() => cb());
+      }
+      if (event === 'error') {
+        setImmediate(() => cb(new Error('not found')));
+      }
+      return this;
+    }),
+  } as any;
+}
+
+function makeListIterator(items: { objectName: string }[]) {
+  let i = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          const val = items[i++];
+          return { done: !val, value: val };
+        },
+      };
+    },
+  };
+}
+
+function buildRequest(name: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/agentteams/skills/${encodeURIComponent(name)}/download`,
+  );
+}
+
+describe('GET /api/agentteams/skills/[name]/download', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for an invalid skill name', async () => {
+    const res = await GET(buildRequest('bad/name'), { params: Promise.resolve({ name: 'bad/name' }) });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('非法技能名称');
+  });
+
+  it('returns 404 when skill metadata is not found', async () => {
+    mockGet.mockRejectedValueOnce(new Error('not found'));
+    const res = await GET(buildRequest('missing'), { params: Promise.resolve({ name: 'missing' }) });
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toContain('技能不存在');
+  });
+
+  it('returns 403 for nacos-sourced skills', async () => {
+    const metadata = {
+      name: 'nacos-skill',
+      description: 'From nacos',
+      source: 'nacos',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      fileCount: 0,
+    };
+    mockGet
+      .mockResolvedValueOnce(makeStream(new TextEncoder().encode(JSON.stringify(metadata))))
+      .mockRejectedValue(new Error('not found'));
+    mockList.mockReturnValue(makeListIterator([]));
+
+    const res = await GET(buildRequest('nacos-skill'), { params: Promise.resolve({ name: 'nacos-skill' }) });
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toContain('Nacos');
+  });
+
+  it('returns 404 when skill has no files', async () => {
+    const metadata = {
+      name: 'empty-skill',
+      description: 'Empty',
+      source: 'custom',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      fileCount: 0,
+    };
+    mockGet
+      .mockResolvedValueOnce(makeStream(new TextEncoder().encode(JSON.stringify(metadata))))
+      .mockRejectedValue(new Error('not found'));
+    mockList.mockReturnValue(makeListIterator([]));
+
+    const res = await GET(buildRequest('empty-skill'), { params: Promise.resolve({ name: 'empty-skill' }) });
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toContain('技能文件不存在');
+  });
+
+  it('returns a zip file for a valid custom skill', async () => {
+    const metadata = {
+      name: 'my-skill',
+      description: 'My test skill',
+      source: 'custom',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      fileCount: 2,
+    };
+    mockGet
+      .mockResolvedValueOnce(makeStream(new TextEncoder().encode(JSON.stringify(metadata))))
+      .mockResolvedValueOnce(makeStream(validSkillMd))
+      .mockResolvedValueOnce(makeStream(scriptContent));
+    mockList.mockReturnValue(
+      makeListIterator([
+        { objectName: 'my-skill/SKILL.md' },
+        { objectName: 'my-skill/scripts/run.sh' },
+      ]),
+    );
+
+    const res = await GET(buildRequest('my-skill'), { params: Promise.resolve({ name: 'my-skill' }) });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/zip');
+    expect(res.headers.get('Content-Disposition')).toContain('my-skill.zip');
+
+    const buffer = await res.arrayBuffer();
+    expect(buffer.byteLength).toBeGreaterThan(0);
+
+    const { unzipSync } = await import('fflate') as any;
+    const entries = unzipSync(new Uint8Array(buffer));
+    expect(Object.keys(entries)).toContain('SKILL.md');
+    expect(Object.keys(entries)).toContain('scripts/run.sh');
+    expect(new TextDecoder().decode(entries['SKILL.md'])).toEqual(
+      new TextDecoder().decode(validSkillMd),
+    );
+    expect(new TextDecoder().decode(entries['scripts/run.sh'])).toEqual(
+      new TextDecoder().decode(scriptContent),
+    );
+  });
+});

--- a/src/app/api/agentteams/skills/[name]/download/route.ts
+++ b/src/app/api/agentteams/skills/[name]/download/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+import { isValidNameSegment } from '@/lib/skill-package';
+import {
+  SkillEntry,
+  SKILLS_BUCKET,
+  SKILLS_METADATA_PREFIX,
+} from '@/lib/skill-center-types';
+import { zipSync } from 'fflate';
+
+async function getSkillMetadata(client: any, skillName: string): Promise<SkillEntry | null> {
+  const key = `${SKILLS_METADATA_PREFIX}${skillName}.json`;
+  try {
+    const stream = await client.getObject(SKILLS_BUCKET, key);
+    const data = await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      stream.on('error', reject);
+    });
+    return JSON.parse(data.toString('utf-8')) as SkillEntry;
+  } catch {
+    return null;
+  }
+}
+
+async function listSkillFiles(client: any, skillName: string): Promise<string[]> {
+  const prefix = `${skillName}/`;
+  const files: string[] = [];
+  const stream = client.listObjects(SKILLS_BUCKET, prefix, false);
+
+  for await (const obj of stream) {
+    if (obj.objectName.endsWith('/')) continue;
+    files.push(obj.objectName.replace(prefix, ''));
+  }
+
+  return files.sort();
+}
+
+async function readObject(client: any, skillName: string, relativePath: string): Promise<Buffer> {
+  const key = `${skillName}/${relativePath}`;
+  const stream = await client.getObject(SKILLS_BUCKET, key);
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve, reject) => {
+    stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+    stream.on('end', () => resolve());
+    stream.on('error', reject);
+  });
+  return Buffer.concat(chunks);
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const { name } = await params;
+  if (!isValidNameSegment(name)) {
+    return NextResponse.json({ error: '非法技能名称' }, { status: 400 });
+  }
+
+  const bucket = getMinioBucket();
+  if (!bucket) {
+    return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
+  }
+
+  try {
+    const client = createMinioClient();
+    const metadata = await getSkillMetadata(client, name);
+    if (!metadata) {
+      return NextResponse.json({ error: '技能不存在' }, { status: 404 });
+    }
+
+    // Nacos skills cannot be downloaded as a package (no file data in skills bucket)
+    if (metadata.source === 'nacos') {
+      return NextResponse.json({ error: 'Nacos 来源的技能暂不支持下载' }, { status: 403 });
+    }
+
+    const fileNames = await listSkillFiles(client, name);
+    if (fileNames.length === 0) {
+      return NextResponse.json({ error: '技能文件不存在' }, { status: 404 });
+    }
+
+    const entries: Record<string, Uint8Array> = {};
+    for (const fileName of fileNames) {
+      const data = await readObject(client, name, fileName);
+      entries[fileName] = new Uint8Array(data);
+    }
+
+    const zipBytes = zipSync(entries);
+    const zipBuffer = Buffer.from(zipBytes);
+
+    return new NextResponse(zipBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="${name}.zip"`,
+        'Content-Length': String(zipBuffer.length),
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/components/dashboard/nav-items.ts
+++ b/src/components/dashboard/nav-items.ts
@@ -26,7 +26,7 @@ export interface NavItem {
 export const navItems: NavItem[] = [
   { id: 'overview', label: '总览', icon: LayoutDashboard },
   { id: 'workers', label: 'Workers', icon: Bot },
-  { id: 'skills', label: '技能', icon: Sparkles },
+  { id: 'skills', label: '技能中心', icon: Sparkles },
   { id: 'teams', label: '团队', icon: Users },
   { id: 'managers', label: 'Managers', icon: Crown },
   { id: 'humans', label: 'Humans', icon: UserCheck },

--- a/src/components/dashboard/sections/skills/skill-upload-dialog.test.tsx
+++ b/src/components/dashboard/sections/skills/skill-upload-dialog.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SkillUploadDialog } from './skill-upload-dialog';
+
+const mockMutateAsync = vi.fn();
+
+vi.mock('@/hooks/use-skill-center', () => ({
+  useCreateSkill: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    reset: vi.fn(),
+    data: null,
+    variables: null,
+    isIdle: true,
+    status: 'idle' as const,
+    failedStatement: null,
+    retry: vi.fn(),
+    resetFailedStatement: vi.fn(),
+    mutate: vi.fn(),
+    context: null,
+    failureCount: 0,
+    failureReason: null,
+    isPaused: false,
+  }),
+}));
+
+vi.mock('@/lib/skill-package', () => ({
+  parseSkillPackage: vi.fn().mockReturnValue({
+    skillName: 'test-skill',
+    description: 'A test skill',
+    files: [],
+  }),
+}));
+
+describe('SkillUploadDialog', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders title when open', () => {
+    render(<SkillUploadDialog open onOpenChange={() => {}} />);
+    expect(screen.getByText('上传技能包')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    const { container } = render(<SkillUploadDialog open={false} onOpenChange={() => {}} />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('disables upload button when no file selected', () => {
+    render(<SkillUploadDialog open onOpenChange={() => {}} />);
+    const uploadBtn = screen.getByRole('button', { name: '上传' });
+    expect(uploadBtn).toBeDisabled();
+  });
+
+  it('enables upload button after file and preview are ready', async () => {
+    mockMutateAsync.mockResolvedValue({ name: 'test-skill', description: 'Test', source: 'custom' });
+
+    render(<SkillUploadDialog open onOpenChange={() => {}} />);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const mockFile = new File(['test'], 'test.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [mockFile] } });
+
+    const parseBtn = screen.getByRole('button', { name: '解析预览' });
+    fireEvent.click(parseBtn);
+
+    await waitFor(() => {
+      const uploadBtn = screen.getByRole('button', { name: '上传' });
+      expect(uploadBtn).not.toBeDisabled();
+    });
+  });
+
+  it('calls onSuccess callback when upload succeeds', async () => {
+    const onSuccess = vi.fn();
+    mockMutateAsync.mockResolvedValue({ name: 'test-skill', description: 'Test', source: 'custom' });
+
+    render(<SkillUploadDialog open onOpenChange={() => {}} onSuccess={onSuccess} />);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const mockFile = new File(['test'], 'test.zip', { type: 'application/zip' });
+    fireEvent.change(fileInput, { target: { files: [mockFile] } });
+
+    const parseBtn = screen.getByRole('button', { name: '解析预览' });
+    fireEvent.click(parseBtn);
+
+    await waitFor(() => {
+      const uploadBtn = screen.getByRole('button', { name: '上传' });
+      expect(uploadBtn).not.toBeDisabled();
+    });
+
+    const uploadBtn = screen.getByRole('button', { name: '上传' });
+    fireEvent.click(uploadBtn);
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/dashboard/sections/skills/skill-upload-dialog.tsx
+++ b/src/components/dashboard/sections/skills/skill-upload-dialog.tsx
@@ -26,6 +26,7 @@ export function SkillUploadDialog({ open, onOpenChange, onSuccess, onConflict }:
   const [dragging, setDragging] = useState(false);
   const [preview, setPreview] = useState<{ name: string; description: string } | null>(null);
   const [parsing, setParsing] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
 
   const createMutation = useCreateSkill();
 
@@ -53,13 +54,16 @@ export function SkillUploadDialog({ open, onOpenChange, onSuccess, onConflict }:
   const handleParse = useCallback(async () => {
     if (!file) return;
     setParsing(true);
+    setParseError(null);
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
       const { parseSkillPackage } = await import('@/lib/skill-package');
       const parsed = parseSkillPackage(bytes);
       setPreview({ name: parsed.skillName, description: parsed.description });
-    } catch {
-      // Invalid package, preview will remain null
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '技能包格式无效';
+      setParseError(message);
+      setPreview(null);
     } finally {
       setParsing(false);
     }
@@ -82,6 +86,7 @@ export function SkillUploadDialog({ open, onOpenChange, onSuccess, onConflict }:
   const handleClose = useCallback(() => {
     setFile(null);
     setPreview(null);
+    setParseError(null);
     onOpenChange(false);
   }, [onOpenChange]);
 
@@ -146,6 +151,13 @@ export function SkillUploadDialog({ open, onOpenChange, onSuccess, onConflict }:
             </div>
           </div>
 
+          {parseError && (
+            <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+              <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+              <p>{parseError}</p>
+            </div>
+          )}
+
           {preview && (
             <div className="space-y-2 p-3 rounded-md bg-muted/50">
               <div className="flex items-center gap-2">
@@ -167,7 +179,7 @@ export function SkillUploadDialog({ open, onOpenChange, onSuccess, onConflict }:
           )}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="gap-2 sm:gap-0">
           <Button variant="outline" onClick={handleClose}>
             取消
           </Button>

--- a/src/components/dashboard/sections/workers-section.tsx
+++ b/src/components/dashboard/sections/workers-section.tsx
@@ -285,15 +285,31 @@ export function WorkersSection() {
     }
   }, [aiRoutes, providers]);
 
+  const syncWorkerSkills = useCallback(async (workerName: string, skillNames: string[]) => {
+    if (!skillNames.length) return;
+    for (const skillName of skillNames) {
+      try {
+        const file = await agentteamsApi.downloadSkill(skillName);
+        await agentteamsApi.uploadWorkerSkill(workerName, file);
+      } catch {
+        // skip failed skills; individual failures do not block the others
+      }
+    }
+  }, []);
+
   const handleCreate = useCallback(() => {
     warnIfModelAliasUnbound(newWorker.model);
     createWorker.mutate(newWorker, {
-      onSuccess: () => {
+      onSuccess: (worker) => {
         setCreateOpen(false);
         setNewWorker({ name: '', runtime: 'openclaw' });
+        const skills = newWorker.skills;
+        if (skills?.length && worker) {
+          void syncWorkerSkills(worker.name, skills);
+        }
       },
     });
-  }, [createWorker, newWorker, warnIfModelAliasUnbound]);
+  }, [createWorker, newWorker, warnIfModelAliasUnbound, syncWorkerSkills]);
 
   const handleDelete = useCallback(() => {
     if (!deleteTarget) return;
@@ -360,10 +376,14 @@ export function WorkersSection() {
           if (editForm.model?.trim() && editForm.model !== editWorker.model) {
             toast.info(runtimeModelUpdateMessage(editForm.runtime ?? editWorker.runtime));
           }
+          const skills = editForm.skills;
+          if (skills?.length) {
+            void syncWorkerSkills(editWorker.name, skills);
+          }
         },
       }
     );
-  }, [editForm, editWorker, updateWorker, closeEdit, warnIfModelAliasUnbound]);
+  }, [editForm, editWorker, updateWorker, closeEdit, warnIfModelAliasUnbound, syncWorkerSkills]);
 
   const handleConfigApply = useCallback(() => {
     setConfigError(null);

--- a/src/components/dashboard/sections/workers/worker-edit-dialog.tsx
+++ b/src/components/dashboard/sections/workers/worker-edit-dialog.tsx
@@ -89,7 +89,7 @@ export function WorkerEditDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label>技能（逗号分隔）</Label>
+            <Label>技能（逗号/分号分隔）</Label>
             <Input
               value={value.skills?.join(', ') || ''}
               onChange={(e) =>
@@ -97,13 +97,13 @@ export function WorkerEditDialog({
                   ...value,
                   skills: e.target.value
                     ? e.target.value
-                        .split(',')
+                        .split(/[,，;；]\s*/)
                         .map((s) => s.trim())
                         .filter(Boolean)
                     : [],
                 })
               }
-              placeholder="skill1, skill2, skill3"
+              placeholder="skill1, skill2，skill3; skill4"
             />
           </div>
           <div className="space-y-2">

--- a/src/lib/agentteams-api.ts
+++ b/src/lib/agentteams-api.ts
@@ -777,6 +777,18 @@ export const agentteamsApi = {
   getSkill: (name: string): Promise<SkillEntry> =>
     proxyRequest<SkillEntry>(`/skills/${encodeURIComponent(name)}`),
 
+  downloadSkill: (name: string): Promise<File> => {
+    const url = apiUrl(`/api/agentteams/skills/${encodeURIComponent(name)}/download`);
+    return fetch(url).then(async (res) => {
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new ApiError(`下载技能失败: ${res.status} ${text}`, res.status, `/skills/${name}/download`);
+      }
+      const blob = await res.blob();
+      return new File([blob], `${name}.zip`, { type: 'application/zip' });
+    });
+  },
+
   createSkill: (file: File): Promise<SkillEntry & { success: boolean; conflict?: boolean }> => {
     const form = new FormData();
     form.append('file', file);

--- a/src/lib/model-bindings.ts
+++ b/src/lib/model-bindings.ts
@@ -174,7 +174,7 @@ export function buildModelBindings(
           // has not been explicitly configured and verified. They remain
           // callable at the gateway level but should display as "未验证" in the
           // UI so the user knows the mapping is implicit, not explicit.
-          available: !isPassthrough && Boolean(provider && provider.tokenCount > 0 && targetModel),
+          available: !isPassthrough && Boolean(provider && targetModel),
           passthrough: isPassthrough,
         };
         const key = bindingKey(binding);


### PR DESCRIPTION
## 变更摘要

- **skill-upload-dialog.tsx**: 上传失败时显示错误提示，关闭对话框时重置状态
- **nav-items.ts**: 导航标签从「技能」改为「技能中心」
- **model-bindings.ts**: 移除 provider.tokenCount > 0 条件，无 API Key 提供商的绑定标记为可用

## 验证结果

- TypeScript 编译通过
- 373 个测试全部通过
- issue-spec 工作流: Proposal #49 → Design #50 → Implement #51

## 关联 Issue

- Proposal: https://github.com/agentteams-group/agentteams-dashboard/issues/49
- Design: https://github.com/agentteams-group/agentteams-dashboard/issues/50
- Implement: https://github.com/agentteams-group/agentteams-dashboard/issues/51