### PR TITLE
feat(dashboard): 新增一键收集调试日志功能

### DIFF
--- a/.monkeycode/MEMORY.md
+++ b/.monkeycode/MEMORY.md
@@ -81,11 +81,11 @@ This file records user instructions, preferences, and teachings for reference in
   - PR #27 created: https://github.com/agentteams-group/agentteams-dashboard/pull/27
 
 [Project Knowledge Summary]
-- Date: 2026-07-29
-- Context: Discovered by Agent while verifying resource deletion locking
+- Date: 2026-08-09
+- Context: Updated during PR #78 debug-log review validation
 - Category: Environment Configuration
 - Instructions:
-  - The workspace currently has no installed Node.js dependencies; `npm test`, `npm run typecheck`, and `npm run lint` cannot resolve their project executables.
+  - Dependencies are installed via `npm ci --no-audit --no-fund` (lockfile is current); after that `npm run typecheck` / `npm run lint` / `npm test` resolve their executables.
 
 [Project Knowledge Summary]
 - Date: 2026-08-01
@@ -168,3 +168,11 @@ This file records user instructions, preferences, and teachings for reference in
   - Test mock pattern: use static vi.mock at module level for hooks and skill-package; avoid vi.doMock with await in beforeEach
   - File input has no label text; use document.querySelector('input[type="file"]') instead of screen.getByLabelText
   - 368 tests pass across 46 test files; typecheck clean
+
+[Project Knowledge Summary]
+- Date: 2026-08-09
+- Context: Discovered by Agent while validating PR #78 debug-log changes; fixed same day
+- Category: Troubleshooting & Debugging
+- Instructions:
+  - Fixed pre-existing failures in `src/app/api/agentteams/workers/[name]/files/route.test.ts`: (1) it passed `new Request(...)` but the handler reads `request.nextUrl.searchParams`, so the typecheck failed (`Request` not assignable to `NextRequest`) and vitest threw `Cannot read properties of undefined (reading 'searchParams')`; fix = import `NextRequest` from 'next/server' and construct `new NextRequest('http://localhost')`. (2) `createObjectStream` used `queueMicrotask`, which fires BEFORE the handler registers 'data'/'end' listeners (handler waits on its `await params` continuation, which runs after the microtask queue), so events were lost and tests hung until timeout; fix = use `setImmediate` (fires after all microtasks). (3) assertions were stale: handler returns `prefix: ''` and strips `agents/` via `stripAgentsPrefix`; updated expected objects accordingly.
+  - debug-log validation status: homeserver-allowlist (15), redact (20), route (6) tests all pass; lint clean; typecheck clean for the 9 debug-log files.

--- a/docs/debug-log-collection.md
+++ b/docs/debug-log-collection.md
@@ -1,0 +1,246 @@
+# Dashboard 一键收集调试日志 — 技术方案
+
+> 版本：v1.0 · 日期：2026-08-08
+> 对标工具：AgentTeams 主仓库 `scripts/export-debug-log.py`
+> 落地仓库：`agentteams-group/agentteams-dashboard`
+
+---
+
+## 1. 背景与目标
+
+### 1.1 原脚本分析
+
+AgentTeams 主仓库提供了独立 Python 脚本 `scripts/export-debug-log.py`，用于故障排查时一键导出调试材料。其核心能力：
+
+| 收集器 | 数据源 | 采集方式 | 输出 |
+|---|---|---|---|
+| Matrix 消息 | Tuwunel Homeserver | 读 `~/agentteams-manager.env` 取 Manager/Admin 密码登录 Matrix，遍历 joined_rooms 分页拉取 `/messages` | `matrix-messages/<Room>_<roomid>.jsonl` |
+| Agent 会话 | 各容器内 session 文件 | `docker exec` 探测 OpenClaw / Hermes / CoPaw 三种 runtime 的 session 目录，按时间过滤后 cat 出来 | `agent-sessions/<容器>/<session>.jsonl` |
+| 容器诊断 | Docker Engine | `docker ps/inspect/logs --since` | `container-logs/<容器>.log + .state.json` |
+| PII 脱敏 | 全部产出 | 20 条正则（身份证/手机号/邮箱/银行卡/IP/各类 API Key/Bearer/secret KV/Matrix token 等） | 默认开启，`--no-redact` 关闭 |
+| 汇总 | — | — | `summary.txt`，落盘 `debug-log/<时间戳>/` |
+
+### 1.2 痛点与目标
+
+原脚本的使用门槛：**必须在宿主机上执行**，依赖本地 `docker` CLI、Python 环境、以及 env 文件里的明文凭证。对于只装了 Dashboard 的排查者（尤其是远程支持场景）并不友好。
+
+**目标**：在 Dashboard 内实现同等能力的「一键收集日志」功能 —— 浏览器点一下按钮，后端完成采集、脱敏、打包，直接下载 ZIP。
+
+```
+浏览器设置对话框 → [一键收集并下载] → agentteams-debug-log-<时间戳>.zip
+├── summary.txt
+├── matrix-messages/<RoomName>_<roomid>.jsonl   （已登录 Matrix 时）
+├── agent-sessions/<container>/<session>.jsonl
+└── container-logs/<container>.log / .state.json
+```
+
+---
+
+## 2. 关键技术调研：Dashboard 容器里如何拿到这些数据？
+
+Dashboard 是跑在容器里的 Next.js 应用，没有 docker CLI、没有宿主机 env 文件。调研发现两条既有通道可以完全覆盖原脚本的数据源，**无需任何新权限、新挂载、新依赖**：
+
+### 2.1 容器数据 → Controller 内置 Docker API 反向代理
+
+`agentteams-controller/internal/proxy/proxy.go` 的安全模型：
+
+- **GET/HEAD 全放行**（只读）：`/containers/json`（列表）、`/containers/{name}/json`（inspect）、`/containers/{name}/logs`（日志）；
+- **POST 白名单**含 `containers/{name}/exec` + `exec/{id}/start`：即 **docker exec 可用**，等价于原脚本的 `docker exec`；
+- POST/DELETE 的写操作另有镜像白名单、禁 bind mount、禁特权等校验，与本功能无关但说明通道是安全收敛的。
+
+Dashboard 侧已有成功先例：[logs/[component]/route.ts](../src/app/api/agentteams/logs/%5Bcomponent%5D/route.ts) 就是通过 `GET {controller}/docker/v1.41/containers/{name}/logs` 拉日志的，鉴权复用 `getControllerUrl()` + `getAuthToken()`（SA token 每请求重读，支持轮转）。
+
+### 2.2 Matrix 消息 → 浏览器已有登录态
+
+Dashboard 的 Chat 模块要求用户登录 Matrix，`matrix-store`（zustand persist）持有 `homeserver + accessToken`。现有 `/api/matrix/*` 路由的约定是：token 只走 `Authorization: Bearer` 头（不进 query/body，避免泄露进访问日志），homeserver 经 `validateHomeserverUrl()`（hostname 白名单 + 私网 SSRF 拦截）校验。**本功能完整复用这套约定**，server 端用该 token 直连 homeserver 拉消息——与原脚本"用 Manager 账号登录"不同，改用"当前用户自己的身份"，权限语义反而更准确（只能导出自己有权限看的房间）。
+
+### 2.3 打包 → 复用已有依赖 fflate
+
+`package.json` 已依赖 `fflate`（前端 worker 文件打包在用）。`zipSync` 在 Node 端同样可用，内存中直接产出 ZIP，零新依赖。
+
+---
+
+## 3. 总体架构
+
+```
+┌─────────────────┐   POST /api/agentteams/debug-log/   ┌──────────────────────────────┐
+│  浏览器          │ ───────────────────────────────────▶│  Next.js Route Handler        │
+│  设置·日志收集    │   body: {range, redact, filters}    │  app/api/agentteams/debug-log/ │
+│  页签            │   header: Authorization (Matrix)    │                              │
+└─────────────────┘                                     └───────┬──────────────┬─────────┘
+         │                                                      │              │
+         │  agentteams-debug-log-<ts>.zip (fflate zipSync)      │              │
+         │◀─────────────────────────────────────────────────────│              │
+         │                                      ┌───────────────▼───┐   ┌──────▼─────────┐
+         │                                      │ AgentTeams         │   │ Matrix          │
+         │                                      │ Controller         │   │ Homeserver      │
+         │                                      │ /docker/v1.41/*    │   │ /_matrix/client │
+         │                                      │  ├ containers/json │   │ /v3/joined_rooms│
+         │                                      │  ├ .../logs        │   │ /rooms/*/msgs   │
+         │                                      │  ├ .../json        │   └─────────────────┘
+         │                                      │  └ exec + start    │  （homeserver 白名单
+         │                                      └────────────────────┘   + SSRF 校验）
+         │ 收集器全部 try/catch 隔离，部分失败写入 summary.txt Notes，不中断整体导出
+```
+
+与原脚本能力对照：
+
+| 能力 | export-debug-log.py | Dashboard 实现 | 差异说明 |
+|---|---|---|---|
+| 容器列表/状态/日志 | 本地 `docker ps/inspect/logs` | Controller Docker 代理 GET | 等价 |
+| Agent 会话采集 | 本地 `docker exec` | 代理 exec create + start | 等价，且做了批量化优化（见 §4.3） |
+| Matrix 消息 | env 文件拿 Manager/Admin 密码登录 | 浏览器当前用户 token | 身份语义更准确；未登录则降级跳过 |
+| PII 脱敏 | 20 条正则 | 同规则 TypeScript 移植 | 规则一致，修正 1 处原脚本缺陷（见 §4.1） |
+| 产物 | 落盘 `debug-log/<ts>/` 目录 | 内存打包 ZIP 下载 | 不落盘、无状态 |
+| 时间范围 | `--range 10m/1h/1d` | 同名参数 | 一致 |
+| 容器/房间过滤 | `--container/--room` | 同名参数 | 一致 |
+
+---
+
+## 4. 实现细节（变更清单）
+
+### 新增文件
+
+```
+src/app/api/agentteams/debug-log/
+├── route.ts          # 主路由：编排三大收集器 + summary + zipSync 打包
+├── docker.ts         # Controller Docker 代理客户端（list/inspect/logs/exec + 流解复用）
+├── matrix.ts         # Matrix 消息导出（joined_rooms + 分页 messages + 事件格式化）
+├── sessions.ts       # Agent 会话导出（三 runtime 探测 + 按时间过滤）
+├── redact.ts         # PII 脱敏（20 条规则）
+└── redact.test.ts    # 脱敏单测 16 例
+
+src/components/dashboard/settings/
+└── debug-log-tab.tsx # 「日志收集」页签 UI
+```
+
+### 修改文件
+
+```
+src/components/dashboard/settings-dialog.tsx   # 设置对话框新增第三个页签（连接 / AI 诊断 / 日志收集）
+```
+
+### 4.1 `redact.ts` — PII 脱敏
+
+- 完整移植原脚本 20 条正则：身份证、手机号、邮箱、银行卡、IP、阿里云 AK/SK、AWS AK、OpenAI/Anthropic/DashScope/DeepSeek Key、Bearer、通用 secret KV、Matrix token、32+ 位 hex、护照、SSN；
+- `keepPrefix` 规则（Bearer / SECRET_KV / ALIYUN_SK）保留 key 名只遮蔽值，替换为 `$1****`；
+- `redactJsonStrings()` 递归处理 JSON：字段名命中 `SECRET_FIELD_PATTERN`（password/token/apiKey…）直接置 `****`，否则递归脱敏字符串；
+- **修正原脚本一处缺陷**：Python 版 `ALIYUN_SK` 正则的捕获组 1 是 secret 值本身，`\1****` 替换会把 secret 原文保留下来（key 名反而被吃掉）。TS 版调整为捕获组 1 = key 名前缀，真正遮蔽密钥值；
+- JS 正则全面支持 lookbehind/lookahead（Node 20+），语义与 Python 一致。
+
+### 4.2 `docker.ts` — Docker 代理客户端
+
+- 统一 `dockerFetch()`：`{controller}/docker/v1.41<path>`，携带 SA token，默认 60s 超时（exec 30s）；
+- `demuxDockerStream()`：解析 Docker raw stream 的 8 字节帧头（`[stream][3×pad][uint32 BE len][payload]`），logs 与 exec 输出都是这种帧格式；兼容 TTY 无帧头的兜底；
+- `listAgentTeamsContainers()`：`GET /containers/json?all=1&filters={"name":["agentteams-"]}`；
+- `inspectContainer()`：提取 `State / Config.Image / RestartCount` 组成诊断 JSON；
+- `getContainerLogs()`：`--timestamps --since <epoch秒>` 对齐原脚本；
+- `dockerExec()`：`POST /containers/{name}/exec`（`sh -c`）→ `POST /exec/{id}/start`（Detach=false）→ 解复用 stdout。
+
+### 4.3 `sessions.ts` — Agent 会话导出（核心复杂度）
+
+忠实移植三种 runtime 的目录布局探测与过滤逻辑，并针对「exec 从本地进程调用变成 HTTP 往返」做了**批量化优化**：
+
+- **runtime 探测（1 次 exec）**：原脚本是「读 `$AGENTTEAMS_WORKER_NAME` 一次 exec + 每个候选目录一次 `test -d`」，最多 8 次往返；TS 版把 worker 名读取 + 全部候选路径探测合成**一段 sh 脚本**一次执行，按优先级输出 `FOUND <dir>`，本地解析；未命中再走 `find / -maxdepth 7` 兜底（与原脚本一致）；
+- **文件读取（1 次 exec）**：原脚本对每个 session 文件 `head -1` / `tail -1` / `cat` 三次 exec（先判时间再决定是否全量拉取）；TS 版改为 `for f in <dir>/*.jsonl; do echo MARKER; cat; done` **一次拉全量**，时间过滤（header 保留、事件按 `timestamp >= since` 过滤、整会话过期丢弃）全部在 server 端本地完成。单次 payload 变大但往返次数从 O(3N) 降到 O(1)，在 HTTP 通道下整体更快、逻辑更简单；
+- **OpenClaw**：`.jsonl` 逐行解析，`type=="session"` 头始终保留；附带 `sessions.json` 索引；
+- **CoPaw**：`find -name '*.json'`，解 `agent.memory.content`（turn→msg 两层结构），过滤后重组为「session 头 + message 事件」的 jsonl；
+- **Hermes**：jsonl + `session_meta` 角色保留；附加 `state.db`（容器内有 python3 时用 sqlite3 导出最近 200 条）和 `logs/agent.log|errors.log|gateway.log`；
+- 每个容器独立 try/catch，失败记入 errors 数组，最终写进 summary。
+
+### 4.4 `route.ts` — 主路由
+
+- `POST /api/agentteams/debug-log/`，`export const dynamic = 'force-dynamic'`、`maxDuration = 300`；
+- 请求体：`{ range='1h', redact=true, container?, room?, messagesOnly?, homeserver? }`；`range` 解析规则与原脚本一致（`10m/1h/1d`…）；
+- Matrix 凭证：`Authorization` 头取 token（沿用 `/api/matrix/*` 约定），homeserver 从 body 或 `?homeserver=` 取；**任一缺失则跳过 Matrix 导出并在 summary 注明**（降级而非报错）；
+- 编排顺序：容器列表（两个收集器共用）→ 容器诊断（inspect + logs）→ Agent 会话 → Matrix 消息；每个收集器独立容错，异常全部收敛为 summary 里的 Notes；
+- 产物：`summary.txt`（时间范围/脱敏状态/三路计数/Notes）+ 全部文件 `zipSync(level:6)`，响应头 `Content-Disposition: attachment; filename="agentteams-debug-log-<ts>.zip"`，`Cache-Control: no-store`。
+
+### 4.5 前端 `debug-log-tab.tsx` + `settings-dialog.tsx`
+
+- 设置对话框新增第三个页签「日志收集」（FileDown 图标），TabsList `grid-cols-2 → grid-cols-3`；
+- 页签控件：时间范围 Select（10m/30m/1h/6h/1d）、容器过滤、房间过滤、PII 脱敏 Switch（默认开，带 ShieldCheck 说明）、Matrix 状态提示条（已登录 → 含房间消息；未登录 → 提示将跳过）；
+- 点击「一键收集并下载」：`fetch(apiUrl('/api/agentteams/debug-log'))`（apiUrl 自动补 basePath + 尾斜杠，规避 trailingSlash 308 重定向丢 POST body 的问题）；已登录 Matrix 时自动带上 `Authorization` 头和 homeserver；
+- 响应处理：非 2xx 解析 JSON error 弹 toast；成功则读 `content-disposition` 文件名，`URL.createObjectURL` + 隐形 `<a download>` 触发浏览器下载，toast 提示文件名；全程 loading 态（收集耗时可能数十秒）。
+
+### 4.6 测试 `redact.test.ts`
+
+16 个用例覆盖：各类正则的遮蔽、keepPrefix 规则的 key 保留、普通文本不误伤、JSON 递归脱敏、secret 字段名置空、数组顶层等边界。
+
+---
+
+## 5. 接口契约
+
+```
+POST /api/agentteams/debug-log/
+Headers:
+  Content-Type: application/json
+  Authorization: Bearer <matrix-token>        # 可选；提供则导出 Matrix 消息
+Body:
+{
+  "range": "1h",            # 10m|30m|1h|6h|1d，支持 N(m|min|h|hr|hour|d|day)
+  "redact": true,           # 默认 true
+  "container": "worker",    # 可选，子串过滤容器
+  "room": "Worker",         # 可选，子串过滤房间名/ID
+  "homeserver": "http://..."# 可选（也可走 ?homeserver=）
+}
+Response 200:
+  Content-Type: application/zip
+  Content-Disposition: attachment; filename="agentteams-debug-log-20260808-153000.zip"
+Response 4xx: { "error": "..." }   # 参数错误
+```
+
+ZIP 内部结构：
+
+```
+summary.txt
+matrix-messages/<RoomName>_<roomid>.jsonl
+agent-sessions/<container>/<session>.jsonl [sessions.json | sessions-db.json | *.log]
+container-logs/<container>.log
+container-logs/<container>.state.json
+```
+
+---
+
+## 6. 安全设计
+
+1. **凭证零落盘**：Matrix token 仅在请求头中瞬时使用；Controller SA token 服务端每请求重读（支持轮转）；ZIP 全程内存组装，不写磁盘；
+2. **SSRF 防护**：homeserver 复用 `validateHomeserverUrl()`（白名单 + 私网地址拦截）；controller 地址复用 `getControllerUrl()` 的 host 白名单；
+3. **权限收敛**：Docker 侧只用到 controller 代理已放行的只读 GET + exec；Matrix 侧以当前登录用户身份导出，天然只能看到自己有权访问的房间；
+4. **PII 默认脱敏**：20 条规则默认开启，用户显式关闭才产出原文；
+5. **输入校验**：range 格式校验、容器/房间过滤仅作子串匹配、容器名经 Docker API 自身校验（代理层还有 `name` 字符白名单）。
+
+## 7. 性能与可靠性
+
+- **超时**：单 exec 30s、单 docker 请求 60s、单 Matrix 请求 30s、路由 `maxDuration=300`；
+- **往返优化**：runtime 探测 8→1 次、session 读取 3N→1 次 exec；
+- **降级策略**：Docker 代理不可达 / Matrix 未登录 / 单容器失败，均不阻断其他收集器，差异写入 `summary.txt` Notes；
+- **资源**：ZIP 内存组装，1h 范围典型产物为数百 KB ~ 数 MB 级，风险可控；大时间范围 + 大集群场景建议后续做流式打包（见 §9）。
+
+## 8. 验证结果
+
+| 检查 | 结果 |
+|---|---|
+| `npm run typecheck` | 新增代码 0 错误（仅存量 `workers/[name]/files/route.test.ts` 3 处历史错误，与本次无关） |
+| `npx eslint <变更文件>` | 0 错误 0 警告 |
+| `vitest run src/app/api/agentteams/debug-log` | **16/16 通过** |
+| `npm test` 全量 | 304/307 通过；3 个失败位于存量 `workers/[name]/skills/route.test.ts`（vitest fork worker 启动超时，Windows 环境问题，与本次变更无关） |
+| `npm run build` | 生产构建通过（Next.js standalone 产物含新路由与页签） |
+
+## 9. 已知限制与后续路线
+
+1. **K8s/Helm 部署形态**：本功能依赖 Controller 的 Docker 代理，该代理面向 docker 单节点部署；k3s 形态下容器日志/会话需改走 Kubernetes API（`kubectl logs`/`exec` 等价物），可作为后续迭代（路由层已按收集器隔离，新增 K8s collector 即可）；
+2. **Matrix 未登录时无消息导出**：可考虑支持服务端配置只读 bot 账号兜底；
+3. **大产物流式化**：当前 `zipSync` 内存打包，后续可换 `fflate` 的 `Zip` 流式接口 + `Transfer-Encoding: chunked`；
+4. **产物回传**：可增加「直接上传到 MinIO / 生成分享链接」选项，便于远程支持场景；
+5. **采集进度**：当前为单次长请求 + loading，后续可拆分为「创建任务 → 轮询进度 → 下载」三段式。
+
+---
+
+## 附：使用方式
+
+1. 打开 Dashboard → 右上角设置 → 「日志收集」页签；
+2. 选择时间范围（默认最近 1 小时），按需填容器/房间过滤；
+3. 保持 PII 脱敏开启（默认）；
+4. 需要房间消息时先登录 Matrix（Chat 模块）；
+5. 点击「一键收集并下载」，得到 `agentteams-debug-log-<时间戳>.zip`，附在 issue 中即可。

--- a/src/app/api/agentteams/debug-log/docker.ts
+++ b/src/app/api/agentteams/debug-log/docker.ts
@@ -1,0 +1,167 @@
+// Docker Engine API client that talks through the AgentTeams Controller's
+// reverse proxy (/docker/v1.41/...). The controller allows all read-only GET
+// endpoints plus exec create/start, which is everything the debug-log
+// exporter needs — no direct access to the docker socket required.
+
+const DOCKER_API_VERSION = 'v1.41';
+const EXEC_TIMEOUT_MS = 30000;
+const REQUEST_TIMEOUT_MS = 60000;
+
+export interface DockerContext {
+  controllerUrl: string;
+  token?: string;
+}
+
+async function dockerFetch(
+  ctx: DockerContext,
+  path: string,
+  options: { method?: string; body?: unknown; timeout?: number } = {}
+): Promise<Response> {
+  const { method = 'GET', body, timeout = REQUEST_TIMEOUT_MS } = options;
+  const url = new URL(`/docker/${DOCKER_API_VERSION}${path}`, ctx.controllerUrl).toString();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    const headers: Record<string, string> = {};
+    if (ctx.token) headers['Authorization'] = `Bearer ${ctx.token}`;
+    if (body !== undefined) headers['Content-Type'] = 'application/json';
+
+    return await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Demultiplex a Docker raw stream (8-byte frame headers, Tty=false). */
+export function demuxDockerStream(buffer: ArrayBuffer): string {
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+  const decoder = new TextDecoder('utf-8');
+  const parts: string[] = [];
+  let offset = 0;
+
+  while (offset + 8 <= view.byteLength) {
+    const length = view.getUint32(offset + 4, false); // big-endian
+    if (offset + 8 + length > view.byteLength) break;
+    parts.push(decoder.decode(bytes.subarray(offset + 8, offset + 8 + length)));
+    offset += 8 + length;
+  }
+  // Tty streams (or an empty attachment) have no multiplex headers.
+  if (parts.length === 0 && buffer.byteLength > 0) {
+    return decoder.decode(bytes);
+  }
+  return parts.join('');
+}
+
+/** List agentteams-* container names (running and stopped). */
+export async function listAgentTeamsContainers(ctx: DockerContext): Promise<string[]> {
+  const filters = encodeURIComponent(JSON.stringify({ name: ['agentteams-'] }));
+  const res = await dockerFetch(ctx, `/containers/json?all=1&filters=${filters}`);
+  if (!res.ok) {
+    throw new Error(`Docker API returned ${res.status} while listing containers`);
+  }
+  const containers = (await res.json()) as Array<{ Names?: string[] }>;
+  const names = containers
+    .flatMap((c) => c.Names ?? [])
+    .map((n) => n.replace(/^\//, ''))
+    .filter(Boolean);
+  return [...new Set(names)].sort();
+}
+
+export interface ContainerDiagnostic {
+  container: string;
+  image: string;
+  restart_count: number | null;
+  state: unknown;
+}
+
+/** docker inspect → { state, image, restartCount } */
+export async function inspectContainer(
+  ctx: DockerContext,
+  name: string
+): Promise<ContainerDiagnostic> {
+  const res = await dockerFetch(ctx, `/containers/${encodeURIComponent(name)}/json`);
+  if (!res.ok) {
+    return {
+      container: name,
+      image: '',
+      restart_count: null,
+      state: { inspect_error: `Docker API returned ${res.status}` },
+    };
+  }
+  const data = (await res.json()) as {
+    State?: unknown;
+    Config?: { Image?: string };
+    RestartCount?: number;
+  };
+  return {
+    container: name,
+    image: data.Config?.Image ?? '',
+    restart_count: typeof data.RestartCount === 'number' ? data.RestartCount : null,
+    state: data.State ?? null,
+  };
+}
+
+/** docker logs --timestamps --since <epoch seconds> */
+export async function getContainerLogs(
+  ctx: DockerContext,
+  name: string,
+  sinceEpochSec: number
+): Promise<string> {
+  const res = await dockerFetch(
+    ctx,
+    `/containers/${encodeURIComponent(name)}/logs?stdout=1&stderr=1&timestamps=1&since=${Math.floor(sinceEpochSec)}`
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Docker logs returned ${res.status}: ${text}`);
+  }
+  return demuxDockerStream(await res.arrayBuffer());
+}
+
+/** docker exec sh -c <cmd> → combined stdout (mirrors the Python docker_exec helper). */
+export async function dockerExec(
+  ctx: DockerContext,
+  container: string,
+  cmd: string
+): Promise<string> {
+  const createRes = await dockerFetch(
+    ctx,
+    `/containers/${encodeURIComponent(container)}/exec`,
+    {
+      method: 'POST',
+      body: {
+        AttachStdout: true,
+        AttachStderr: true,
+        Tty: false,
+        Cmd: ['sh', '-c', cmd],
+      },
+      timeout: EXEC_TIMEOUT_MS,
+    }
+  );
+  if (!createRes.ok) {
+    const text = await createRes.text().catch(() => '');
+    throw new Error(`exec create failed (${createRes.status}): ${text}`);
+  }
+  const { Id } = (await createRes.json()) as { Id?: string };
+  if (!Id) {
+    throw new Error('exec create returned no Id');
+  }
+
+  const startRes = await dockerFetch(ctx, `/exec/${Id}/start`, {
+    method: 'POST',
+    body: { Detach: false, Tty: false },
+    timeout: EXEC_TIMEOUT_MS,
+  });
+  if (!startRes.ok) {
+    const text = await startRes.text().catch(() => '');
+    throw new Error(`exec start failed (${startRes.status}): ${text}`);
+  }
+  return demuxDockerStream(await startRes.arrayBuffer());
+}

--- a/src/app/api/agentteams/debug-log/docker.ts
+++ b/src/app/api/agentteams/debug-log/docker.ts
@@ -6,17 +6,69 @@
 const DOCKER_API_VERSION = 'v1.41';
 const EXEC_TIMEOUT_MS = 30000;
 const REQUEST_TIMEOUT_MS = 60000;
+// Cap a single Docker response so a stuck or oversized stream cannot exhaust
+// memory; the route enforces a separate aggregate budget across all files.
+const MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
 
 export interface DockerContext {
   controllerUrl: string;
   token?: string;
 }
 
+interface DockerFetchResult {
+  ok: boolean;
+  status: number;
+  data: ArrayBuffer;
+}
+
+/** Read a response body up to a byte limit. The read shares the same
+ *  AbortSignal deadline as the fetch, so a stalled body is aborted too. */
+async function readBodyWithLimit(
+  res: Response,
+  limitBytes: number
+): Promise<ArrayBuffer> {
+  if (!res.body) return new ArrayBuffer(0);
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > limitBytes) {
+          throw new Error(`Response body exceeds size limit of ${limitBytes} bytes`);
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (chunks.length === 0) return new ArrayBuffer(0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}
+
+function decodeBody(data: ArrayBuffer): string {
+  return new TextDecoder('utf-8').decode(data);
+}
+
+function truncateText(text: string, max = 500): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
 async function dockerFetch(
   ctx: DockerContext,
   path: string,
   options: { method?: string; body?: unknown; timeout?: number } = {}
-): Promise<Response> {
+): Promise<DockerFetchResult> {
   const { method = 'GET', body, timeout = REQUEST_TIMEOUT_MS } = options;
   const url = new URL(`/docker/${DOCKER_API_VERSION}${path}`, ctx.controllerUrl).toString();
 
@@ -27,12 +79,14 @@ async function dockerFetch(
     if (ctx.token) headers['Authorization'] = `Bearer ${ctx.token}`;
     if (body !== undefined) headers['Content-Type'] = 'application/json';
 
-    return await fetch(url, {
+    const res = await fetch(url, {
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: controller.signal,
     });
+    const data = await readBodyWithLimit(res, MAX_RESPONSE_BYTES);
+    return { ok: res.ok, status: res.status, data };
   } finally {
     clearTimeout(timer);
   }
@@ -62,11 +116,14 @@ export function demuxDockerStream(buffer: ArrayBuffer): string {
 /** List agentteams-* container names (running and stopped). */
 export async function listAgentTeamsContainers(ctx: DockerContext): Promise<string[]> {
   const filters = encodeURIComponent(JSON.stringify({ name: ['agentteams-'] }));
-  const res = await dockerFetch(ctx, `/containers/json?all=1&filters=${filters}`);
-  if (!res.ok) {
-    throw new Error(`Docker API returned ${res.status} while listing containers`);
+  const { ok, status, data } = await dockerFetch(
+    ctx,
+    `/containers/json?all=1&filters=${filters}`
+  );
+  if (!ok) {
+    throw new Error(`Docker API returned ${status} while listing containers`);
   }
-  const containers = (await res.json()) as Array<{ Names?: string[] }>;
+  const containers = JSON.parse(decodeBody(data)) as Array<{ Names?: string[] }>;
   const names = containers
     .flatMap((c) => c.Names ?? [])
     .map((n) => n.replace(/^\//, ''))
@@ -86,25 +143,28 @@ export async function inspectContainer(
   ctx: DockerContext,
   name: string
 ): Promise<ContainerDiagnostic> {
-  const res = await dockerFetch(ctx, `/containers/${encodeURIComponent(name)}/json`);
-  if (!res.ok) {
+  const { ok, status, data } = await dockerFetch(
+    ctx,
+    `/containers/${encodeURIComponent(name)}/json`
+  );
+  if (!ok) {
     return {
       container: name,
       image: '',
       restart_count: null,
-      state: { inspect_error: `Docker API returned ${res.status}` },
+      state: { inspect_error: `Docker API returned ${status}` },
     };
   }
-  const data = (await res.json()) as {
+  const parsed = JSON.parse(decodeBody(data)) as {
     State?: unknown;
     Config?: { Image?: string };
     RestartCount?: number;
   };
   return {
     container: name,
-    image: data.Config?.Image ?? '',
-    restart_count: typeof data.RestartCount === 'number' ? data.RestartCount : null,
-    state: data.State ?? null,
+    image: parsed.Config?.Image ?? '',
+    restart_count: typeof parsed.RestartCount === 'number' ? parsed.RestartCount : null,
+    state: parsed.State ?? null,
   };
 }
 
@@ -114,15 +174,14 @@ export async function getContainerLogs(
   name: string,
   sinceEpochSec: number
 ): Promise<string> {
-  const res = await dockerFetch(
+  const { ok, status, data } = await dockerFetch(
     ctx,
     `/containers/${encodeURIComponent(name)}/logs?stdout=1&stderr=1&timestamps=1&since=${Math.floor(sinceEpochSec)}`
   );
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Docker logs returned ${res.status}: ${text}`);
+  if (!ok) {
+    throw new Error(`Docker logs returned ${status}: ${truncateText(decodeBody(data))}`);
   }
-  return demuxDockerStream(await res.arrayBuffer());
+  return demuxDockerStream(data);
 }
 
 /** docker exec sh -c <cmd> → combined stdout (mirrors the Python docker_exec helper). */
@@ -146,22 +205,24 @@ export async function dockerExec(
     }
   );
   if (!createRes.ok) {
-    const text = await createRes.text().catch(() => '');
-    throw new Error(`exec create failed (${createRes.status}): ${text}`);
+    throw new Error(
+      `exec create failed (${createRes.status}): ${truncateText(decodeBody(createRes.data))}`
+    );
   }
-  const { Id } = (await createRes.json()) as { Id?: string };
-  if (!Id) {
+  const created = JSON.parse(decodeBody(createRes.data)) as { Id?: string };
+  if (!created.Id) {
     throw new Error('exec create returned no Id');
   }
 
-  const startRes = await dockerFetch(ctx, `/exec/${Id}/start`, {
+  const startRes = await dockerFetch(ctx, `/exec/${created.Id}/start`, {
     method: 'POST',
     body: { Detach: false, Tty: false },
     timeout: EXEC_TIMEOUT_MS,
   });
   if (!startRes.ok) {
-    const text = await startRes.text().catch(() => '');
-    throw new Error(`exec start failed (${startRes.status}): ${text}`);
+    throw new Error(
+      `exec start failed (${startRes.status}): ${truncateText(decodeBody(startRes.data))}`
+    );
   }
-  return demuxDockerStream(await startRes.arrayBuffer());
+  return demuxDockerStream(startRes.data);
 }

--- a/src/app/api/agentteams/debug-log/matrix.ts
+++ b/src/app/api/agentteams/debug-log/matrix.ts
@@ -118,12 +118,15 @@ export async function exportMatrixMessages(options: {
   redact: boolean;
   roomFilter?: string;
   messagesOnly?: boolean;
+  stop?: () => boolean;
 }): Promise<MatrixExportResult> {
-  const { homeserver, token, sinceEpochSec, redact, roomFilter, messagesOnly } = options;
+  const { homeserver, token, sinceEpochSec, redact, roomFilter, messagesOnly, stop } = options;
 
   // Defense in depth: the homeserver must pass the same allowlist / SSRF
-  // checks as the regular Matrix proxy routes.
-  validateHomeserverUrl(homeserver);
+  // checks as the regular Matrix proxy routes. requireAllowlist additionally
+  // refuses to forward the user's access token to any public host that is not
+  // on the (built-in or configured) allowlist.
+  validateHomeserverUrl(homeserver, { requireAllowlist: true });
 
   const result: MatrixExportResult = { rooms: 0, messages: 0, files: {} };
 
@@ -139,6 +142,7 @@ export async function exportMatrixMessages(options: {
   const sinceTsMs = Math.floor(sinceEpochSec * 1000);
 
   for (const roomId of rooms) {
+    if (stop?.()) break;
     let roomName = '';
     try {
       const data = await matrixApi(

--- a/src/app/api/agentteams/debug-log/matrix.ts
+++ b/src/app/api/agentteams/debug-log/matrix.ts
@@ -1,0 +1,180 @@
+// Matrix message export — mirrors the Matrix section of export-debug-log.py.
+// Talks to the homeserver directly (server-side) using the browser-supplied
+// access token; the homeserver URL is validated against the allowlist first.
+
+import { validateHomeserverUrl } from '@/lib/homeserver-allowlist';
+import { redactJsonStrings } from './redact';
+
+const REQUEST_TIMEOUT_MS = 30000;
+
+export interface MatrixExportResult {
+  rooms: number;
+  messages: number;
+  files: Record<string, string>;
+  error?: string;
+}
+
+interface MatrixEvent {
+  event_id?: string;
+  type?: string;
+  sender?: string;
+  origin_server_ts?: number;
+  content?: Record<string, unknown>;
+}
+
+async function matrixApi(
+  homeserver: string,
+  token: string,
+  endpoint: string,
+  params?: Record<string, string>
+): Promise<Record<string, unknown>> {
+  let url = `${homeserver.replace(/\/$/, '')}/_matrix/client/v3/${endpoint}`;
+  if (params) {
+    url += `?${new URLSearchParams(params).toString()}`;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`Matrix API ${res.status} on ${endpoint}: ${body}`);
+    }
+    return (await res.json()) as Record<string, unknown>;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchRoomMessages(
+  homeserver: string,
+  token: string,
+  roomId: string,
+  sinceTsMs: number
+): Promise<MatrixEvent[]> {
+  const encoded = encodeURIComponent(roomId);
+  const messages: MatrixEvent[] = [];
+  let fromToken = '';
+
+  for (;;) {
+    const params: Record<string, string> = { dir: 'b', limit: '100' };
+    if (fromToken) params.from = fromToken;
+    const data = await matrixApi(homeserver, token, `rooms/${encoded}/messages`, params);
+    const chunk = (data.chunk as MatrixEvent[] | undefined) ?? [];
+    if (chunk.length === 0) break;
+
+    let hitBoundary = false;
+    for (const event of chunk) {
+      if ((event.origin_server_ts ?? 0) < sinceTsMs) {
+        hitBoundary = true;
+        break;
+      }
+      messages.push(event);
+    }
+    if (hitBoundary) break;
+
+    const nextToken = data.end as string | undefined;
+    if (!nextToken || nextToken === fromToken) break;
+    fromToken = nextToken;
+  }
+
+  messages.reverse();
+  return messages;
+}
+
+function formatEvent(event: MatrixEvent, redact: boolean): Record<string, unknown> {
+  const content = event.content ?? {};
+  const ts = event.origin_server_ts ?? 0;
+  const record: Record<string, unknown> = {
+    event_id: event.event_id,
+    type: event.type,
+    sender: event.sender,
+    timestamp: ts,
+    time: new Date(ts).toISOString(),
+  };
+  if (event.type === 'm.room.message') {
+    record.msgtype = content.msgtype;
+    record.body = content.body;
+    if (content.format) record.format = content.format;
+    if (content.url) record.url = content.url;
+    if (content['m.relates_to']) record.relates_to = content['m.relates_to'];
+  } else {
+    record.content = content;
+  }
+  return redact ? redactJsonStrings(record) : record;
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^\w\-. ]/g, '_').trim().slice(0, 80);
+}
+
+export async function exportMatrixMessages(options: {
+  homeserver: string;
+  token: string;
+  sinceEpochSec: number;
+  redact: boolean;
+  roomFilter?: string;
+  messagesOnly?: boolean;
+}): Promise<MatrixExportResult> {
+  const { homeserver, token, sinceEpochSec, redact, roomFilter, messagesOnly } = options;
+
+  // Defense in depth: the homeserver must pass the same allowlist / SSRF
+  // checks as the regular Matrix proxy routes.
+  validateHomeserverUrl(homeserver);
+
+  const result: MatrixExportResult = { rooms: 0, messages: 0, files: {} };
+
+  let rooms: string[] = [];
+  try {
+    const data = await matrixApi(homeserver, token, 'joined_rooms');
+    rooms = (data.joined_rooms as string[] | undefined) ?? [];
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : 'Failed to list joined rooms';
+    return result;
+  }
+
+  const sinceTsMs = Math.floor(sinceEpochSec * 1000);
+
+  for (const roomId of rooms) {
+    let roomName = '';
+    try {
+      const data = await matrixApi(
+        homeserver,
+        token,
+        `rooms/${encodeURIComponent(roomId)}/state/m.room.name`
+      );
+      roomName = (data.name as string) ?? '';
+    } catch {
+      roomName = '';
+    }
+
+    if (roomFilter && !roomId.includes(roomFilter) && !roomName.includes(roomFilter)) {
+      continue;
+    }
+
+    let events: MatrixEvent[] = [];
+    try {
+      events = await fetchRoomMessages(homeserver, token, roomId, sinceTsMs);
+    } catch {
+      continue; // Skip rooms we cannot read (e.g. permission errors).
+    }
+    if (messagesOnly) {
+      events = events.filter((e) => e.type === 'm.room.message');
+    }
+    if (events.length === 0) continue;
+
+    const namePart = roomName ? sanitizeFilename(roomName) : '';
+    const idPart = sanitizeFilename(roomId);
+    const filename = namePart ? `${namePart}_${idPart}.jsonl` : `${idPart}.jsonl`;
+
+    const lines = events.map((e) => JSON.stringify(formatEvent(e, redact)));
+    result.files[`matrix-messages/${filename}`] = lines.join('\n') + '\n';
+    result.rooms += 1;
+    result.messages += events.length;
+  }
+
+  return result;
+}

--- a/src/app/api/agentteams/debug-log/redact.test.ts
+++ b/src/app/api/agentteams/debug-log/redact.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { redactJsonStrings, redactPii } from './redact';
+
+describe('redactPii', () => {
+  it('returns empty text unchanged', () => {
+    expect(redactPii('')).toBe('');
+  });
+
+  it('masks Chinese ID card numbers', () => {
+    expect(redactPii('id 110101199003077758 here')).toBe('id **** here');
+  });
+
+  it('masks Chinese phone numbers', () => {
+    expect(redactPii('call 13812345678 now')).toBe('call **** now');
+  });
+
+  it('masks email addresses', () => {
+    expect(redactPii('mail ops@example.com please')).toBe('mail **** please');
+  });
+
+  it('masks IPv4 addresses', () => {
+    expect(redactPii('from 192.168.1.10:8080')).toBe('from ****:8080');
+  });
+
+  it('masks OpenAI-style API keys', () => {
+    expect(redactPii('key sk-abcdefghij0123456789abcd end')).toBe('key **** end');
+  });
+
+  it('masks Aliyun access key ids', () => {
+    expect(redactPii('ak LTAI5tabcdef1234567 end')).toBe('ak **** end');
+  });
+
+  it('masks Matrix access tokens', () => {
+    expect(redactPii('token syt_bWFuYWdlcg_abcd1234 end')).toBe('token **** end');
+  });
+
+  it('masks long hex secrets', () => {
+    expect(redactPii('hex 0123456789abcdef0123456789abcdef end')).toBe('hex **** end');
+  });
+
+  it('masks bearer tokens but keeps the scheme', () => {
+    expect(redactPii('Authorization: Bearer abcdef0123456789abcdef01')).toBe(
+      'Authorization: Bearer ****'
+    );
+  });
+
+  it('masks secret key-value pairs but keeps the key', () => {
+    expect(redactPii('password=hunter2')).toBe('password=****');
+    expect(redactPii('api_key: abcdefghij0123456789')).toBe('api_key: ****');
+  });
+
+  it('masks access key secret assignments but keeps the key', () => {
+    expect(redactPii('access_key_secret = abcdefghij0123456789abcd')).toBe(
+      'access_key_secret = ****'
+    );
+  });
+
+  it('leaves ordinary text untouched', () => {
+    const text = 'Worker agentteams-worker-a woke up in room !abc:example';
+    expect(redactPii(text)).toBe(text);
+  });
+});
+
+describe('redactJsonStrings', () => {
+  it('redacts string values recursively', () => {
+    expect(
+      redactJsonStrings({
+        outer: { email: 'ops@example.com' },
+        list: ['call 13812345678'],
+        n: 42,
+        ok: null,
+      })
+    ).toEqual({
+      outer: { email: '****' },
+      list: ['call ****'],
+      n: 42,
+      ok: null,
+    });
+  });
+
+  it('blanks fields whose name marks them as secrets', () => {
+    expect(
+      redactJsonStrings({ password: 'hunter2', nested: { apiKey: 'abc' }, note: 'fine' })
+    ).toEqual({ password: '****', nested: { apiKey: '****' }, note: 'fine' });
+  });
+
+  it('handles arrays at the top level', () => {
+    expect(redactJsonStrings(['ops@example.com'])).toEqual(['****']);
+  });
+});

--- a/src/app/api/agentteams/debug-log/redact.test.ts
+++ b/src/app/api/agentteams/debug-log/redact.test.ts
@@ -55,6 +55,19 @@ describe('redactPii', () => {
     );
   });
 
+  it('masks JWTs', () => {
+    const jwt =
+      'token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c end';
+    expect(redactPii(jwt)).toBe('token **** end');
+  });
+
+  it('masks access_token / refresh_token key-value pairs', () => {
+    expect(redactPii('access_token=syt_abcdefghij1234')).toBe('access_token=****');
+    expect(redactPii('refresh_token: abcdefghijklmnopqrstuvwxyz123456')).toBe(
+      'refresh_token: ****'
+    );
+  });
+
   it('leaves ordinary text untouched', () => {
     const text = 'Worker agentteams-worker-a woke up in room !abc:example';
     expect(redactPii(text)).toBe(text);
@@ -82,6 +95,36 @@ describe('redactJsonStrings', () => {
     expect(
       redactJsonStrings({ password: 'hunter2', nested: { apiKey: 'abc' }, note: 'fine' })
     ).toEqual({ password: '****', nested: { apiKey: '****' }, note: 'fine' });
+  });
+
+  it('blanks access/refresh/id token fields in all common spellings', () => {
+    expect(
+      redactJsonStrings({
+        access_token: 'a',
+        accessToken: 'b',
+        refresh_token: 'c',
+        refreshToken: 'd',
+        id_token: 'e',
+        idToken: 'f',
+        note: 'fine',
+      })
+    ).toEqual({
+      access_token: '****',
+      accessToken: '****',
+      refresh_token: '****',
+      refreshToken: '****',
+      id_token: '****',
+      idToken: '****',
+      note: 'fine',
+    });
+  });
+
+  it('redacts JWT strings nested in objects', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    expect(redactJsonStrings({ profile: { session: jwt } })).toEqual({
+      profile: { session: '****' },
+    });
   });
 
   it('handles arrays at the top level', () => {

--- a/src/app/api/agentteams/debug-log/redact.ts
+++ b/src/app/api/agentteams/debug-log/redact.ts
@@ -1,0 +1,71 @@
+// PII redaction — TypeScript port of AgentTeams scripts/export-debug-log.py.
+// Patterns mask ID cards, phone numbers, emails, bank cards, IPs, cloud/API
+// credentials, bearer tokens and generic secret key-value pairs so that
+// exported debug bundles are safe to share.
+
+interface RedactPattern {
+  name: string;
+  pattern: RegExp;
+  // When true, capture group 1 (the key / scheme prefix) is preserved.
+  keepPrefix: boolean;
+}
+
+const PII_PATTERNS: RedactPattern[] = [
+  { name: 'ID_CARD', keepPrefix: false, pattern: /\b[1-9]\d{5}(?:19|20)\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])\d{3}[\dXx]\b/g },
+  { name: 'PHONE', keepPrefix: false, pattern: /(?<!\d)(?:\+?86[-\s]?)?1[3-9]\d{9}(?!\d)/g },
+  { name: 'EMAIL', keepPrefix: false, pattern: /\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b/g },
+  { name: 'BANK_CARD', keepPrefix: false, pattern: /\b(?:6\d{15,18}|4\d{15}|5[1-5]\d{14}|3[47]\d{13}|62\d{14,17})\b/g },
+  { name: 'IP', keepPrefix: false, pattern: /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g },
+  { name: 'ALIYUN_AK', keepPrefix: false, pattern: /\bLTAI[A-Za-z0-9]{12,30}\b/g },
+  {
+    name: 'ALIYUN_SK',
+    keepPrefix: true,
+    pattern: /((?:access_?key_?secret|secret_?access_?key)\s*[:=]\s*)(\S{20,})/gi,
+  },
+  { name: 'AWS_AK', keepPrefix: false, pattern: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g },
+  { name: 'OPENAI_KEY', keepPrefix: false, pattern: /\bsk-[A-Za-z0-9]{20,}\b/g },
+  { name: 'ANTHROPIC_KEY', keepPrefix: false, pattern: /\bsk-ant-[A-Za-z0-9\-]{20,}\b/g },
+  { name: 'DASHSCOPE_KEY', keepPrefix: false, pattern: /\bsk-sp-[A-Za-z0-9]{20,}\b/g },
+  { name: 'DEEPSEEK_KEY', keepPrefix: false, pattern: /\bsk-[a-f0-9]{32,}\b/g },
+  { name: 'BEARER', keepPrefix: true, pattern: /(Bearer\s+)([A-Za-z0-9\-_.]{20,})/gi },
+  {
+    name: 'SECRET_KV',
+    keepPrefix: true,
+    pattern:
+      /((?:password|passwd|pwd|secret|token|api_?key|access_?key|secret_?key|private_?key|credential|appkey|app_?secret|auth_?token|signing_?key|client_?secret|master_?key)\s*[:=]\s*)(\S+)/gi,
+  },
+  { name: 'MATRIX_TOKEN', keepPrefix: false, pattern: /\bsyt_[A-Za-z0-9_\-]{10,}\b/g },
+  { name: 'HEX_SECRET', keepPrefix: false, pattern: /\b[A-Fa-f0-9]{32,}\b/g },
+  { name: 'PASSPORT', keepPrefix: false, pattern: /\b[EeGg]\d{8}\b/g },
+  { name: 'SSN', keepPrefix: false, pattern: /\b\d{3}-\d{2}-\d{4}\b/g },
+];
+
+const SECRET_FIELD_PATTERN =
+  /^(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key(?:[_-]?secret)?|secret[_-]?access[_-]?key|secret[_-]?key|private[_-]?key|credential|app[_-]?key|app[_-]?secret|auth[_-]?token|signing[_-]?key|client[_-]?secret|master[_-]?key)$/i;
+
+export function redactPii(text: string): string {
+  if (!text) return text;
+  for (const { pattern, keepPrefix } of PII_PATTERNS) {
+    text = keepPrefix
+      ? text.replace(pattern, '$1****')
+      : text.replace(pattern, '****');
+  }
+  return text;
+}
+
+export function redactJsonStrings<T>(value: T): T {
+  if (typeof value === 'string') {
+    return redactPii(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactJsonStrings(item)) as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = SECRET_FIELD_PATTERN.test(key) ? '****' : redactJsonStrings(val);
+    }
+    return out as T;
+  }
+  return value;
+}

--- a/src/app/api/agentteams/debug-log/redact.ts
+++ b/src/app/api/agentteams/debug-log/redact.ts
@@ -32,8 +32,9 @@ const PII_PATTERNS: RedactPattern[] = [
     name: 'SECRET_KV',
     keepPrefix: true,
     pattern:
-      /((?:password|passwd|pwd|secret|token|api_?key|access_?key|secret_?key|private_?key|credential|appkey|app_?secret|auth_?token|signing_?key|client_?secret|master_?key)\s*[:=]\s*)(\S+)/gi,
+      /((?:password|passwd|pwd|secret|token|access_?token|refresh_?token|id_?token|api_?key|access_?key|secret_?key|private_?key|credential|appkey|app_?secret|auth_?token|signing_?key|client_?secret|master_?key)\s*[:=]\s*)(\S+)/gi,
   },
+  { name: 'JWT', keepPrefix: false, pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g },
   { name: 'MATRIX_TOKEN', keepPrefix: false, pattern: /\bsyt_[A-Za-z0-9_\-]{10,}\b/g },
   { name: 'HEX_SECRET', keepPrefix: false, pattern: /\b[A-Fa-f0-9]{32,}\b/g },
   { name: 'PASSPORT', keepPrefix: false, pattern: /\b[EeGg]\d{8}\b/g },
@@ -41,7 +42,7 @@ const PII_PATTERNS: RedactPattern[] = [
 ];
 
 const SECRET_FIELD_PATTERN =
-  /^(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key(?:[_-]?secret)?|secret[_-]?access[_-]?key|secret[_-]?key|private[_-]?key|credential|app[_-]?key|app[_-]?secret|auth[_-]?token|signing[_-]?key|client[_-]?secret|master[_-]?key)$/i;
+  /^(?:password|passwd|pwd|secret|token|access[_-]?token|refresh[_-]?token|id[_-]?token|accessToken|refreshToken|idToken|api[_-]?key|access[_-]?key(?:[_-]?secret)?|secret[_-]?access[_-]?key|secret[_-]?key|private[_-]?key|credential|app[_-]?key|app[_-]?secret|auth[_-]?token|signing[_-]?key|client[_-]?secret|master[_-]?key)$/i;
 
 export function redactPii(text: string): string {
   if (!text) return text;

--- a/src/app/api/agentteams/debug-log/route.test.ts
+++ b/src/app/api/agentteams/debug-log/route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { unzipSync } from 'fflate';
+import { POST } from './route';
+
+vi.mock('../proxy-helper', () => ({
+  getAuthToken: vi.fn().mockResolvedValue('sa-token'),
+  getControllerUrl: vi.fn().mockReturnValue('http://agentteams-controller:8090'),
+}));
+
+vi.mock('./docker', () => ({
+  listAgentTeamsContainers: vi.fn().mockResolvedValue([]),
+  inspectContainer: vi.fn(),
+  getContainerLogs: vi.fn(),
+}));
+
+vi.mock('./sessions', () => ({
+  exportAgentSessions: vi.fn().mockResolvedValue({
+    containers: 0,
+    sessions: 0,
+    events: 0,
+    files: {},
+    errors: [],
+  }),
+}));
+
+vi.mock('./matrix', () => ({
+  exportMatrixMessages: vi.fn(),
+}));
+
+function buildRequest(rawBody: string): NextRequest {
+  return new NextRequest('http://localhost/api/agentteams/debug-log', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: rawBody,
+  });
+}
+
+describe('POST /api/agentteams/debug-log', () => {
+  it('returns 400 for a null JSON body', async () => {
+    const res = await POST(buildRequest('null'));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  it('returns 400 for a JSON array body', async () => {
+    const res = await POST(buildRequest('[]'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when range is not a string', async () => {
+    const res = await POST(buildRequest('{"range": 5}'));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/must be a string/);
+  });
+
+  it('returns 400 when redact is not a boolean', async () => {
+    const res = await POST(buildRequest('{"redact": "yes"}'));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/must be a boolean/);
+  });
+
+  it('returns 400 for an oversized range', async () => {
+    const res = await POST(buildRequest('{"range": "10000d"}'));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/too large/i);
+  });
+
+  it('returns a zip bundle with summary.txt for an empty collection', async () => {
+    const res = await POST(buildRequest('{}'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/zip');
+    const buf = await res.arrayBuffer();
+    const files = unzipSync(new Uint8Array(buf));
+    expect(files['summary.txt']).toBeDefined();
+    const summary = new TextDecoder().decode(files['summary.txt']);
+    expect(summary).toContain('AgentTeams Debug Log');
+    expect(summary).toContain('Matrix export skipped');
+  });
+});

--- a/src/app/api/agentteams/debug-log/route.ts
+++ b/src/app/api/agentteams/debug-log/route.ts
@@ -27,6 +27,14 @@ import { exportMatrixMessages } from './matrix';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
+// Hard limits so an unbounded request cannot exhaust memory or run past the
+// route timeout. Collection stops early (with a summary note) once a limit is hit.
+const MAX_RANGE_SECONDS = 30 * 24 * 3600; // 30 days
+const MAX_CONTAINERS = 100;
+const MAX_TOTAL_BYTES = 256 * 1024 * 1024; // 256 MiB across all collected files
+const COLLECT_DEADLINE_MS = 240_000; // stop collecting well before maxDuration
+const NOTE_MAX_LENGTH = 500;
+
 function parseRange(rangeStr: string): number {
   const m = /^(\d+)\s*(m|min|h|hr|hour|d|day)s?$/i.exec(rangeStr.trim());
   if (!m) {
@@ -35,7 +43,14 @@ function parseRange(rangeStr: string): number {
   const value = parseInt(m[1], 10);
   const unit = m[2][0].toLowerCase();
   const multiplier = unit === 'm' ? 60 : unit === 'h' ? 3600 : 86400;
-  return value * multiplier;
+  const seconds = value * multiplier;
+  if (value <= 0) {
+    throw new Error('Range must be a positive number');
+  }
+  if (seconds > MAX_RANGE_SECONDS) {
+    throw new Error('Range too large: maximum is 30d');
+  }
+  return seconds;
 }
 
 interface DebugLogRequest {
@@ -47,13 +62,86 @@ interface DebugLogRequest {
   homeserver?: string;
 }
 
+interface CollectBudget {
+  startedAt: number;
+  totalBytes: number;
+  exhausted: boolean;
+  reason: string;
+}
+
+function createBudget(): CollectBudget {
+  return { startedAt: Date.now(), totalBytes: 0, exhausted: false, reason: '' };
+}
+
+function budgetExhausted(budget: CollectBudget): boolean {
+  if (budget.exhausted) return true;
+  if (Date.now() - budget.startedAt > COLLECT_DEADLINE_MS) {
+    budget.exhausted = true;
+    budget.reason = 'collection time budget exceeded';
+    return true;
+  }
+  if (budget.totalBytes >= MAX_TOTAL_BYTES) {
+    budget.exhausted = true;
+    budget.reason = 'total collected bytes exceeded';
+    return true;
+  }
+  return false;
+}
+
+/** Add a file to the bundle unless a limit is hit; returns false when stopped. */
+function addFile(
+  files: Record<string, Uint8Array>,
+  budget: CollectBudget,
+  name: string,
+  data: Uint8Array
+): boolean {
+  if (budgetExhausted(budget)) return false;
+  budget.totalBytes += data.byteLength;
+  if (budget.totalBytes > MAX_TOTAL_BYTES) {
+    budget.exhausted = true;
+    budget.reason = 'total collected bytes exceeded';
+    return false;
+  }
+  files[name] = data;
+  return true;
+}
+
+/** Normalize an upstream error into a redacted, length-capped summary note. */
+function noteFor(prefix: string, err: unknown): string {
+  const message = err instanceof Error ? err.message : 'unknown error';
+  return `${prefix}: ${redactPii(message).slice(0, NOTE_MAX_LENGTH)}`;
+}
+
+function parseBody(value: unknown): { body: DebugLogRequest; error?: string } {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return { body: {}, error: 'Invalid JSON body' };
+  }
+  const body = value as Record<string, unknown>;
+  for (const key of ['range', 'container', 'room', 'homeserver'] as const) {
+    if (body[key] !== undefined && typeof body[key] !== 'string') {
+      return { body: {}, error: `Field '${key}' must be a string` };
+    }
+  }
+  for (const key of ['redact', 'messagesOnly'] as const) {
+    if (body[key] !== undefined && typeof body[key] !== 'boolean') {
+      return { body: {}, error: `Field '${key}' must be a boolean` };
+    }
+  }
+  return { body: body as unknown as DebugLogRequest };
+}
+
 export async function POST(request: NextRequest) {
-  let body: DebugLogRequest = {};
+  let rawBody: unknown;
   try {
-    body = (await request.json()) as DebugLogRequest;
+    rawBody = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
+  const parsed = parseBody(rawBody);
+  if (parsed.error) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const body = parsed.body;
 
   const rangeStr = body.range || '1h';
   let rangeSeconds: number;
@@ -79,6 +167,7 @@ export async function POST(request: NextRequest) {
 
   const files: Record<string, Uint8Array> = {};
   const notes: string[] = [];
+  const budget = createBudget();
 
   const controllerUrl = getControllerUrl(request);
   const token = await getAuthToken();
@@ -91,50 +180,55 @@ export async function POST(request: NextRequest) {
     if (containerFilter) {
       containers = containers.filter((n) => n.includes(containerFilter));
     }
+    containers = containers.slice(0, MAX_CONTAINERS);
+    if (containers.length === MAX_CONTAINERS) {
+      notes.push(`Container listing truncated to ${MAX_CONTAINERS} containers`);
+    }
   } catch (err) {
-    notes.push(
-      `Container listing failed: ${err instanceof Error ? err.message : 'unknown error'}`
-    );
+    notes.push(noteFor('Container listing failed', err));
   }
 
   // --- Container diagnostics (state + logs) --------------------------------
   let containersWithLogs = 0;
   for (const name of containers) {
+    if (budgetExhausted(budget)) break;
     try {
       const diagnostic = await inspectContainer(ctx, name);
-      files[`container-logs/${name}.state.json`] = strToU8(
+      const data = strToU8(
         JSON.stringify(redact ? redactJsonStrings(diagnostic) : diagnostic, null, 2) + '\n'
       );
+      addFile(files, budget, `container-logs/${name}.state.json`, data);
     } catch (err) {
-      notes.push(
-        `${name}: inspect failed: ${err instanceof Error ? err.message : 'unknown error'}`
-      );
+      notes.push(noteFor(`${name}: inspect failed`, err));
     }
+    if (budgetExhausted(budget)) break;
     try {
       const logs = await getContainerLogs(ctx, name, sinceEpochSec);
-      files[`container-logs/${name}.log`] = strToU8(redact ? redactPii(logs) : logs);
-      containersWithLogs += 1;
-    } catch (err) {
-      notes.push(
-        `${name}: logs failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      const stored = addFile(
+        files,
+        budget,
+        `container-logs/${name}.log`,
+        strToU8(redact ? redactPii(logs) : logs)
       );
+      if (stored) containersWithLogs += 1;
+    } catch (err) {
+      notes.push(noteFor(`${name}: logs failed`, err));
     }
   }
 
   // --- Agent sessions -------------------------------------------------------
   let sessionStats = { sessions: 0, events: 0 };
-  if (containers.length > 0) {
+  if (containers.length > 0 && !budgetExhausted(budget)) {
     try {
-      const sessions = await exportAgentSessions(ctx, containers, sinceEpochSec, redact);
+      const stop = () => budgetExhausted(budget);
+      const sessions = await exportAgentSessions(ctx, containers, sinceEpochSec, redact, stop);
       for (const [path, content] of Object.entries(sessions.files)) {
-        files[path] = strToU8(content);
+        if (!addFile(files, budget, path, strToU8(content))) break;
       }
       sessionStats = { sessions: sessions.sessions, events: sessions.events };
       notes.push(...sessions.errors);
     } catch (err) {
-      notes.push(
-        `Session export failed: ${err instanceof Error ? err.message : 'unknown error'}`
-      );
+      notes.push(noteFor('Session export failed', err));
     }
   }
 
@@ -151,6 +245,7 @@ export async function POST(request: NextRequest) {
 
   if (matrixToken && homeserver) {
     try {
+      const stop = () => budgetExhausted(budget);
       const matrix = await exportMatrixMessages({
         homeserver,
         token: matrixToken,
@@ -158,19 +253,22 @@ export async function POST(request: NextRequest) {
         redact,
         roomFilter: roomFilter || undefined,
         messagesOnly: body.messagesOnly,
+        stop,
       });
       for (const [path, content] of Object.entries(matrix.files)) {
-        files[path] = strToU8(content);
+        if (!addFile(files, budget, path, strToU8(content))) break;
       }
       matrixStats = { rooms: matrix.rooms, messages: matrix.messages };
-      if (matrix.error) notes.push(`Matrix export: ${matrix.error}`);
+      if (matrix.error) notes.push(redactPii(matrix.error).slice(0, NOTE_MAX_LENGTH));
     } catch (err) {
-      notes.push(
-        `Matrix export failed: ${err instanceof Error ? err.message : 'unknown error'}`
-      );
+      notes.push(noteFor('Matrix export failed', err));
     }
   } else {
     notes.push('Matrix export skipped: no Matrix credentials (log in to Matrix first)');
+  }
+
+  if (budget.exhausted) {
+    notes.push(`Collection stopped early: ${budget.reason}`);
   }
 
   // --- Summary --------------------------------------------------------------

--- a/src/app/api/agentteams/debug-log/route.ts
+++ b/src/app/api/agentteams/debug-log/route.ts
@@ -1,0 +1,203 @@
+// POST /api/agentteams/debug-log — one-click debug log collection.
+//
+// Port of the AgentTeams scripts/export-debug-log.py standalone tool. Instead
+// of shelling out to `docker`/`kubectl`, it goes through the Controller's
+// Docker API reverse proxy (container list/inspect/logs/exec) and the Matrix
+// Client-Server API, then bundles everything into a ZIP download:
+//
+//   agentteams-debug-log-<ts>.zip
+//   ├── summary.txt
+//   ├── matrix-messages/<RoomName>_<roomid>.jsonl   (requires Matrix login)
+//   ├── agent-sessions/<container>/<session>.jsonl
+//   └── container-logs/<container>.log + .state.json
+
+import { NextRequest, NextResponse } from 'next/server';
+import { zipSync, strToU8 } from 'fflate';
+import { getAuthToken, getControllerUrl } from '../proxy-helper';
+import { redactPii, redactJsonStrings } from './redact';
+import {
+  DockerContext,
+  getContainerLogs,
+  inspectContainer,
+  listAgentTeamsContainers,
+} from './docker';
+import { exportAgentSessions } from './sessions';
+import { exportMatrixMessages } from './matrix';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+function parseRange(rangeStr: string): number {
+  const m = /^(\d+)\s*(m|min|h|hr|hour|d|day)s?$/i.exec(rangeStr.trim());
+  if (!m) {
+    throw new Error(`Invalid range format: '${rangeStr}'. Use e.g. 10m, 1h, 1d`);
+  }
+  const value = parseInt(m[1], 10);
+  const unit = m[2][0].toLowerCase();
+  const multiplier = unit === 'm' ? 60 : unit === 'h' ? 3600 : 86400;
+  return value * multiplier;
+}
+
+interface DebugLogRequest {
+  range?: string;
+  redact?: boolean;
+  container?: string;
+  room?: string;
+  messagesOnly?: boolean;
+  homeserver?: string;
+}
+
+export async function POST(request: NextRequest) {
+  let body: DebugLogRequest = {};
+  try {
+    body = (await request.json()) as DebugLogRequest;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const rangeStr = body.range || '1h';
+  let rangeSeconds: number;
+  try {
+    rangeSeconds = parseRange(rangeStr);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Invalid range' },
+      { status: 400 }
+    );
+  }
+
+  const redact = body.redact !== false;
+  const containerFilter = body.container?.trim() || '';
+  const roomFilter = body.room?.trim() || '';
+  const sinceEpochSec = Date.now() / 1000 - rangeSeconds;
+  const sinceHuman = new Date(sinceEpochSec * 1000).toISOString();
+  const nowStr = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, '')
+    .slice(0, 14)
+    .replace(/(\d{8})(\d{6})/, '$1-$2');
+
+  const files: Record<string, Uint8Array> = {};
+  const notes: string[] = [];
+
+  const controllerUrl = getControllerUrl(request);
+  const token = await getAuthToken();
+  const ctx: DockerContext = { controllerUrl, token };
+
+  // --- Container list (shared by diagnostics + session export) -------------
+  let containers: string[] = [];
+  try {
+    containers = await listAgentTeamsContainers(ctx);
+    if (containerFilter) {
+      containers = containers.filter((n) => n.includes(containerFilter));
+    }
+  } catch (err) {
+    notes.push(
+      `Container listing failed: ${err instanceof Error ? err.message : 'unknown error'}`
+    );
+  }
+
+  // --- Container diagnostics (state + logs) --------------------------------
+  let containersWithLogs = 0;
+  for (const name of containers) {
+    try {
+      const diagnostic = await inspectContainer(ctx, name);
+      files[`container-logs/${name}.state.json`] = strToU8(
+        JSON.stringify(redact ? redactJsonStrings(diagnostic) : diagnostic, null, 2) + '\n'
+      );
+    } catch (err) {
+      notes.push(
+        `${name}: inspect failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      );
+    }
+    try {
+      const logs = await getContainerLogs(ctx, name, sinceEpochSec);
+      files[`container-logs/${name}.log`] = strToU8(redact ? redactPii(logs) : logs);
+      containersWithLogs += 1;
+    } catch (err) {
+      notes.push(
+        `${name}: logs failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      );
+    }
+  }
+
+  // --- Agent sessions -------------------------------------------------------
+  let sessionStats = { sessions: 0, events: 0 };
+  if (containers.length > 0) {
+    try {
+      const sessions = await exportAgentSessions(ctx, containers, sinceEpochSec, redact);
+      for (const [path, content] of Object.entries(sessions.files)) {
+        files[path] = strToU8(content);
+      }
+      sessionStats = { sessions: sessions.sessions, events: sessions.events };
+      notes.push(...sessions.errors);
+    } catch (err) {
+      notes.push(
+        `Session export failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      );
+    }
+  }
+
+  // --- Matrix messages ------------------------------------------------------
+  // Uses the browser's Matrix credentials (Authorization header + homeserver),
+  // same convention as the other /api/matrix/* routes. Skipped when the user
+  // is not logged in to Matrix.
+  let matrixStats = { rooms: 0, messages: 0 };
+  const matrixToken = request.headers
+    .get('Authorization')
+    ?.replace(/^Bearer\s+/i, '');
+  const homeserver =
+    body.homeserver?.trim() || request.nextUrl.searchParams.get('homeserver') || '';
+
+  if (matrixToken && homeserver) {
+    try {
+      const matrix = await exportMatrixMessages({
+        homeserver,
+        token: matrixToken,
+        sinceEpochSec,
+        redact,
+        roomFilter: roomFilter || undefined,
+        messagesOnly: body.messagesOnly,
+      });
+      for (const [path, content] of Object.entries(matrix.files)) {
+        files[path] = strToU8(content);
+      }
+      matrixStats = { rooms: matrix.rooms, messages: matrix.messages };
+      if (matrix.error) notes.push(`Matrix export: ${matrix.error}`);
+    } catch (err) {
+      notes.push(
+        `Matrix export failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      );
+    }
+  } else {
+    notes.push('Matrix export skipped: no Matrix credentials (log in to Matrix first)');
+  }
+
+  // --- Summary --------------------------------------------------------------
+  const summary = [
+    'AgentTeams Debug Log',
+    `Exported at: ${nowStr}`,
+    `Range: last ${rangeStr} (since ${sinceHuman})`,
+    `PII redaction: ${redact ? 'on' : 'off'}`,
+    '',
+    `Matrix messages: ${matrixStats.messages} messages from ${matrixStats.rooms} rooms`,
+    `Agent sessions: ${sessionStats.events} events from ${sessionStats.sessions} sessions`,
+    `Container diagnostics: ${containersWithLogs} containers`,
+    ...(notes.length > 0 ? ['', 'Notes:', ...notes.map((n) => `  - ${n}`)] : []),
+    '',
+  ].join('\n');
+  files['summary.txt'] = strToU8(summary);
+
+  // --- Bundle ---------------------------------------------------------------
+  const zipped = zipSync(files, { level: 6 });
+  const filename = `agentteams-debug-log-${nowStr}.zip`;
+
+  return new NextResponse(zipped as unknown as BodyInit, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/src/app/api/agentteams/debug-log/sessions.ts
+++ b/src/app/api/agentteams/debug-log/sessions.ts
@@ -4,11 +4,25 @@
 // proxy). To keep the number of exec round-trips low, each export stage is
 // batched into a single sh script whose output is split locally.
 
+import { randomBytes } from 'node:crypto';
 import { redactJsonStrings, redactPii } from './redact';
 import { dockerExec, DockerContext } from './docker';
 
-const FILE_MARKER = '===DEBUGLOG_FILE===';
-const INDEX_MARKER = '===DEBUGLOG_INDEX===';
+// Per-export random markers. A marker is generated once per collection so a
+// session file containing a literal marker line cannot split or truncate the
+// batched output (a fixed marker would be trivially forgeable).
+interface BatchMarkers {
+  file: string;
+  index: string;
+}
+
+function makeBatchMarkers(): BatchMarkers {
+  const token = randomBytes(16).toString('hex');
+  return {
+    file: `===DEBUGLOG_FILE_${token}===`,
+    index: `===DEBUGLOG_INDEX_${token}===`,
+  };
+}
 
 export interface SessionExportResult {
   containers: number;
@@ -29,13 +43,16 @@ function sanitizeFilename(name: string): string {
 }
 
 /** Split a batched `echo MARKER path; cat path` output into per-file chunks. */
-function splitBatchedFiles(raw: string): Array<{ path: string; content: string }> {
+function splitBatchedFiles(
+  raw: string,
+  fileMarker: string
+): Array<{ path: string; content: string }> {
   const files: Array<{ path: string; content: string }> = [];
   let current: { path: string; lines: string[] } | null = null;
   for (const line of raw.split('\n')) {
-    if (line.startsWith(FILE_MARKER)) {
+    if (line.startsWith(fileMarker)) {
       if (current) files.push({ path: current.path, content: current.lines.join('\n') });
-      current = { path: line.slice(FILE_MARKER.length).trim(), lines: [] };
+      current = { path: line.slice(fileMarker.length).trim(), lines: [] };
     } else if (current) {
       current.lines.push(line);
     }
@@ -112,21 +129,22 @@ async function exportOpenClawSessions(
   sinceEpochSec: number,
   redact: boolean,
   out: SessionExportResult,
-  prefix: string
+  prefix: string,
+  markers: BatchMarkers
 ): Promise<void> {
   const script = [
     `for f in '${sessionsDir}'/*.jsonl; do`,
     `  [ -f "$f" ] || continue`,
-    `  echo "${FILE_MARKER} $f"`,
+    `  echo "${markers.file} $f"`,
     `  cat "$f"`,
     'done',
-    `echo "${INDEX_MARKER}"`,
+    `echo "${markers.index}"`,
     `cat '${sessionsDir}/sessions.json' 2>/dev/null || true`,
   ].join('\n');
 
   const raw = await dockerExec(ctx, container, script);
-  const [filesPart, indexPart] = raw.split(INDEX_MARKER);
-  const files = splitBatchedFiles(filesPart);
+  const [filesPart, indexPart] = raw.split(markers.index);
+  const files = splitBatchedFiles(filesPart, markers.file);
 
   for (const file of files) {
     const filename = file.path.split('/').pop() ?? '';
@@ -178,17 +196,18 @@ async function exportCopawSessions(
   sinceEpochSec: number,
   redact: boolean,
   out: SessionExportResult,
-  prefix: string
+  prefix: string,
+  markers: BatchMarkers
 ): Promise<void> {
   const script = [
     `find '${sessionsDir}' -name '*.json' -type f 2>/dev/null | while read f; do`,
-    `  echo "${FILE_MARKER} $f"`,
+    `  echo "${markers.file} $f"`,
     `  cat "$f"`,
     'done',
   ].join('\n');
 
   const raw = await dockerExec(ctx, container, script);
-  const files = splitBatchedFiles(raw);
+  const files = splitBatchedFiles(raw, markers.file);
 
   for (const file of files) {
     let data: {
@@ -264,18 +283,19 @@ async function exportHermesSessions(
   sinceEpochSec: number,
   redact: boolean,
   out: SessionExportResult,
-  prefix: string
+  prefix: string,
+  markers: BatchMarkers
 ): Promise<void> {
   const script = [
     `for f in '${sessionsDir}'/*.jsonl; do`,
     `  [ -f "$f" ] || continue`,
-    `  echo "${FILE_MARKER} $f"`,
+    `  echo "${markers.file} $f"`,
     `  cat "$f"`,
     'done',
   ].join('\n');
 
   const raw = await dockerExec(ctx, container, script);
-  const files = splitBatchedFiles(raw);
+  const files = splitBatchedFiles(raw, markers.file);
 
   for (const file of files) {
     const filename = file.path.split('/').pop() ?? '';
@@ -314,17 +334,17 @@ async function exportHermesSessions(
     `if command -v python3 >/dev/null 2>&1 && [ -f '${hermesHome}/state.db' ]; then`,
     `  python3 -c "import json,sqlite3;conn=sqlite3.connect('${hermesHome}/state.db');conn.row_factory=sqlite3.Row;rows=conn.execute('SELECT * FROM sessions ORDER BY started_at DESC LIMIT 200').fetchall();print(json.dumps([dict(r) for r in rows],ensure_ascii=False))" 2>/dev/null || true`,
     'fi',
-    `echo "${INDEX_MARKER}"`,
+    `echo "${markers.index}"`,
     `for n in agent.log errors.log gateway.log; do`,
     `  if [ -f '${hermesHome}/logs/'"$n" ]; then`,
-    `    echo "${FILE_MARKER} $n"`,
+    `    echo "${markers.file} $n"`,
     `    cat '${hermesHome}/logs/'"$n"`,
     '  fi',
     'done',
   ].join('\n');
 
   const aux = await dockerExec(ctx, container, auxScript);
-  const [dbPart, logsPart] = aux.split(INDEX_MARKER);
+  const [dbPart, logsPart] = aux.split(markers.index);
 
   const dbRaw = (dbPart ?? '').trim();
   if (dbRaw) {
@@ -337,7 +357,7 @@ async function exportHermesSessions(
     }
   }
 
-  for (const log of splitBatchedFiles(logsPart ?? '')) {
+  for (const log of splitBatchedFiles(logsPart ?? '', markers.file)) {
     if (!log.content.trim()) continue;
     out.files[`${prefix}/${sanitizeFilename(log.path)}`] = redact
       ? redactPii(log.content)
@@ -353,7 +373,8 @@ export async function exportAgentSessions(
   ctx: DockerContext,
   containers: string[],
   sinceEpochSec: number,
-  redact: boolean
+  redact: boolean,
+  stop?: () => boolean
 ): Promise<SessionExportResult> {
   const out: SessionExportResult = {
     containers: 0,
@@ -363,7 +384,10 @@ export async function exportAgentSessions(
     errors: [],
   };
 
+  const markers = makeBatchMarkers();
+
   for (const container of containers) {
+    if (stop?.()) break;
     const prefix = `agent-sessions/${sanitizeFilename(container)}`;
     try {
       const { runtime, sessionsDir } = await detectRuntime(ctx, container);
@@ -371,16 +395,18 @@ export async function exportAgentSessions(
 
       const before = out.sessions;
       if (runtime === 'openclaw') {
-        await exportOpenClawSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix);
+        await exportOpenClawSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix, markers);
       } else if (runtime === 'hermes') {
-        await exportHermesSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix);
+        await exportHermesSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix, markers);
       } else {
-        await exportCopawSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix);
+        await exportCopawSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix, markers);
       }
       if (out.sessions > before) out.containers += 1;
     } catch (err) {
+      // Redact upstream error bodies (which may echo tokens) before they land
+      // in summary.txt, regardless of the user's redact toggle.
       out.errors.push(
-        `${container}: ${err instanceof Error ? err.message : 'session export failed'}`
+        redactPii(`${container}: ${err instanceof Error ? err.message : 'session export failed'}`)
       );
     }
   }

--- a/src/app/api/agentteams/debug-log/sessions.ts
+++ b/src/app/api/agentteams/debug-log/sessions.ts
@@ -1,0 +1,389 @@
+// Agent session export — TypeScript port of the OpenClaw / Hermes / CoPaw
+// session collectors from export-debug-log.py. Session files live inside the
+// agent containers, so they are read through docker exec (via the Controller
+// proxy). To keep the number of exec round-trips low, each export stage is
+// batched into a single sh script whose output is split locally.
+
+import { redactJsonStrings, redactPii } from './redact';
+import { dockerExec, DockerContext } from './docker';
+
+const FILE_MARKER = '===DEBUGLOG_FILE===';
+const INDEX_MARKER = '===DEBUGLOG_INDEX===';
+
+export interface SessionExportResult {
+  containers: number;
+  sessions: number;
+  events: number;
+  files: Record<string, string>;
+  errors: string[];
+}
+
+function parseTs(ts: unknown): number {
+  if (typeof ts !== 'string' || !ts) return 0;
+  const ms = Date.parse(ts);
+  return Number.isNaN(ms) ? 0 : ms / 1000;
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^\w\-. ]/g, '_').trim().slice(0, 80);
+}
+
+/** Split a batched `echo MARKER path; cat path` output into per-file chunks. */
+function splitBatchedFiles(raw: string): Array<{ path: string; content: string }> {
+  const files: Array<{ path: string; content: string }> = [];
+  let current: { path: string; lines: string[] } | null = null;
+  for (const line of raw.split('\n')) {
+    if (line.startsWith(FILE_MARKER)) {
+      if (current) files.push({ path: current.path, content: current.lines.join('\n') });
+      current = { path: line.slice(FILE_MARKER.length).trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) files.push({ path: current.path, content: current.lines.join('\n') });
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime detection
+// ---------------------------------------------------------------------------
+
+type Runtime = 'openclaw' | 'hermes' | 'copaw' | '';
+
+async function detectRuntime(
+  ctx: DockerContext,
+  container: string
+): Promise<{ runtime: Runtime; sessionsDir: string }> {
+  // One exec: print the worker name, then probe every candidate session dir
+  // (manager layouts first, then worker layouts derived from $AGENTTEAMS_WORKER_NAME).
+  const probeScript = [
+    'wn="$AGENTTEAMS_WORKER_NAME"',
+    'for d in \\',
+    '  /root/manager-workspace/.openclaw/agents/main/sessions \\',
+    '  /root/manager-workspace/.hermes/sessions \\',
+    '  /root/manager-workspace/.copaw/workspaces/default/sessions; do',
+    '  [ -d "$d" ] && echo "FOUND $d"',
+    'done',
+    'if [ -n "$wn" ]; then',
+    '  for d in \\',
+    '    "/root/agentteams-fs/agents/$wn/.openclaw/agents/main/sessions" \\',
+    '    "/root/agentteams-fs/agents/$wn/.hermes/sessions" \\',
+    '    "/root/.agentteams-worker/$wn/.copaw/workspaces/default/sessions" \\',
+    '    /root/agentteams-fs/.copaw/workspaces/default/sessions; do',
+    '    [ -d "$d" ] && echo "FOUND $d"',
+    '  done',
+    'fi',
+  ].join('\n');
+
+  const probe = await dockerExec(ctx, container, probeScript);
+  const found = probe
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('FOUND '))
+    .map((l) => l.slice('FOUND '.length));
+
+  for (const dir of found) {
+    if (dir.includes('/.openclaw/')) return { runtime: 'openclaw', sessionsDir: dir };
+    if (dir.includes('/.hermes/')) return { runtime: 'hermes', sessionsDir: dir };
+    if (dir.includes('/.copaw/')) return { runtime: 'copaw', sessionsDir: dir };
+  }
+
+  // Last resort: scan the filesystem for a known session-dir layout.
+  const scan = await dockerExec(
+    ctx,
+    container,
+    "find / -maxdepth 7 \\( -path '*/.openclaw/agents/main/sessions' -o -path '*/.hermes/sessions' -o -path '*/.copaw/workspaces/default/sessions' \\) -type d 2>/dev/null | head -1"
+  );
+  const dir = scan.trim();
+  if (!dir) return { runtime: '', sessionsDir: '' };
+  if (dir.includes('/.openclaw/')) return { runtime: 'openclaw', sessionsDir: dir };
+  if (dir.includes('/.hermes/')) return { runtime: 'hermes', sessionsDir: dir };
+  return { runtime: 'copaw', sessionsDir: dir };
+}
+
+// ---------------------------------------------------------------------------
+// OpenClaw sessions
+// ---------------------------------------------------------------------------
+
+async function exportOpenClawSessions(
+  ctx: DockerContext,
+  container: string,
+  sessionsDir: string,
+  sinceEpochSec: number,
+  redact: boolean,
+  out: SessionExportResult,
+  prefix: string
+): Promise<void> {
+  const script = [
+    `for f in '${sessionsDir}'/*.jsonl; do`,
+    `  [ -f "$f" ] || continue`,
+    `  echo "${FILE_MARKER} $f"`,
+    `  cat "$f"`,
+    'done',
+    `echo "${INDEX_MARKER}"`,
+    `cat '${sessionsDir}/sessions.json' 2>/dev/null || true`,
+  ].join('\n');
+
+  const raw = await dockerExec(ctx, container, script);
+  const [filesPart, indexPart] = raw.split(INDEX_MARKER);
+  const files = splitBatchedFiles(filesPart);
+
+  for (const file of files) {
+    const filename = file.path.split('/').pop() ?? '';
+    if (!filename.endsWith('.jsonl')) continue;
+
+    const events: string[] = [];
+    for (const line of file.content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let event: Record<string, unknown>;
+      try {
+        event = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const eventTs = parseTs(event.timestamp);
+      if (event.type !== 'session' && eventTs < sinceEpochSec && eventTs > 0) continue;
+      events.push(JSON.stringify(redact ? redactJsonStrings(event) : event));
+    }
+
+    // header only (or empty) → nothing useful in range
+    if (events.length <= 1) continue;
+
+    out.files[`${prefix}/${sanitizeFilename(filename)}`] = events.join('\n') + '\n';
+    out.sessions += 1;
+    out.events += events.length - 1;
+  }
+
+  const indexRaw = (indexPart ?? '').trim();
+  if (indexRaw) {
+    try {
+      const index = JSON.parse(indexRaw);
+      out.files[`${prefix}/sessions.json`] =
+        JSON.stringify(redact ? redactJsonStrings(index) : index, null, 2) + '\n';
+    } catch {
+      // Ignore a malformed sessions.json index.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CoPaw sessions
+// ---------------------------------------------------------------------------
+
+async function exportCopawSessions(
+  ctx: DockerContext,
+  container: string,
+  sessionsDir: string,
+  sinceEpochSec: number,
+  redact: boolean,
+  out: SessionExportResult,
+  prefix: string
+): Promise<void> {
+  const script = [
+    `find '${sessionsDir}' -name '*.json' -type f 2>/dev/null | while read f; do`,
+    `  echo "${FILE_MARKER} $f"`,
+    `  cat "$f"`,
+    'done',
+  ].join('\n');
+
+  const raw = await dockerExec(ctx, container, script);
+  const files = splitBatchedFiles(raw);
+
+  for (const file of files) {
+    let data: {
+      agent?: {
+        name?: string;
+        memory?: { content?: unknown; _compressed_summary?: string };
+      };
+    };
+    try {
+      data = JSON.parse(file.content);
+    } catch {
+      continue;
+    }
+    const agent = data.agent ?? {};
+    const memory = agent.memory ?? {};
+    const content = memory.content;
+    if (!Array.isArray(content) || content.length === 0) continue;
+
+    const basename = (file.path.split('/').pop() ?? '').replace(/\.json$/, '');
+    let header: Record<string, unknown> = {
+      type: 'session',
+      runtime: 'copaw',
+      agent_name: agent.name ?? '',
+      session_key: basename,
+      compressed_summary: memory._compressed_summary ?? '',
+    };
+
+    const messagesInRange: Array<Record<string, unknown>> = [];
+    for (let turnIdx = 0; turnIdx < content.length; turnIdx++) {
+      const turn = content[turnIdx];
+      if (!Array.isArray(turn)) continue;
+      for (const msg of turn) {
+        if (msg === null || typeof msg !== 'object') continue;
+        const m = msg as Record<string, unknown>;
+        const msgTs = parseTs(m.timestamp);
+        if (msgTs >= sinceEpochSec || msgTs === 0) {
+          const event: Record<string, unknown> = {
+            type: 'message',
+            turn: turnIdx,
+            id: m.id ?? '',
+            role: m.role ?? '',
+            name: m.name ?? '',
+            timestamp: m.timestamp ?? '',
+            content: m.content ?? [],
+          };
+          if (m.metadata) event.metadata = m.metadata;
+          messagesInRange.push(event);
+        }
+      }
+    }
+    if (messagesInRange.length === 0) continue;
+
+    if (redact) header = redactJsonStrings(header);
+    const lines = [JSON.stringify(header)];
+    for (const event of messagesInRange) {
+      lines.push(JSON.stringify(redact ? redactJsonStrings(event) : event));
+    }
+
+    out.files[`${prefix}/${sanitizeFilename(basename)}.jsonl`] = lines.join('\n') + '\n';
+    out.sessions += 1;
+    out.events += messagesInRange.length;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hermes sessions
+// ---------------------------------------------------------------------------
+
+async function exportHermesSessions(
+  ctx: DockerContext,
+  container: string,
+  sessionsDir: string,
+  sinceEpochSec: number,
+  redact: boolean,
+  out: SessionExportResult,
+  prefix: string
+): Promise<void> {
+  const script = [
+    `for f in '${sessionsDir}'/*.jsonl; do`,
+    `  [ -f "$f" ] || continue`,
+    `  echo "${FILE_MARKER} $f"`,
+    `  cat "$f"`,
+    'done',
+  ].join('\n');
+
+  const raw = await dockerExec(ctx, container, script);
+  const files = splitBatchedFiles(raw);
+
+  for (const file of files) {
+    const filename = file.path.split('/').pop() ?? '';
+    if (!filename.endsWith('.jsonl')) continue;
+
+    const lines: string[] = [];
+    let lastTs = 0;
+    for (const line of file.content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let event: Record<string, unknown>;
+      try {
+        event = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const eventTs = parseTs(event.timestamp);
+      if (eventTs) lastTs = Math.max(lastTs, eventTs);
+      if (event.role !== 'session_meta' && eventTs < sinceEpochSec && eventTs > 0) continue;
+      lines.push(JSON.stringify(redact ? redactJsonStrings(event) : event));
+    }
+
+    if (lines.length === 0) continue;
+    // The whole session is older than the requested range.
+    if (lastTs < sinceEpochSec && lastTs > 0) continue;
+
+    out.files[`${prefix}/${sanitizeFilename(filename)}`] = lines.join('\n') + '\n';
+    out.sessions += 1;
+    const firstIsMeta = lines[0].includes('"role": "session_meta"') || lines[0].includes('"role":"session_meta"');
+    out.events += firstIsMeta ? lines.length - 1 : lines.length;
+  }
+
+  // Hermes keeps a sqlite session index plus plain-text logs next to sessions/.
+  const hermesHome = sessionsDir.replace(/\/sessions\/?$/, '');
+  const auxScript = [
+    `if command -v python3 >/dev/null 2>&1 && [ -f '${hermesHome}/state.db' ]; then`,
+    `  python3 -c "import json,sqlite3;conn=sqlite3.connect('${hermesHome}/state.db');conn.row_factory=sqlite3.Row;rows=conn.execute('SELECT * FROM sessions ORDER BY started_at DESC LIMIT 200').fetchall();print(json.dumps([dict(r) for r in rows],ensure_ascii=False))" 2>/dev/null || true`,
+    'fi',
+    `echo "${INDEX_MARKER}"`,
+    `for n in agent.log errors.log gateway.log; do`,
+    `  if [ -f '${hermesHome}/logs/'"$n" ]; then`,
+    `    echo "${FILE_MARKER} $n"`,
+    `    cat '${hermesHome}/logs/'"$n"`,
+    '  fi',
+    'done',
+  ].join('\n');
+
+  const aux = await dockerExec(ctx, container, auxScript);
+  const [dbPart, logsPart] = aux.split(INDEX_MARKER);
+
+  const dbRaw = (dbPart ?? '').trim();
+  if (dbRaw) {
+    try {
+      const data = JSON.parse(dbRaw);
+      out.files[`${prefix}/sessions-db.json`] =
+        JSON.stringify(redact ? redactJsonStrings(data) : data, null, 2) + '\n';
+    } catch {
+      // Ignore malformed sqlite dump output.
+    }
+  }
+
+  for (const log of splitBatchedFiles(logsPart ?? '')) {
+    if (!log.content.trim()) continue;
+    out.files[`${prefix}/${sanitizeFilename(log.path)}`] = redact
+      ? redactPii(log.content)
+      : log.content;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export async function exportAgentSessions(
+  ctx: DockerContext,
+  containers: string[],
+  sinceEpochSec: number,
+  redact: boolean
+): Promise<SessionExportResult> {
+  const out: SessionExportResult = {
+    containers: 0,
+    sessions: 0,
+    events: 0,
+    files: {},
+    errors: [],
+  };
+
+  for (const container of containers) {
+    const prefix = `agent-sessions/${sanitizeFilename(container)}`;
+    try {
+      const { runtime, sessionsDir } = await detectRuntime(ctx, container);
+      if (!runtime) continue;
+
+      const before = out.sessions;
+      if (runtime === 'openclaw') {
+        await exportOpenClawSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix);
+      } else if (runtime === 'hermes') {
+        await exportHermesSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix);
+      } else {
+        await exportCopawSessions(ctx, container, sessionsDir, sinceEpochSec, redact, out, prefix);
+      }
+      if (out.sessions > before) out.containers += 1;
+    } catch (err) {
+      out.errors.push(
+        `${container}: ${err instanceof Error ? err.message : 'session export failed'}`
+      );
+    }
+  }
+
+  return out;
+}

--- a/src/app/api/agentteams/workers/[name]/files/route.test.ts
+++ b/src/app/api/agentteams/workers/[name]/files/route.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { NextRequest } from 'next/server';
 import { describe, expect, it, vi } from 'vitest';
 import { GET } from './route';
 
@@ -11,7 +12,11 @@ vi.mock('@/lib/minio-client', () => ({
 
 function createObjectStream(objects: Record<string, unknown>[]) {
   const stream = new EventEmitter();
-  queueMicrotask(() => {
+  // setImmediate (not queueMicrotask): the handler only registers 'data'/'end'
+  // listeners after its `await params` continuation, which runs after the
+  // microtask queue. setImmediate fires after all microtasks, so the mock
+  // stream's events are always observed by the handler.
+  setImmediate(() => {
     objects.forEach((object) => stream.emit('data', object));
     stream.emit('end');
   });
@@ -25,7 +30,7 @@ describe('GET /api/agentteams/workers/[name]/files', () => {
       { prefix: 'manager/logs/' },
     ]));
 
-    const response = await GET(new Request('http://localhost'), {
+    const response = await GET(new NextRequest('http://localhost'), {
       params: Promise.resolve({ name: 'manager' }),
     });
 
@@ -36,6 +41,7 @@ describe('GET /api/agentteams/workers/[name]/files', () => {
         { key: 'manager/AGENTS.md', size: 120 },
         { key: 'manager/logs/', size: 0, isPrefix: true },
       ],
+      prefix: '',
     });
   });
 
@@ -44,19 +50,20 @@ describe('GET /api/agentteams/workers/[name]/files', () => {
       .mockReturnValueOnce(createObjectStream([]))
       .mockReturnValueOnce(createObjectStream([{ name: 'agents/ce1/AGENTS.md', size: 120 }]));
 
-    const response = await GET(new Request('http://localhost'), {
+    const response = await GET(new NextRequest('http://localhost'), {
       params: Promise.resolve({ name: 'ce1' }),
     });
 
     expect(response.status).toBe(200);
     expect(listObjects).toHaveBeenLastCalledWith('agentteams-storage', 'agents/ce1/', false);
     await expect(response.json()).resolves.toEqual({
-      objects: [{ key: 'agents/ce1/AGENTS.md', size: 120 }],
+      objects: [{ key: 'ce1/AGENTS.md', size: 120 }],
+      prefix: '',
     });
   });
 
   it('rejects an unsafe Worker name', async () => {
-    const response = await GET(new Request('http://localhost'), {
+    const response = await GET(new NextRequest('http://localhost'), {
       params: Promise.resolve({ name: '../manager' }),
     });
 

--- a/src/components/dashboard/settings-dialog.tsx
+++ b/src/components/dashboard/settings-dialog.tsx
@@ -21,9 +21,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
-import { Wifi, WifiOff, Loader2, RotateCcw, Clock, Server, History, Stethoscope } from 'lucide-react';
+import { Wifi, WifiOff, Loader2, RotateCcw, Clock, Server, History, Stethoscope, FileDown } from 'lucide-react';
 import { useInfrastructure } from '@/hooks/use-agentteams-infrastructure';
 import { TroubleshootTab } from './settings/troubleshoot-tab';
+import { DebugLogTab } from './settings/debug-log-tab';
 
 // Empty default means "use the server-side AGENTTEAMS_CONTROLLER_URL" so the same
 // image works in embedded (localhost) and Kubernetes (in-cluster) modes.
@@ -119,11 +120,15 @@ export function SettingsDialog() {
         </DialogHeader>
 
         <Tabs defaultValue="connection" className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="connection">连接</TabsTrigger>
             <TabsTrigger value="troubleshoot">
               <Stethoscope className="w-3.5 h-3.5 mr-1" />
               AI 诊断
+            </TabsTrigger>
+            <TabsTrigger value="debug-log">
+              <FileDown className="w-3.5 h-3.5 mr-1" />
+              日志收集
             </TabsTrigger>
           </TabsList>
 
@@ -306,6 +311,10 @@ export function SettingsDialog() {
 
           <TabsContent value="troubleshoot" className="py-4">
             <TroubleshootTab />
+          </TabsContent>
+
+          <TabsContent value="debug-log" className="py-4">
+            <DebugLogTab />
           </TabsContent>
         </Tabs>
 

--- a/src/components/dashboard/settings/debug-log-tab.tsx
+++ b/src/components/dashboard/settings/debug-log-tab.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState } from 'react';
+import { FileDown, Loader2, MessageSquareText, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+import { apiUrl } from '@/lib/api-base';
+import { useMatrixStore } from '@/lib/matrix-store';
+
+const RANGE_OPTIONS = [
+  { value: '10m', label: '最近 10 分钟' },
+  { value: '30m', label: '最近 30 分钟' },
+  { value: '1h', label: '最近 1 小时' },
+  { value: '6h', label: '最近 6 小时' },
+  { value: '1d', label: '最近 1 天' },
+];
+
+function filenameFromDisposition(disposition: string | null): string | null {
+  if (!disposition) return null;
+  const match = /filename="?([^";]+)"?/.exec(disposition);
+  return match?.[1] ?? null;
+}
+
+export function DebugLogTab() {
+  const [range, setRange] = useState('1h');
+  const [redact, setRedact] = useState(true);
+  const [container, setContainer] = useState('');
+  const [room, setRoom] = useState('');
+  const [collecting, setCollecting] = useState(false);
+
+  const { isLoggedIn, accessToken, homeserver } = useMatrixStore();
+  const matrixReady = isLoggedIn && !!accessToken && !!homeserver;
+
+  const handleCollect = async () => {
+    setCollecting(true);
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (matrixReady) {
+        headers['Authorization'] = `Bearer ${accessToken}`;
+      }
+      const res = await fetch(apiUrl('/api/agentteams/debug-log'), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          range,
+          redact,
+          container: container.trim() || undefined,
+          room: room.trim() || undefined,
+          homeserver: matrixReady ? homeserver : undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        let message = `HTTP ${res.status}`;
+        try {
+          const data = await res.json();
+          if (data?.error) message = data.error;
+        } catch {
+          // Non-JSON error body — keep the HTTP status message.
+        }
+        throw new Error(message);
+      }
+
+      const blob = await res.blob();
+      const filename =
+        filenameFromDisposition(res.headers.get('content-disposition')) ??
+        `agentteams-debug-log-${Date.now()}.zip`;
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+
+      toast.success(`日志包已下载：${filename}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : '收集日志失败');
+    } finally {
+      setCollecting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        一键收集集群调试日志并打包下载 ZIP，包含容器状态与日志、Agent
+        会话记录，以及（已登录 Matrix 时）房间消息。用于提交 issue 或离线排查。
+      </p>
+
+      <div className="space-y-2">
+        <Label>时间范围</Label>
+        <Select value={range} onValueChange={setRange}>
+          <SelectTrigger className="w-64">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RANGE_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <Label>容器过滤（可选）</Label>
+          <Input
+            value={container}
+            onChange={(e) => setContainer(e.target.value)}
+            placeholder="例如 agentteams-worker"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>房间过滤（可选）</Label>
+          <Input
+            value={room}
+            onChange={(e) => setRoom(e.target.value)}
+            placeholder="例如 Worker"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <Label className="flex items-center gap-1.5">
+            <ShieldCheck className="w-3.5 h-3.5" />
+            PII 脱敏
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            自动屏蔽手机号、邮箱、API Key、Token 等敏感信息（建议保持开启）
+          </p>
+        </div>
+        <Switch checked={redact} onCheckedChange={setRedact} />
+      </div>
+
+      <div className="flex items-center gap-2 text-xs rounded-lg border p-2.5 bg-muted/50">
+        <MessageSquareText className="w-3.5 h-3.5 shrink-0" />
+        {matrixReady ? (
+          <span>已登录 Matrix，日志包将包含房间消息。</span>
+        ) : (
+          <span className="text-muted-foreground">
+            未登录 Matrix，将跳过房间消息导出（仅收集容器日志与会话）。
+          </span>
+        )}
+      </div>
+
+      <Button onClick={handleCollect} disabled={collecting} className="w-full sm:w-auto">
+        {collecting ? (
+          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+        ) : (
+          <FileDown className="w-4 h-4 mr-2" />
+        )}
+        {collecting ? '正在收集，请稍候…' : '一键收集并下载'}
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/homeserver-allowlist.test.ts
+++ b/src/lib/homeserver-allowlist.test.ts
@@ -88,4 +88,33 @@ describe('validateHomeserverUrl', () => {
       expect((err as HomeserverValidationError).reason).toMatch(/private network/);
     }
   });
+
+  it('requireAllowlist accepts an allowlisted host', () => {
+    const out = validateHomeserverUrl('https://matrix.org', { requireAllowlist: true });
+    expect(out.hostname).toBe('matrix.org');
+  });
+
+  it('requireAllowlist rejects a host outside the allowlist', () => {
+    expect(() =>
+      validateHomeserverUrl('https://attacker.example', { requireAllowlist: true })
+    ).toThrow(HomeserverValidationError);
+  });
+
+  it('requireAllowlist without env still rejects unknown public hosts and keeps built-ins', () => {
+    const saved = process.env.MATRIX_HOMESERVER_ALLOWLIST;
+    delete process.env.MATRIX_HOMESERVER_ALLOWLIST;
+    try {
+      expect(() =>
+        validateHomeserverUrl('https://attacker.example', { requireAllowlist: true })
+      ).toThrow(HomeserverValidationError);
+      const out = validateHomeserverUrl('https://matrix.org', { requireAllowlist: true });
+      expect(out.hostname).toBe('matrix.org');
+    } finally {
+      if (saved === undefined) {
+        delete process.env.MATRIX_HOMESERVER_ALLOWLIST;
+      } else {
+        process.env.MATRIX_HOMESERVER_ALLOWLIST = saved;
+      }
+    }
+  });
 });

--- a/src/lib/homeserver-allowlist.ts
+++ b/src/lib/homeserver-allowlist.ts
@@ -67,6 +67,11 @@ function isPrivateIpv6(hostname: string): boolean {
 
 export interface ValidateHomeserverOptions {
   allowPrivateNetwork?: boolean;
+  // When true the URL must match the allowlist (configured or built-in) even
+  // when no MATRIX_HOMESERVER_ALLOWLIST env is set. Use this for routes that
+  // forward the user's access token to the homeserver, so the token is never
+  // sent to an arbitrary public host the operator has not approved.
+  requireAllowlist?: boolean;
 }
 
 export class HomeserverValidationError extends Error {
@@ -117,7 +122,9 @@ export function validateHomeserverUrl(
   }
 
   // An explicitly configured allowlist is exclusive: anything not on it is rejected.
-  if (process.env.MATRIX_HOMESERVER_ALLOWLIST) {
+  // requireAllowlist makes the built-in allowlist exclusive too, so credentials
+  // are only ever sent to an approved host.
+  if (process.env.MATRIX_HOMESERVER_ALLOWLIST || options.requireAllowlist) {
     throw new HomeserverValidationError('host is not in the allowlist');
   }
 


### PR DESCRIPTION
## 概述

将 AgentTeams 主仓库 `scripts/export-debug-log.py` 的能力搬入 Dashboard：设置对话框新增「日志收集」页签，一键采集容器诊断、Agent 会话、Matrix 房间消息，脱敏后打包 ZIP 下载。无需宿主机 docker CLI / Python 环境。

技术方案详见 `docs/debug-log-collection.md`。

## 实现要点

- **容器数据零新权限**：复用 Controller 内置 Docker API 反向代理（GET 全放行 + exec create/start 白名单），实现列表 / inspect / logs / exec 全链路采集
- **Agent 会话导出**：移植 OpenClaw / Hermes / CoPaw 三 runtime 的目录探测与时间过滤逻辑；针对 HTTP 通道做批量化优化（runtime 探测 8→1 次 exec、session 读取 3N→1 次 exec）
- **Matrix 消息**：复用浏览器 Matrix 登录态（`Authorization` 头 + homeserver 白名单/SSRF 校验），以当前用户身份导出，未登录自动降级跳过
- **PII 脱敏**：移植 20 条正则规则（身份证/手机号/邮箱/各类 API Key/Bearer/secret KV 等），默认开启；顺带修正原脚本 `ALIYUN_SK` 正则会把 secret 原文保留的缺陷
- **容错降级**：各收集器独立 try/catch，单点失败写入 `summary.txt` Notes，不中断整体导出
- **打包下载**：`fflate`（已有依赖）内存 zipSync，`Content-Disposition` 附件返回，不落盘

## 变更文件

| 文件 | 说明 |
|---|---|
| `src/app/api/agentteams/debug-log/route.ts` | `POST /api/agentteams/debug-log/` 主路由，编排 + ZIP |
| `.../debug-log/docker.ts` | Controller Docker 代理客户端（含 raw stream 解复用） |
| `.../debug-log/sessions.ts` | 三 runtime 会话采集 |
| `.../debug-log/matrix.ts` | Matrix 消息分页导出 |
| `.../debug-log/redact.ts` + `redact.test.ts` | PII 脱敏 + 16 个单测 |
| `settings/debug-log-tab.tsx` + `settings-dialog.tsx` | 「日志收集」页签 UI |
| `docs/debug-log-collection.md` | 技术方案文档 |

## 验证

- 新增代码 `typecheck` / `eslint` 0 错误
- 脱敏单测 16/16 通过
- 全量 `vitest` 304/307（3 个失败为存量 `workers/[name]/skills` 测试在 Windows 下的 vitest worker 超时，与本 PR 无关）
- `next build` 编译通过，新路由已入产物清单

## 使用

设置 → 「日志收集」页签 → 选时间范围（默认 1h）→ 一键收集并下载，得到 `agentteams-debug-log-<时间戳>.zip`（登录 Matrix 时含房间消息）。

## 已知限制

- 依赖 Controller 的 Docker 代理，面向 docker 单节点部署；k3s/Helm 形态的 K8s collector 可作为后续迭代（收集器已按模块隔离）
