### PR TITLE
fix(deps): add missing react-is dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.84.0",
+        "react-is": "^19.0.0",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.1",
         "rehype-highlight": "^7.0.2",
@@ -11917,6 +11918,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-is": "^19.0.0",
     "react-hook-form": "^7.84.0",
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.1",


### PR DESCRIPTION
## Summary

- add `react-is` as a direct production dependency
- update `package-lock.json` with `react-is@19.2.8`

## Root cause

`recharts@3.9.1` imports `react-is` as a peer dependency. The lockfile no longer contained a top-level `react-is`, and the Docker build uses `npm ci --legacy-peer-deps`, so the peer dependency was not installed. The release image build then failed during `next build` with `Module not found: Can't resolve 'react-is'`.

## Validation

- `npm ci --no-audit --no-fund --legacy-peer-deps --registry=https://registry.npmmirror.com`
- `npm ls react-is recharts --all`
- `npm run build`
- `git diff --check`

The production build passes. The full Vitest run reported 374 passing and 22 existing environment/mock failures: the integration suite expected a server on port 3000 and configured MinIO, while `models-section.test.tsx` has a `DialogDescription` mock mismatch.
