### PR TITLE
fix(auth): keep external dashboard login session-only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Keep host dependencies, generated assets, local state, and credentials out of
+# the image build context. The Dockerfile restores dependencies from package-lock.
+node_modules
+.next
+.git
+.env
+.env.*
+!.env.example
+*.log
+coverage

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import {
+  callHigressConsole,
+  forwardCookies,
+  getHigressConsoleURL,
+} from '../../higress/proxy-helper';
+
+vi.mock('../../higress/proxy-helper', () => ({
+  callHigressConsole: vi.fn(),
+  forwardCookies: vi.fn(),
+  getHigressConsoleURL: vi.fn(() => 'http://higress-console:8080'),
+  higressErrorResponse: vi.fn(),
+}));
+
+vi.mock('@/lib/homeserver-allowlist', () => ({
+  validateHomeserverUrl: vi.fn(),
+}));
+
+const mockCallHigressConsole = vi.mocked(callHigressConsole);
+const mockForwardCookies = vi.mocked(forwardCookies);
+const mockGetHigressConsoleURL = vi.mocked(getHigressConsoleURL);
+
+function request() {
+  return new NextRequest('http://dashboard.test/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ username: 'admin', password: 'password' }),
+  });
+}
+
+function successfulConsoleLogin() {
+  return {
+    response: new Response(null, { status: 200 }),
+    body: { success: true },
+  };
+}
+
+describe('POST /api/auth/login', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+    mockCallHigressConsole.mockReset();
+    mockForwardCookies.mockReset();
+    mockGetHigressConsoleURL.mockReset();
+    mockGetHigressConsoleURL.mockReturnValue('http://higress-console:8080');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('skips Console initialization in external Higress mode', async () => {
+    vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'external');
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mockCallHigressConsole).toHaveBeenCalledTimes(1);
+    expect(mockCallHigressConsole).toHaveBeenCalledWith('/session/login', {
+      method: 'POST',
+      body: { username: 'admin', password: 'password' },
+      consoleUrl: 'http://higress-console:8080',
+    });
+    expect(mockCallHigressConsole).not.toHaveBeenCalledWith(
+      '/system/init',
+      expect.anything(),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('retains Console initialization for direct Higress mode', async () => {
+    vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'direct');
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mockCallHigressConsole).toHaveBeenCalledTimes(2);
+    expect(mockCallHigressConsole).toHaveBeenNthCalledWith(1, '/system/init', {
+      method: 'POST',
+      body: {
+        adminUser: {
+          name: 'admin',
+          password: 'password',
+          displayName: 'admin',
+        },
+      },
+      consoleUrl: 'http://higress-console:8080',
+    });
+  });
+});

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -68,24 +68,29 @@ async function tryMatrixLogin(username: string, password: string): Promise<Recor
 async function loginViaHigress(username: string, password: string) {
   const consoleUrl = getHigressConsoleURL();
 
-  // 1. Initialize Higress Console admin account (idempotent).
-  try {
-    await callHigressConsole('/system/init', {
-      method: 'POST',
-      body: {
-        adminUser: {
-          name: username,
-          password,
-          displayName: username,
+  // Embedded/direct deployments retain the upstream idempotent initializer.
+  // External mode must never bootstrap or change a shared Console admin during
+  // a Dashboard login; it authenticates only against an already-provisioned
+  // Console account.
+  if (process.env.AGENTTEAMS_HIGRESS_ADAPTER_MODE !== 'external') {
+    try {
+      await callHigressConsole('/system/init', {
+        method: 'POST',
+        body: {
+          adminUser: {
+            name: username,
+            password,
+            displayName: username,
+          },
         },
-      },
-      consoleUrl,
-    });
-  } catch {
-    // continue to login attempt
+        consoleUrl,
+      });
+    } catch {
+      // Continue to the login attempt; initialization is best-effort only.
+    }
   }
 
-  // 2. Login to obtain the session cookie.
+  // Login to obtain the session cookie.
   const { response, body: loginBody } = await callHigressConsole('/session/login', {
     method: 'POST',
     body: { username, password },
@@ -96,8 +101,12 @@ async function loginViaHigress(username: string, password: string) {
     return higressErrorResponse(response, loginBody);
   }
 
-  // 3. Attempt Matrix login with the same credentials (non-blocking).
-  const matrix = await tryMatrixLogin(username, password);
+  // External mode has no browser-reachable Matrix endpoint and must not return
+  // an internal homeserver URL or Matrix access token to the Tailnet client.
+  // Direct deployments retain the upstream convenience auto-login behavior.
+  const matrix = process.env.AGENTTEAMS_HIGRESS_ADAPTER_MODE === 'external'
+    ? null
+    : await tryMatrixLogin(username, password);
 
   // Forward Set-Cookie headers from Higress Console back to the browser.
   const responseHeaders = new Headers();


### PR DESCRIPTION
## Summary
- Make `external` Higress adapter login session-only.
- Skip `/system/init` in external mode.
- Skip Matrix auto-login and return `matrix: null` in external mode.
- Retain upstream initializer and Matrix convenience behavior for direct mode.
- Add focused regression coverage and exclude local build/environment artifacts from Docker context.

## Validation
- Focused login route tests: 2 passed.
- Targeted ESLint for the login route and test: passed.
- Production build: passed.

## Security
External/shared-console mode now makes only the Higress `/session/login` request. It does not bootstrap Console state, invoke Matrix password login, or return Matrix connection/token data to the browser.

 
