### PR TITLE
fix(team-tasks): scan team-scoped shared prefixes so team projects appear on the board

### DIFF
--- a/src/app/api/agentteams/team-tasks/route.test.ts
+++ b/src/app/api/agentteams/team-tasks/route.test.ts
@@ -1,5 +1,7 @@
+// @vitest-environment node
 import { describe, it, expect } from 'vitest';
-import { __test__ } from './route';
+import { Readable } from 'node:stream';
+import { __test__, type TaskBoardTask } from './route';
 
 const {
   normalizeTask,
@@ -10,6 +12,10 @@ const {
   pickProjectId,
   normalizeStatus,
   normalizeProjectStatus,
+  collectSharedTasks,
+  collectSharedProjects,
+  listTeamScopes,
+  mergeTasks,
 } = __test__;
 
 const NOW = 1700000000000;
@@ -325,5 +331,210 @@ describe('parseOutcomeFromResult', () => {
     ['## outcome: success', 'SUCCESS'], // case-insensitive on the word
   ])('parses %s -> %s', (input, expected) => {
     expect(parseOutcomeFromResult(input)).toBe(expected);
+  });
+});
+
+// ----- mergeTasks -----
+
+function task(id: string, overrides: Partial<TaskBoardTask> = {}): TaskBoardTask {
+  return {
+    runId: id,
+    title: id,
+    status: 'in_progress',
+    assignedTo: 'alice',
+    roomId: '!room',
+    dependsOn: [],
+    createdAt: NOW,
+    outcome: null,
+    source: 'shared/tasks/x',
+    ...overrides,
+  };
+}
+
+describe('mergeTasks', () => {
+  it('keeps shared (canonical) task over worker history on runId conflict', () => {
+    const shared = task('t1', { projectId: 'proj-1', outcome: 'SUCCESS' });
+    const history = task('t1', { title: 'stale history', projectId: undefined });
+    const merged = mergeTasks([shared], [history]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toBe(shared);
+  });
+
+  it('dedupes and combines disjoint tasks', () => {
+    const shared = [task('t1'), task('t2')];
+    const history = [task('t3')];
+    const merged = mergeTasks(shared, history);
+    expect(merged.map((t) => t.runId).sort()).toEqual(['t1', 't2', 't3']);
+  });
+
+  it('returns empty when both inputs are empty', () => {
+    expect(mergeTasks([], [])).toEqual([]);
+  });
+});
+
+// ----- Dual-track scanning helpers -----
+
+/** Minimal fake MinIO client backed by a key -> content map. */
+function makeClient(metaByKey: Record<string, unknown>): never {
+  return {
+    statObject: async () => ({ size: 4096 }),
+    getObject: async (_bucket: string, key: string) => {
+      const text = metaByKey[key];
+      const stream = new Readable();
+      if (text !== undefined) {
+        stream.push(typeof text === 'string' ? text : JSON.stringify(text));
+      }
+      stream.push(null);
+      return stream;
+    },
+  } as never;
+}
+
+/** listAt stub driven by a prefix -> ListResult map. */
+function makeListAt(
+  prefixMap: Record<string, { prefixes?: string[]; files?: string[] }>,
+) {
+  return async (_client: unknown, _bucket: string, prefix: string) => {
+    const entry = prefixMap[prefix] ?? { prefixes: [], files: [] };
+    return { prefixes: entry.prefixes ?? [], files: entry.files ?? [] };
+  };
+}
+
+// ----- listTeamScopes -----
+
+describe('listTeamScopes', () => {
+  it('enumerates team directories under teams/', async () => {
+    const listAt = makeListAt({
+      'teams/': { prefixes: ['teams/sysdev/', 'teams/biz/'] },
+    });
+    const scopes = await listTeamScopes({} as never, 'bucket', listAt);
+    expect(scopes).toEqual(['teams/sysdev/', 'teams/biz/']);
+  });
+
+  it('returns [] when the teams/ listing fails', async () => {
+    const listAt = async () => {
+      throw new Error('no such prefix');
+    };
+    const scopes = await listTeamScopes({} as never, 'bucket', listAt);
+    expect(scopes).toEqual([]);
+  });
+
+  it('returns [] when teams/ has no entries', async () => {
+    const listAt = makeListAt({ 'teams/': { prefixes: [] } });
+    const scopes = await listTeamScopes({} as never, 'bucket', listAt);
+    expect(scopes).toEqual([]);
+  });
+});
+
+// ----- collectSharedTasks (dual-track) -----
+
+describe('collectSharedTasks (dual-track)', () => {
+  it('collects root and team-scoped tasks together', async () => {
+    const metaByKey = {
+      'shared/tasks/root-task/meta.json': {
+        task_id: 'task-root',
+        task_title: 'Root task',
+        status: 'in_progress',
+      },
+      'teams/sysdev/shared/tasks/team-task/meta.json': {
+        task_id: 'task-team',
+        task_title: 'Team task',
+        status: 'assigned',
+      },
+    };
+    const client = makeClient(metaByKey);
+    const listAt = makeListAt({
+      'shared/tasks/': { prefixes: ['shared/tasks/root-task/'] },
+      'teams/': { prefixes: ['teams/sysdev/'] },
+      'teams/sysdev/shared/tasks/': {
+        prefixes: ['teams/sysdev/shared/tasks/team-task/'],
+      },
+    });
+    const out = await collectSharedTasks(client, 'bucket', NOW, listAt);
+    expect(out.tasks).toHaveLength(2);
+    const ids = out.tasks.map((t) => t.runId).sort();
+    expect(ids).toEqual(['task-root', 'task-team']);
+    const teamTask = out.tasks.find((t) => t.runId === 'task-team');
+    expect(teamTask?.source).toBe('teams/sysdev/shared/tasks/team-task');
+    expect(out.scannedKeys).toContain(
+      'teams/sysdev/shared/tasks/team-task/meta.json',
+    );
+    expect(out.scannedKeys).toContain('shared/tasks/root-task/meta.json');
+  });
+
+  it('degrades to root only when teams/ has no entries', async () => {
+    const metaByKey = {
+      'shared/tasks/root-task/meta.json': {
+        task_id: 'task-root',
+        task_title: 'Root task',
+      },
+    };
+    const client = makeClient(metaByKey);
+    const listAt = makeListAt({
+      'shared/tasks/': { prefixes: ['shared/tasks/root-task/'] },
+      'teams/': { prefixes: [] },
+    });
+    const out = await collectSharedTasks(client, 'bucket', NOW, listAt);
+    expect(out.tasks).toHaveLength(1);
+    expect(out.tasks[0].runId).toBe('task-root');
+  });
+
+  it('returns empty when no tasks exist in either track', async () => {
+    const client = makeClient({});
+    const listAt = makeListAt({
+      'shared/tasks/': { prefixes: [] },
+      'teams/': { prefixes: [] },
+    });
+    const out = await collectSharedTasks(client, 'bucket', NOW, listAt);
+    expect(out.tasks).toEqual([]);
+    expect(out.scannedKeys).toEqual([]);
+  });
+});
+
+// ----- collectSharedProjects (dual-track) -----
+
+describe('collectSharedProjects (dual-track)', () => {
+  it('collects root and team-scoped projects together', async () => {
+    const metaByKey = {
+      'shared/projects/root-proj/meta.json': {
+        project_id: 'proj-root',
+        project_name: 'Root Proj',
+      },
+      'teams/sysdev/shared/projects/team-proj/meta.json': {
+        project_id: 'proj-team',
+        project_name: 'Team Proj',
+      },
+    };
+    const client = makeClient(metaByKey);
+    const listAt = makeListAt({
+      'shared/projects/': { prefixes: ['shared/projects/root-proj/'] },
+      'teams/': { prefixes: ['teams/sysdev/'] },
+      'teams/sysdev/shared/projects/': {
+        prefixes: ['teams/sysdev/shared/projects/team-proj/'],
+      },
+    });
+    const out = await collectSharedProjects(client, 'bucket', NOW, listAt);
+    expect(out.projects).toHaveLength(2);
+    const ids = out.projects.map((p) => p.runId).sort();
+    expect(ids).toEqual(['proj-root', 'proj-team']);
+    const teamProj = out.projects.find((p) => p.runId === 'proj-team');
+    expect(teamProj?.source).toBe('teams/sysdev/shared/projects/team-proj');
+  });
+
+  it('degrades to root only when teams/ has no entries', async () => {
+    const metaByKey = {
+      'shared/projects/root-proj/meta.json': {
+        project_id: 'proj-root',
+        project_name: 'Root Proj',
+      },
+    };
+    const client = makeClient(metaByKey);
+    const listAt = makeListAt({
+      'shared/projects/': { prefixes: ['shared/projects/root-proj/'] },
+      'teams/': { prefixes: [] },
+    });
+    const out = await collectSharedProjects(client, 'bucket', NOW, listAt);
+    expect(out.projects).toHaveLength(1);
+    expect(out.projects[0].runId).toBe('proj-root');
   });
 });

--- a/src/app/api/agentteams/team-tasks/route.ts
+++ b/src/app/api/agentteams/team-tasks/route.ts
@@ -146,6 +146,15 @@ const SHARED_PROJECTS_PREFIX = 'shared/projects/';
 const AGENTS_PREFIX = 'agents/';
 const WORKER_HISTORY_FILENAME = 'task-history.json';
 
+// Team-scoped storage layout (see AgentTeams project-management skill):
+//   teams/{team}/shared/projects/{project-id}/meta.json
+//   teams/{team}/shared/tasks/{task-id}/meta.json
+// The dashboard board reads the root shared/ prefixes below; the team-scoped
+// prefixes are scanned in addition so project/task collaboration files
+// created under a team (the primary layout for TeamHarness MCP) are visible.
+const TEAMS_PREFIX = 'teams/';
+const TEAM_SHARED_SUFFIX = 'shared/';
+
 const SPEC_MAX_BYTES = 4 * 1024;
 
 interface RawMeta {
@@ -438,6 +447,26 @@ async function listAtPrefix(
   });
 }
 
+type ListAtFn = typeof listAtPrefix;
+
+/**
+ * Enumerate team directories under `teams/` (e.g. `teams/sysdev/`).
+ * Returns an empty array when the prefix is missing or listing fails so
+ * callers degrade gracefully to the root shared/ layout.
+ */
+async function listTeamScopes(
+  client: Client,
+  bucket: string,
+  listAt: ListAtFn = listAtPrefix,
+): Promise<string[]> {
+  try {
+    const list = await listAt(client, bucket, TEAMS_PREFIX);
+    return list.prefixes;
+  } catch {
+    return [];
+  }
+}
+
 async function getObjectText(
   client: Client,
   bucket: string,
@@ -475,44 +504,54 @@ async function collectSharedTasks(
   client: Client,
   bucket: string,
   now: number,
+  listAt: ListAtFn = listAtPrefix,
 ): Promise<{ tasks: TaskBoardTask[]; scannedKeys: string[] }> {
   const out = { tasks: [] as TaskBoardTask[], scannedKeys: [] as string[] };
-  let list: ListResult;
-  try {
-    list = await listAtPrefix(client, bucket, SHARED_TASKS_PREFIX);
-  } catch {
-    return out;
-  }
-  for (const taskPrefix of list.prefixes) {
-    const metaKey = `${taskPrefix}meta.json`;
-    const metaText = await getObjectText(client, bucket, metaKey);
-    if (!metaText) continue;
-    out.scannedKeys.push(metaKey);
-    let meta: RawMeta;
+  // Dual-track scan: root shared/tasks/ (manager/legacy writes) plus
+  // teams/{team}/shared/tasks/ (TeamHarness MCP, the primary layout).
+  const teamScopes = await listTeamScopes(client, bucket, listAt);
+  const prefixes = [
+    SHARED_TASKS_PREFIX,
+    ...teamScopes.map((scope) => `${scope}${TEAM_SHARED_SUFFIX}tasks/`),
+  ];
+  for (const prefix of prefixes) {
+    let list: ListResult;
     try {
-      meta = JSON.parse(metaText);
+      list = await listAt(client, bucket, prefix);
     } catch {
       continue;
     }
-    const source = taskPrefix.replace(/\/$/, '');
-    // result.md drives the outcome field.
-    const resultText = await getObjectText(
-      client,
-      bucket,
-      `${taskPrefix}result.md`,
-    );
-    if (resultText) out.scannedKeys.push(`${taskPrefix}result.md`);
-    const outcome = parseOutcomeFromResult(resultText);
-    // spec.md is optional and bounded.
-    const specText = await getObjectText(
-      client,
-      bucket,
-      `${taskPrefix}spec.md`,
-      SPEC_MAX_BYTES,
-    );
-    if (specText) out.scannedKeys.push(`${taskPrefix}spec.md`);
-    const task = normalizeTask(meta, source, now, outcome, specText ?? undefined);
-    if (task) out.tasks.push(task);
+    for (const taskPrefix of list.prefixes) {
+      const metaKey = `${taskPrefix}meta.json`;
+      const metaText = await getObjectText(client, bucket, metaKey);
+      if (!metaText) continue;
+      out.scannedKeys.push(metaKey);
+      let meta: RawMeta;
+      try {
+        meta = JSON.parse(metaText);
+      } catch {
+        continue;
+      }
+      const source = taskPrefix.replace(/\/$/, '');
+      // result.md drives the outcome field.
+      const resultText = await getObjectText(
+        client,
+        bucket,
+        `${taskPrefix}result.md`,
+      );
+      if (resultText) out.scannedKeys.push(`${taskPrefix}result.md`);
+      const outcome = parseOutcomeFromResult(resultText);
+      // spec.md is optional and bounded.
+      const specText = await getObjectText(
+        client,
+        bucket,
+        `${taskPrefix}spec.md`,
+        SPEC_MAX_BYTES,
+      );
+      if (specText) out.scannedKeys.push(`${taskPrefix}spec.md`);
+      const task = normalizeTask(meta, source, now, outcome, specText ?? undefined);
+      if (task) out.tasks.push(task);
+    }
   }
   return out;
 }
@@ -521,35 +560,45 @@ async function collectSharedProjects(
   client: Client,
   bucket: string,
   now: number,
+  listAt: ListAtFn = listAtPrefix,
 ): Promise<{ projects: TaskBoardProject[]; scannedKeys: string[] }> {
   const out = { projects: [] as TaskBoardProject[], scannedKeys: [] as string[] };
-  let list: ListResult;
-  try {
-    list = await listAtPrefix(client, bucket, SHARED_PROJECTS_PREFIX);
-  } catch {
-    return out;
-  }
-  for (const projectPrefix of list.prefixes) {
-    const metaKey = `${projectPrefix}meta.json`;
-    const metaText = await getObjectText(client, bucket, metaKey);
-    if (!metaText) continue;
-    out.scannedKeys.push(metaKey);
-    let meta: RawProjectMeta;
+  // Dual-track scan: root shared/projects/ (legacy) plus
+  // teams/{team}/shared/projects/ (TeamHarness MCP, the primary layout).
+  const teamScopes = await listTeamScopes(client, bucket, listAt);
+  const prefixes = [
+    SHARED_PROJECTS_PREFIX,
+    ...teamScopes.map((scope) => `${scope}${TEAM_SHARED_SUFFIX}projects/`),
+  ];
+  for (const prefix of prefixes) {
+    let list: ListResult;
     try {
-      meta = JSON.parse(metaText);
+      list = await listAt(client, bucket, prefix);
     } catch {
       continue;
     }
-    const source = projectPrefix.replace(/\/$/, '');
-    const planText = await getObjectText(
-      client,
-      bucket,
-      `${projectPrefix}plan.md`,
-    );
-    if (planText) out.scannedKeys.push(`${projectPrefix}plan.md`);
-    const phases = parsePlan(planText);
-    const project = normalizeProject(meta, source, now, phases);
-    if (project) out.projects.push(project);
+    for (const projectPrefix of list.prefixes) {
+      const metaKey = `${projectPrefix}meta.json`;
+      const metaText = await getObjectText(client, bucket, metaKey);
+      if (!metaText) continue;
+      out.scannedKeys.push(metaKey);
+      let meta: RawProjectMeta;
+      try {
+        meta = JSON.parse(metaText);
+      } catch {
+        continue;
+      }
+      const source = projectPrefix.replace(/\/$/, '');
+      const planText = await getObjectText(
+        client,
+        bucket,
+        `${projectPrefix}plan.md`,
+      );
+      if (planText) out.scannedKeys.push(`${projectPrefix}plan.md`);
+      const phases = parsePlan(planText);
+      const project = normalizeProject(meta, source, now, phases);
+      if (project) out.projects.push(project);
+    }
   }
   return out;
 }
@@ -587,6 +636,25 @@ async function collectWorkerHistories(
     }),
   );
   return out;
+}
+
+/**
+ * Merge tasks by runId with canonical (shared/tasks/) entries winning over
+ * worker-history fallbacks. `sharedTasks` includes both root and
+ * team-scoped entries (team-scoped already win within the collector); this
+ * keeps the canonical meta.json state (projectId / outcome / completedAt)
+ * rather than the flat history record.
+ */
+function mergeTasks(
+  sharedTasks: TaskBoardTask[],
+  historyTasks: TaskBoardTask[],
+): TaskBoardTask[] {
+  const byId = new Map<string, TaskBoardTask>();
+  // history first, shared second so shared (canonical) wins on conflict.
+  for (const t of [...historyTasks, ...sharedTasks]) {
+    byId.set(t.runId, t);
+  }
+  return Array.from(byId.values());
 }
 
 export async function GET() {
@@ -631,10 +699,10 @@ export async function GET() {
     collectWorkerHistories(client, bucket, now),
   ]);
 
-  // Merge by runId. shared/tasks/ entries win over worker history so the
-  // canonical state takes precedence.
+  // Merge by runId. shared/tasks/ entries (root + team-scoped) win over
+  // worker history so the canonical state takes precedence.
   const taskById = new Map<string, TaskBoardTask>();
-  for (const t of [...tasksSrc.tasks, ...historySrc.tasks]) {
+  for (const t of mergeTasks(tasksSrc.tasks, historySrc.tasks)) {
     taskById.set(t.runId, t);
   }
 
@@ -655,7 +723,11 @@ export async function GET() {
   }
 
   const matchedPrefixes: string[] = [];
+  const hasTeamTasks = tasksSrc.scannedKeys.some((k) => k.startsWith(TEAMS_PREFIX));
+  if (hasTeamTasks) matchedPrefixes.push(`teams/*/${TEAM_SHARED_SUFFIX}tasks/ (team-scoped)`);
   if (tasksSrc.scannedKeys.length > 0) matchedPrefixes.push(SHARED_TASKS_PREFIX);
+  const hasTeamProjects = projectsSrc.scannedKeys.some((k) => k.startsWith(TEAMS_PREFIX));
+  if (hasTeamProjects) matchedPrefixes.push(`teams/*/${TEAM_SHARED_SUFFIX}projects/ (team-scoped)`);
   if (projectsSrc.scannedKeys.length > 0) matchedPrefixes.push(SHARED_PROJECTS_PREFIX);
   if (historySrc.scannedKeys.length > 0) matchedPrefixes.push(`${AGENTS_PREFIX} (worker-history)`);
 
@@ -683,4 +755,11 @@ export const __test__ = {
   pickProjectId,
   normalizeStatus,
   normalizeProjectStatus,
+  collectSharedTasks,
+  collectSharedProjects,
+  listTeamScopes,
+  mergeTasks,
+  SHARED_TASKS_PREFIX,
+  SHARED_PROJECTS_PREFIX,
+  TEAMS_PREFIX,
 };


### PR DESCRIPTION
## Summary

The task board only read the root `shared/tasks/` and `shared/projects/` prefixes. AgentTeams' TeamHarness MCP writes team collaboration files under `teams/{team}/shared/{tasks,projects}/` — the primary layout for projects created via `projectflow` — so team projects/tasks were invisible on the board.

This PR scans both tracks:
- root `shared/tasks/` + `shared/projects/` (manager/legacy writes)
- `teams/*/shared/tasks/` + `teams/*/shared/projects/` (team-scoped, TeamHarness MCP)

Team-scoped entries win on `runId` dedup (matching the upstream layout where team scope is primary). Degrades gracefully to root-only when `teams/` is missing or empty. `matchedPrefixes` now reports team-scoped scans separately for diagnostics.

## What's included

1. `src/app/api/agentteams/team-tasks/route.ts`:
   - `listTeamScopes()` — enumerates `teams/` directories via `listAtPrefix`
   - `collectSharedTasks` / `collectSharedProjects` now scan root + team-scoped prefixes (each collector accepts an injectable `listAt` parameter, defaulting to `listAtPrefix`, so the dual-track walk is unit-testable without a MinIO server)
   - `matchedPrefixes` reports `teams/*/shared/{tasks,projects}/ (team-scoped)` separately
   - `mergeTasks()` — fixes merge order so canonical `shared/tasks/` entries (now including team-scoped) win over flat worker-history records on `runId` conflict, aligning with the documented intent
2. `src/app/api/agentteams/team-tasks/route.test.ts` — 11 new unit tests: `listTeamScopes` enumeration / failure degrade / empty; dual-track collection for tasks + projects; root-only degrade; empty tracks; `mergeTasks` canonical-wins / dedupe / empty

## Data boundary

The write path is confirmed against AgentTeams source: a team member worker gets `AGENTTEAMS_SHARED_STORAGE_PREFIX=teams/{team}/shared` (`_apply_runtime_storage`), so `_sync_task` pushes `teams/{team}/shared/tasks/` and `_sync_project` pushes `teams/{team}/shared/projects/`; a standalone worker writes root `shared/`. The dual track therefore covers all TeamHarness MCP write paths. The auth gate for this endpoint is already covered by `src/middleware.ts` (all `/api/agentteams/*` require a Higress session; `PUBLIC_PATHS` only contains setup).

## Tests

- `route.test.ts`: 70 tests (11 new) — all pass
- `tsc --noEmit` clean; `eslint` clean on the changed files
- Full suite unchanged vs baseline: 109 pre-existing jsdom component-test failures (e.g. `MessageBubble.test.tsx`), verified identical with `git stash` baseline before/after
- The dashboard repo has no CI gate on `src/` changes (build on tags only; install-test on `install/**`), so local tests are the hard guarantee

## Related

- Regression history: `e74ff7b` implemented a team-scoped layout, reverted 20 minutes later by `1b0582d` (task-panel rewrite) — this PR restores the team-scoped track on top of the current data model.
- AgentTeams side: W-PR-1 (`GET /api/v1/projects`, agentteams/AgentTeams#1169) provides a standardized API for the same data source.

---

## 摘要

任务看板之前只读根前缀 `shared/tasks/` 和 `shared/projects/`。AgentTeams 的 TeamHarness MCP（`projectflow` 建的项目）把团队协作文件写到 `teams/{team}/shared/{tasks,projects}/`——这是团队项目的**主存储布局**——所以看板读不到团队项目/任务。

本 PR 补双轨扫描：
- 根 `shared/tasks/` + `shared/projects/`（Manager/遗留写入）
- `teams/*/shared/tasks/` + `teams/*/shared/projects/`（团队域，TeamHarness MCP）

按 `runId` 去重时团队域优先（与上游布局一致——团队域是主布局）。`teams/` 缺失/为空时优雅降级到仅根前缀。`matchedPrefixes` 单独报告团队域扫描结果，便于诊断。

## 包含内容

1. `src/app/api/agentteams/team-tasks/route.ts`：
   - `listTeamScopes()` — 通过 `listAtPrefix` 枚举 `teams/` 目录
   - `collectSharedTasks` / `collectSharedProjects` 现在扫根前缀 + 团队前缀（每个 collector 接受可注入的 `listAt` 参数，默认 `listAtPrefix`，使双轨扫描可在无 MinIO 服务器的情况下单元测试）
   - `matchedPrefixes` 单独报告 `teams/*/shared/{tasks,projects}/ (team-scoped)`
   - `mergeTasks()` — 修复合并顺序，使 canonical 的 `shared/tasks/` 条目（现在含团队域）在 `runId` 冲突时优先于扁平 worker-history 记录，与文档意图一致
2. `src/app/api/agentteams/team-tasks/route.test.ts` — 11 个新单元测试：`listTeamScopes` 枚举/失败降级/空；tasks + projects 双轨收集；仅根前缀降级；空轨；`mergeTasks` canonical 优先/去重/空

## 数据边界

写路径已对照 AgentTeams 源码确认：团队成员的 Worker 获得 `AGENTTEAMS_SHARED_STORAGE_PREFIX=teams/{team}/shared`（`_apply_runtime_storage`），因此 `_sync_task` 推 `teams/{team}/shared/tasks/`、`_sync_project` 推 `teams/{team}/shared/projects/`；独立 Worker 写根 `shared/`。双轨因此覆盖 TeamHarness MCP 的全部写路径。该端点的鉴权已由 `src/middleware.ts` 覆盖（所有 `/api/agentteams/*` 需要 Higress session；`PUBLIC_PATHS` 仅含 setup）。

## 测试

- `route.test.ts`：70 测试（11 新增）全过
- `tsc --noEmit` 干净；改动文件 eslint 干净
- 全量测试与基线一致：109 个预存 jsdom 组件测试失败（如 `MessageBubble.test.tsx`），stash 前后验证一致
- dashboard 仓库对 `src/` 改动无 CI gate（build 仅 tag 触发；install-test 仅 `install/**`）——本地测试是硬保障

## 关联

- 回归历史：`e74ff7b` 曾实现团队域布局，20 分钟后被 `1b0582d`（task-panel 重写）回退——本 PR 在当前数据模型之上恢复团队域轨道。
- AgentTeams 侧：W-PR-1（`GET /api/v1/projects`，agentteams/AgentTeams#1169）为同一数据源提供标准 API。
