### PR TITLE
feat(tasks): render project task DAG (dependency graph) in project view

### DIFF
--- a/src/components/dashboard/sections/tasks-section.tsx
+++ b/src/components/dashboard/sections/tasks-section.tsx
@@ -17,6 +17,7 @@ import {
   Users,
   Eye,
   FolderTree,
+  GitBranch,
   Layers,
   AlertTriangle,
   Sparkles,
@@ -43,6 +44,7 @@ import {
   type PlanItem,
 } from '@/hooks/use-task-board';
 import { useTaskStore } from '@/lib/task-store';
+import { buildProjectDag, layoutProjectDag } from '@/lib/project-dag';
 
 // ----- Status config -----
 
@@ -440,6 +442,127 @@ function ProjectPlanPreview({ project }: { project: BoardProject }) {
   );
 }
 
+// ----- Project DAG view -----
+
+const DAG_NODE_FILL: Record<TaskStatus, { fill: string; stroke: string; text: string }> = {
+  pending: { fill: 'rgba(148,163,184,0.12)', stroke: '#94a3b8', text: '#94a3b8' },
+  assigned: { fill: 'rgba(148,163,184,0.18)', stroke: '#94a3b8', text: '#cbd5e1' },
+  in_progress: { fill: 'rgba(139,92,246,0.16)', stroke: '#8b5cf6', text: '#a78bfa' },
+  completed: { fill: 'rgba(16,185,129,0.14)', stroke: '#10b981', text: '#34d399' },
+  failed: { fill: 'rgba(239,68,68,0.14)', stroke: '#ef4444', text: '#f87171' },
+  blocked: { fill: 'rgba(245,158,11,0.14)', stroke: '#f59e0b', text: '#fbbf24' },
+  unknown: { fill: 'rgba(148,163,184,0.08)', stroke: '#64748b', text: '#94a3b8' },
+};
+
+function ProjectDagView({ project, tasks }: { project: BoardProject; tasks: BoardTask[] }) {
+  const dag = useMemo(
+    () => buildProjectDag(tasks, project.runId),
+    [tasks, project.runId],
+  );
+  // Layout is computed unconditionally (before any early return) to satisfy
+  // the Rules of Hooks — layoutProjectDag is safe on an empty dag.
+  const W = 190;
+  const H = 40;
+  const GY = 64;
+  const layout = useMemo(
+    () => layoutProjectDag(dag, { nodeWidth: W, nodeHeight: H, gapY: GY }),
+    [dag],
+  );
+  const { width: svgW, height: svgH, positions: pos } = layout;
+
+  if (dag.nodes.length === 0) return null;
+  if (dag.edges.length === 0 && dag.nodes.length <= 1) {
+    return (
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1.5">
+          <GitBranch className="h-3 w-3" />
+          依赖图
+        </p>
+        <p className="text-xs text-muted-foreground italic">
+          该项目任务之间暂无依赖关系
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1.5">
+        <GitBranch className="h-3 w-3" />
+        依赖图
+        <span className="text-[10px] text-muted-foreground/70 font-normal">
+          {dag.nodes.length} 任务 · {dag.edges.length} 依赖
+          {dag.externalDeps.length > 0 && ` · ${dag.externalDeps.length} 外部依赖`}
+        </span>
+      </p>
+      <div className="rounded-lg border bg-background/40 overflow-x-auto p-2">
+        <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} role="img" aria-label={`${project.name} 任务依赖图`}>
+          {dag.edges.map((e, i) => {
+            const a = pos.get(e.source);
+            const b = pos.get(e.target);
+            if (!a || !b) return null;
+            const x1 = a.x + W / 2;
+            const y1 = a.y + H;
+            const x2 = b.x + W / 2;
+            const y2 = b.y;
+            const my = (y1 + y2) / 2;
+            return (
+              <path
+                key={`edge-${i}`}
+                d={`M ${x1} ${y1} C ${x1} ${my}, ${x2} ${my}, ${x2} ${y2}`}
+                fill="none"
+                stroke="rgba(148,163,184,0.55)"
+                strokeWidth={1.2}
+                markerEnd="url(#dag-arrow)"
+              />
+            );
+          })}
+          <defs>
+            <marker id="dag-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
+              <path d="M0,0 L7,3 L0,6 Z" fill="rgba(148,163,184,0.7)" />
+            </marker>
+          </defs>
+          {dag.nodes.map((n) => {
+            const p = pos.get(n.id);
+            if (!p) return null;
+            const colors = DAG_NODE_FILL[n.status] ?? DAG_NODE_FILL.unknown;
+            // ~14 CJK glyphs at 11px fit inside W=190.
+            const label = n.title.length > 14 ? `${n.title.slice(0, 14)}…` : n.title;
+            return (
+              <g key={n.id}>
+                <title>{n.title}</title>
+                <rect
+                  x={p.x}
+                  y={p.y}
+                  width={W}
+                  height={H}
+                  rx={7}
+                  fill={colors.fill}
+                  stroke={n.ready ? '#22d3ee' : colors.stroke}
+                  strokeWidth={n.ready ? 1.8 : 1}
+                  strokeDasharray={n.ready ? '5 3' : undefined}
+                />
+                {n.ready && (
+                  <circle cx={p.x + 10} cy={p.y + H / 2} r={3} fill="#22d3ee" />
+                )}
+                <text
+                  x={p.x + 18}
+                  y={p.y + H / 2 + 4}
+                  fontSize={11}
+                  fill={colors.text}
+                  fontFamily="inherit"
+                >
+                  {label}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
 // ----- Main section -----
 
 type ViewMode = 'kanban' | 'projects';
@@ -756,6 +879,10 @@ export function TasksSection() {
                     <p className="text-xs font-semibold text-muted-foreground mb-2">执行计划</p>
                     <ProjectPlanPreview project={selectedProject} />
                   </div>
+                  <ProjectDagView
+                    project={selectedProject}
+                    tasks={tasksForProject(selectedProject.runId)}
+                  />
                   <div>
                     <p className="text-xs font-semibold text-muted-foreground mb-2">
                       该项目的任务 ({tasksForProject(selectedProject.runId).length})

--- a/src/lib/project-dag.test.ts
+++ b/src/lib/project-dag.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { buildProjectDag, layoutProjectDag, type ProjectDag } from './project-dag';
+import type { BoardTask } from '@/hooks/use-task-board';
+
+function task(
+  id: string,
+  overrides: Partial<BoardTask> = {},
+): BoardTask {
+  return {
+    runId: id,
+    title: id,
+    status: 'assigned',
+    assignedTo: 'alice',
+    roomId: '!room',
+    dependsOn: [],
+    createdAt: 0,
+    outcome: null,
+    source: 'shared/tasks/x',
+    projectId: 'proj-1',
+    ...overrides,
+  };
+}
+
+describe('buildProjectDag', () => {
+  it('builds nodes + edges for a linear chain', () => {
+    const tasks = [
+      task('t1'),
+      task('t2', { dependsOn: ['t1'] }),
+      task('t3', { dependsOn: ['t2'] }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    expect(dag.nodes.map((n) => n.id).sort()).toEqual(['t1', 't2', 't3']);
+    expect(dag.edges).toEqual([
+      { source: 't1', target: 't2' },
+      { source: 't2', target: 't3' },
+    ]);
+    expect(dag.externalDeps).toEqual([]);
+  });
+
+  it('computes layers top-down (no deps -> 0, then +1 per hop)', () => {
+    const tasks = [
+      task('t1'),
+      task('t2', { dependsOn: ['t1'] }),
+      task('t3', { dependsOn: ['t1', 't2'] }),
+      task('t4', { dependsOn: ['t3'] }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    const layer = Object.fromEntries(dag.nodes.map((n) => [n.id, n.layer]));
+    expect(layer).toEqual({ t1: 0, t2: 1, t3: 2, t4: 3 });
+  });
+
+  it('marks a task ready when all project deps are completed', () => {
+    const tasks = [
+      task('t1', { status: 'completed' }),
+      task('t2', { dependsOn: ['t1'] }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    const t2 = dag.nodes.find((n) => n.id === 't2');
+    expect(t2?.ready).toBe(true);
+    const t1 = dag.nodes.find((n) => n.id === 't1');
+    expect(t1?.ready).toBe(false); // already completed, not "ready to start"
+  });
+
+  it('does not mark ready when a dependency is not completed', () => {
+    const tasks = [
+      task('t1', { status: 'in_progress' }),
+      task('t2', { dependsOn: ['t1'] }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    expect(dag.nodes.find((n) => n.id === 't2')?.ready).toBe(false);
+  });
+
+  it('surfaces external deps without blocking readiness', () => {
+    const tasks = [
+      task('t1', { dependsOn: ['external-task-99'] }),
+      task('t2', { dependsOn: ['t1'] }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    expect(dag.externalDeps).toEqual(['external-task-99']);
+    // t1's only dependency is external -> assumed satisfied -> ready.
+    expect(dag.nodes.find((n) => n.id === 't1')?.ready).toBe(true);
+    // t2 depends on t1 (not completed) -> not ready.
+    expect(dag.nodes.find((n) => n.id === 't2')?.ready).toBe(false);
+    // External dep is not an edge (no node to draw).
+    expect(dag.edges).toEqual([{ source: 't1', target: 't2' }]);
+  });
+
+  it('ignores tasks from other projects', () => {
+    const tasks = [
+      task('t1'),
+      task('other', { projectId: 'proj-2' }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    expect(dag.nodes.map((n) => n.id)).toEqual(['t1']);
+  });
+
+  it('returns empty dag for a project with no tasks', () => {
+    const dag = buildProjectDag([], 'proj-1');
+    expect(dag.nodes).toEqual([]);
+    expect(dag.edges).toEqual([]);
+    expect(dag.externalDeps).toEqual([]);
+  });
+
+  it('defends against a cycle without infinite loop', () => {
+    const tasks = [
+      task('t1', { dependsOn: ['t2'] }),
+      task('t2', { dependsOn: ['t1'] }),
+    ];
+    const dag = buildProjectDag(tasks, 'proj-1');
+    // Both nodes still present; layering may be partial but must terminate.
+    expect(dag.nodes).toHaveLength(2);
+    expect(dag.edges).toHaveLength(2);
+  });
+});
+
+// ----- layoutProjectDag -----
+
+describe('layoutProjectDag', () => {
+  function makeDag(): ProjectDag {
+    return {
+      nodes: [
+        { id: 't1', title: 'a', status: 'completed', ready: false, layer: 0 },
+        { id: 't2', title: 'b', status: 'assigned', ready: true, layer: 1 },
+      ],
+      edges: [{ source: 't1', target: 't2' }],
+      externalDeps: [],
+    };
+  }
+
+  it('places layer-0 nodes above layer-1 nodes', () => {
+    const layout = layoutProjectDag(makeDag(), {
+      nodeWidth: 100,
+      nodeHeight: 30,
+      gapY: 50,
+      padding: 10,
+    });
+    const t1 = layout.positions.get('t1');
+    const t2 = layout.positions.get('t2');
+    expect(t1?.y).toBe(8);
+    expect(t2?.y).toBe(58); // 8 + 50
+    expect(t2 && t1 ? t2.y > t1.y : false).toBe(true);
+  });
+
+  it('lays nodes in the same layer left-to-right', () => {
+    const dag: ProjectDag = {
+      nodes: [
+        { id: 't1', title: 'a', status: 'pending', ready: false, layer: 0 },
+        { id: 't2', title: 'b', status: 'pending', ready: false, layer: 0 },
+      ],
+      edges: [],
+      externalDeps: [],
+    };
+    const layout = layoutProjectDag(dag, { nodeWidth: 100, gapX: 20, padding: 10 });
+    const t1 = layout.positions.get('t1');
+    const t2 = layout.positions.get('t2');
+    expect(t1?.x).toBe(10);
+    expect(t2?.x).toBe(130); // 10 + 100 + 20
+    expect(layout.width).toBe(240); // 130 + 100 + 10
+    expect(layout.height).toBe(104); // 1 layer * default gapY(64) + default nodeHeight(40)
+  });
+
+  it('returns empty layout for an empty dag', () => {
+    const layout = layoutProjectDag({ nodes: [], edges: [], externalDeps: [] });
+    expect(layout.positions.size).toBe(0);
+    expect(layout.width).toBe(0);
+    expect(layout.height).toBe(40); // default nodeHeight fallback
+  });
+});

--- a/src/lib/project-dag.ts
+++ b/src/lib/project-dag.ts
@@ -1,0 +1,178 @@
+// Project DAG (dependency graph) builder.
+//
+// Turns a project's tasks (BoardTask with dependsOn) into a minimal
+// directed acyclic graph for visualization:
+//
+//   nodes: one per project task (id = runId, title, status, ready)
+//   edges: task -> dependency (the target depends on the source)
+//   externalDeps: dependency ids referenced by project tasks that are not
+//     themselves project tasks (e.g. tasks from another project or
+//     historical ids). They are surfaced for the UI but do not block
+//     readiness of the depending task.
+//
+// `ready` mirrors the upstream "next" semantics at a task level: a
+// non-completed task whose project-internal dependencies are all
+// completed is ready to start. External dependencies are assumed
+// satisfied (their state is not visible here).
+//
+// Layers are computed iteratively (no dependencies -> layer 0; a task's
+// layer = max(dependency layers) + 1) so the renderer can lay out the
+// graph top-down. Cycles are defended against by capping the pass count.
+
+import type { BoardTask, TaskStatus } from '@/hooks/use-task-board';
+
+export interface DagNode {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  ready: boolean;
+  /** 0-based dependency depth; used for vertical layout. */
+  layer: number;
+}
+
+export interface DagEdge {
+  /** The dependency (upstream) node id. */
+  source: string;
+  /** The depending (downstream) node id. */
+  target: string;
+}
+
+export interface ProjectDag {
+  nodes: DagNode[];
+  edges: DagEdge[];
+  /** Dependency ids referenced but not part of this project. */
+  externalDeps: string[];
+}
+
+const TERMINAL_DONE = new Set<TaskStatus>(['completed']);
+
+export interface DagLayoutOptions {
+  nodeWidth?: number;
+  nodeHeight?: number;
+  gapX?: number;
+  gapY?: number;
+  padding?: number;
+}
+
+export interface DagLayout {
+  /** Total SVG width (px). */
+  width: number;
+  /** Total SVG height (px). */
+  height: number;
+  /** Top-left position of each node, keyed by node id. */
+  positions: Map<string, { x: number; y: number }>;
+}
+
+/**
+ * Compute a simple top-down layout for a DAG: nodes are grouped by layer
+ * (0 at the top), laid out left-to-right within a layer. The height covers
+ * all layers; the width covers the widest layer.
+ */
+export function layoutProjectDag(
+  dag: ProjectDag,
+  options: DagLayoutOptions = {},
+): DagLayout {
+  const W = options.nodeWidth ?? 168;
+  const H = options.nodeHeight ?? 40;
+  const GX = options.gapX ?? 24;
+  const GY = options.gapY ?? 64;
+  const PAD = options.padding ?? 12;
+
+  const byLayer = new Map<number, DagNode[]>();
+  for (const n of dag.nodes) {
+    const arr = byLayer.get(n.layer) ?? [];
+    arr.push(n);
+    byLayer.set(n.layer, arr);
+  }
+  const layers = Array.from(byLayer.keys()).sort((a, b) => a - b);
+
+  const positions = new Map<string, { x: number; y: number }>();
+  let width = 0;
+  const height = layers.length > 0 ? layers.length * GY + H : H;
+  for (const [i, layer] of layers.entries()) {
+    const nodes = byLayer.get(layer) ?? [];
+    let x = PAD;
+    for (const n of nodes) {
+      positions.set(n.id, { x, y: i * GY + 8 });
+      x += W + GX;
+    }
+    width = Math.max(width, x - GX + PAD);
+  }
+  return { width, height, positions };
+}
+
+export function buildProjectDag(
+  tasks: BoardTask[],
+  projectId: string,
+): ProjectDag {
+  const projectTasks = tasks.filter((t) => t.projectId === projectId);
+  const byId = new Map(projectTasks.map((t) => [t.runId, t]));
+
+  const nodes: DagNode[] = [];
+  const edges: DagEdge[] = [];
+  const externalDeps = new Set<string>();
+
+  for (const task of projectTasks) {
+    const deps = (task.dependsOn ?? []).filter((d) => typeof d === 'string');
+    for (const dep of deps) {
+      if (byId.has(dep)) {
+        edges.push({ source: dep, target: task.runId });
+      } else {
+        externalDeps.add(dep);
+      }
+    }
+  }
+
+  // Iterative layering: layer(task) = max(layer(dep) + 1) over project
+  // dependencies; tasks without project deps sit at layer 0. Cap passes to
+  // defend against unexpected cycles in the data.
+  const layerOf = new Map<string, number>();
+  const maxPasses = projectTasks.length + 1;
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let changed = false;
+    for (const task of projectTasks) {
+      const deps = (task.dependsOn ?? []).filter((d) => byId.has(d));
+      if (deps.length === 0) {
+        if (layerOf.get(task.runId) !== 0) {
+          layerOf.set(task.runId, 0);
+          changed = true;
+        }
+        continue;
+      }
+      let maxDep = -1;
+      for (const d of deps) {
+        const l = layerOf.get(d);
+        if (l === undefined) {
+          maxDep = -1;
+          break;
+        }
+        if (l > maxDep) maxDep = l;
+      }
+      if (maxDep >= 0) {
+        const next = maxDep + 1;
+        if (layerOf.get(task.runId) !== next) {
+          layerOf.set(task.runId, next);
+          changed = true;
+        }
+      }
+    }
+    if (!changed) break;
+  }
+
+  for (const task of projectTasks) {
+    const deps = (task.dependsOn ?? []).filter((d) => byId.has(d));
+    const allDepsDone = deps.every((d) => {
+      const depTask = byId.get(d);
+      return depTask !== undefined && TERMINAL_DONE.has(depTask.status);
+    });
+    nodes.push({
+      id: task.runId,
+      title: task.title,
+      status: task.status,
+      ready: allDepsDone && !TERMINAL_DONE.has(task.status),
+      layer: layerOf.get(task.runId) ?? 0,
+    });
+  }
+
+  return { nodes, edges, externalDeps: Array.from(externalDeps) };
+}


### PR DESCRIPTION
## Summary

The project view showed plan.md phases and a flat task list, but no dependency relationships. Tasks already carry `dependsOn` (parsed from `meta.json` / `plan.md`), so the dependency structure was available but invisible. This PR renders it as a DAG.

## What's included

1. `src/lib/project-dag.ts`:
   - `buildProjectDag()` — pure function: `nodes` (one per project task: `id` / `title` / `status` / `ready` / `layer`), `edges` (task → dependency), `externalDeps` (referenced but not project tasks). `ready` = a non-completed task whose project-internal deps are all completed (mirrors upstream "next" semantics at task level); external deps assumed satisfied. Iterative layering, cycle-defensive.
   - `layoutProjectDag()` — pure top-down layout (layer rows, left-to-right, width/height/positions) so the renderer stays a thin mapping.
2. `src/lib/project-dag.test.ts` — 11 unit tests (chain, layers, ready, external deps, cross-project filter, empty, cycle defense, layout rows / same-layer / empty).
3. `src/components/dashboard/sections/tasks-section.tsx` — `ProjectDagView`: self-contained SVG renderer (curved dependency edges + status colors + ready highlight + native title tooltip), inserted between the plan preview and the task list; degrades to a hint when the project has no dependencies.

## Data boundary

The DAG is built from `BoardTask` records (independent task `meta.json` / worker history), so TeamHarness MCP projects (tasks have independent `TaskMeta`) render fully; legacy copaw projects (DAG only in `plan.md`) may be partial — acceptable, CoPaw is retired.

## Tests

- `src/lib/project-dag.test.ts`: 11 tests (chain, layers, ready, external deps, cross-project filter, empty, cycle defense, layout rows / same-layer / empty) — all pass
- `tsc --noEmit` clean; `eslint` clean on the new files
- Full suite unchanged vs baseline: 109 pre-existing jsdom component-test failures (e.g. `MessageBubble.test.tsx`), 508 passed (baseline 497 + 11 new)
- Unused-import lint errors in `tasks-section.tsx` (`ChevronDown` / `Select*`) are pre-existing upstream (no CI lint gate)

## Related

- The task DAG data is already available via `GET /api/agentteams/team-tasks/` (`dependsOn`); once the AgentTeams controller API `GET /api/v1/projects/{id}/workflow` (agentteams/AgentTeams#1169) lands, the renderer can switch to the standardized `nodes`/`edges`/`next` payload for richer state (loop, interrupts).

---

## 摘要

项目视图之前只显示 plan.md 阶段和扁平任务列表，看不到任务之间的依赖关系。任务本身已带 `dependsOn`（从 `meta.json` / `plan.md` 解析），依赖结构一直存在只是不可见。本 PR 把它画成 DAG 图。

## 包含内容

1. `src/lib/project-dag.ts`：
   - `buildProjectDag()` — 纯函数：`nodes`（项目内每个任务一个节点：`id` / `title` / `status` / `ready` / `layer`）、`edges`（任务 → 依赖）、`externalDeps`（被引用但不是本项目任务）。`ready` = 非完成态任务且项目内依赖全部 completed（任务级对齐上游 "next" 语义）；外部依赖视为已满足。迭代分层，防循环。
   - `layoutProjectDag()` — 纯函数自上而下布局（分层行、左到右、宽高/坐标），渲染层保持薄映射。
2. `src/lib/project-dag.test.ts` — 11 单元测试（链式/分层/ready/外部依赖/跨项目过滤/空/防循环/布局行/同层横排/空布局）
3. `src/components/dashboard/sections/tasks-section.tsx` — `ProjectDagView`：自绘 SVG 渲染（曲线依赖边 + 状态颜色 + ready 高亮 + 原生 title tooltip），插在执行计划与任务列表之间；项目无依赖时降级为提示

## 数据边界

DAG 基于 `BoardTask` 记录（独立任务 `meta.json` / worker history）构建——TeamHarness MCP 项目（任务有独立 `TaskMeta`）完整渲染；legacy copaw 项目（DAG 只在 `plan.md`）可能不完整——可接受（CoPaw 已退役）。

## 测试

- `src/lib/project-dag.test.ts`：11 测试（链式/分层/ready/外部依赖/跨项目过滤/空/防循环/布局行/同层横排/空布局）全过
- `tsc --noEmit` 干净；新文件 eslint 干净
- 全量测试与基线一致：109 个预存 jsdom 组件测试失败（如 `MessageBubble.test.tsx`），508 passed（基线 497 + 11 新）
- `tasks-section.tsx` 的 unused import lint 错误（`ChevronDown` / `Select*`）是上游预存（无 CI lint gate）

## 关联

任务 DAG 数据已通过 `GET /api/agentteams/team-tasks/`（`dependsOn`）可用；AgentTeams Controller API `GET /api/v1/projects/{id}/workflow`（agentteams/AgentTeams#1169）落地后，渲染器可切换到标准 `nodes`/`edges`/`next` payload，获得更丰富的状态（loop、interrupts）。
