### PR TITLE
feat(projects): proxy AgentTeams controller project/workflow API to dashboard

### DIFF
--- a/src/app/api/agentteams/projects/[id]/pause/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/pause/route.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callPost(
+  projectId: string,
+  controllerStatus: number,
+  controllerBody: unknown,
+  requestBody: string,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), {
+        status: controllerStatus,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.POST(
+    {
+      method: 'POST',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/pause`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+      text: () => Promise.resolve(requestBody),
+    } as never,
+    { params: Promise.resolve({ id: projectId }) },
+  );
+  return response;
+}
+
+describe('POST /api/agentteams/projects/[id]/pause (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('forwards the reason body and returns the refreshed workflow', async () => {
+    const res = await callPost('p1', 200, { project_id: 'p1', status: 'paused' }, '{"reason":"manual stop"}');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/pause',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"reason":"manual stop"}',
+      }),
+    );
+  });
+
+  it('passes through 409 already-paused conflict', async () => {
+    const res = await callPost('p1', 409, { error: 'project is already paused' }, '{}');
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toContain('already paused');
+  });
+
+  it('passes through 403 cross-team forbidden', async () => {
+    const res = await callPost('p1', 403, { error: 'Forbidden' }, '{}');
+    expect(res.status).toBe(403);
+  });
+
+  it('passes through 404 (project not found)', async () => {
+    const res = await callPost('missing', 404, { message: 'project not found' }, '{}');
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.message).toContain('not found');
+  });
+
+  it('encodes the project id in the proxied path', async () => {
+    await callPost('a/b c', 200, { project_id: 'a/b c' }, '{}');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/pause',
+      expect.anything(),
+    );
+  });
+
+  it('forwards team query and drops controllerUrl', async () => {
+    const res = await callPost('p1', 200, { project_id: 'p1' }, '{}', 'team=t1&controllerUrl=http://evil');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/pause?team=t1',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/pause/route.ts
+++ b/src/app/api/agentteams/projects/[id]/pause/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/agentteams/projects/{id}/pause
+//
+// Proxies the AgentTeams controller intervention endpoint
+// (`POST /api/v1/projects/{id}/pause`, agentteams/AgentTeams#1172).
+// The JSON body ({ reason?: string }) is forwarded as-is; `team` is passed
+// as a query param for (team, project_id) identity scoping (#1169), while
+// the internal `controllerUrl` override is dropped.
+//
+// Non-2xx statuses are passed through (409 "project is already paused" /
+// "cannot pause a completed project", 403 cross-team) so the frontend can
+// surface the controller's exact conflict reason. On success the controller
+// returns 200 with the refreshed workflow JSON.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/pause${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { method: 'POST', forwardBody: true },
+  );
+}

--- a/src/app/api/agentteams/projects/[id]/replan/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/replan/route.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callPost(
+  projectId: string,
+  controllerStatus: number,
+  controllerBody: unknown,
+  requestBody: string,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), {
+        status: controllerStatus,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.POST(
+    {
+      method: 'POST',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/replan`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+      text: () => Promise.resolve(requestBody),
+    } as never,
+    { params: Promise.resolve({ id: projectId }) },
+  );
+  return response;
+}
+
+describe('POST /api/agentteams/projects/[id]/replan (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('forwards the tasks body and returns the refreshed workflow', async () => {
+    const res = await callPost(
+      'p1',
+      200,
+      { project_id: 'p1', status: 'active' },
+      '{"tasks":[{"taskId":"t1","title":"A"}]}',
+    );
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/replan',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"tasks":[{"taskId":"t1","title":"A"}]}',
+      }),
+    );
+  });
+
+  it('passes through 400 invalid body', async () => {
+    const res = await callPost('p1', 400, { error: 'invalid request body' }, 'not-json');
+    expect(res.status).toBe(400);
+  });
+
+  it('passes through 409 precondition conflict', async () => {
+    const res = await callPost('p1', 409, { error: 'cannot replan while tasks are running' }, '{"tasks":[]}');
+    expect(res.status).toBe(409);
+  });
+
+  it('passes through 404 (project not found)', async () => {
+    const res = await callPost('missing', 404, { message: 'project not found' }, '{"tasks":[]}');
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.message).toContain('not found');
+  });
+
+  it('encodes the project id in the proxied path', async () => {
+    await callPost('a/b c', 200, { project_id: 'a/b c' }, '{"tasks":[]}');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/replan',
+      expect.anything(),
+    );
+  });
+
+  it('forwards team query and drops controllerUrl', async () => {
+    const res = await callPost('p1', 200, { project_id: 'p1' }, '{"tasks":[]}', 'team=t1&controllerUrl=http://evil');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/replan?team=t1',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/replan/route.ts
+++ b/src/app/api/agentteams/projects/[id]/replan/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/agentteams/projects/{id}/replan
+//
+// Proxies the AgentTeams controller replan endpoint
+// (`POST /api/v1/projects/{id}/replan`, agentteams/AgentTeams#1172).
+// The JSON body ({ tasks: [...] }) is forwarded as-is; the controller
+// validates the new DAG with TeamHarness semantics (duplicate task ids,
+// unknown dependencies and cycles are rejected) and normalizes fields.
+// `team` is forwarded as a query param for (team, project_id) identity
+// scoping (#1169).
+//
+// Non-2xx statuses are passed through (409 plan_type/status/executing-task
+// preconditions, 400 invalid body, 403 cross-team). On success the
+// controller returns 200 with the refreshed workflow JSON.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/replan${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { method: 'POST', forwardBody: true },
+  );
+}

--- a/src/app/api/agentteams/projects/[id]/resume/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/resume/route.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callPost(
+  projectId: string,
+  controllerStatus: number,
+  controllerBody: unknown,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), {
+        status: controllerStatus,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.POST(
+    {
+      method: 'POST',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/resume`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+      text: () => Promise.resolve(''),
+    } as never,
+    { params: Promise.resolve({ id: projectId }) },
+  );
+  return response;
+}
+
+describe('POST /api/agentteams/projects/[id]/resume (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('proxies the resume action and returns the refreshed workflow', async () => {
+    const res = await callPost('p1', 200, { project_id: 'p1', status: 'active' });
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/resume',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('passes through 409 not-paused conflict', async () => {
+    const res = await callPost('p1', 409, { error: 'project is not paused' });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toContain('not paused');
+  });
+
+  it('passes through 403 cross-team forbidden', async () => {
+    const res = await callPost('p1', 403, { message: 'Forbidden' });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes through 404 (project not found)', async () => {
+    const res = await callPost('missing', 404, { message: 'project not found' });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.message).toContain('not found');
+  });
+
+  it('encodes the project id in the proxied path', async () => {
+    await callPost('a/b c', 200, { project_id: 'a/b c' });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/resume',
+      expect.anything(),
+    );
+  });
+
+  it('forwards team query and drops controllerUrl', async () => {
+    const res = await callPost('p1', 200, { project_id: 'p1' }, 'team=t1&controllerUrl=http://evil');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/resume?team=t1',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/resume/route.ts
+++ b/src/app/api/agentteams/projects/[id]/resume/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/agentteams/projects/{id}/resume
+//
+// Proxies the AgentTeams controller intervention endpoint
+// (`POST /api/v1/projects/{id}/resume`, agentteams/AgentTeams#1172).
+// No request body is required; the controller sets the project back to
+// active and notifies the team. `team` is forwarded as a query param for
+// (team, project_id) identity scoping (#1169).
+//
+// Non-2xx statuses are passed through (409 "project is not paused", 403
+// cross-team). On success the controller returns 200 with the refreshed
+// workflow JSON.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/resume${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { method: 'POST', forwardBody: true },
+  );
+}

--- a/src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callGet(
+  projectId: string,
+  taskId: string,
+  controllerStatus: number,
+  controllerBody: BodyInit | null,
+  controllerHeaders: Record<string, string> = { 'content-type': 'application/json' },
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(controllerBody, {
+        status: controllerStatus,
+        headers: controllerHeaders,
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.GET(
+    {
+      method: 'GET',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/tasks/${taskId}/artifact`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+    } as never,
+    { params: Promise.resolve({ id: projectId, taskId }) },
+  );
+  return response;
+}
+
+describe('GET /api/agentteams/projects/[id]/tasks/[taskId]/artifact (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('streams a successful binary artifact with its content-type', async () => {
+    const body = new TextEncoder().encode('PDF-BYTES-123');
+    const res = await callGet('p1', 't1', 200, body, { 'content-type': 'application/pdf' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+    expect(await res.arrayBuffer()).toEqual(body.buffer);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/tasks/t1/artifact',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('passes through content-disposition (RFC 5987 filename)', async () => {
+    const res = await callGet('p1', 't1', 200, 'x', {
+      'content-type': 'application/octet-stream',
+      'content-disposition': "attachment; filename*=UTF-8''%E6%96%B9%E6%A1%88.pdf",
+    });
+    expect(res.headers.get('content-disposition')).toBe(
+      "attachment; filename*=UTF-8''%E6%96%B9%E6%A1%88.pdf",
+    );
+  });
+
+  it('passes through 404 (artifact missing)', async () => {
+    const res = await callGet('p1', 'missing', 404, JSON.stringify({ error: 'artifact not found' }), {
+      'content-type': 'application/json',
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('passes through 400 (invalid deliverable path)', async () => {
+    const res = await callGet('p1', 't1', 400, JSON.stringify({ error: 'invalid path' }), {
+      'content-type': 'application/json',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards ?path= query and drops controllerUrl', async () => {
+    await callGet('p1', 't1', 200, 'x', { 'content-type': 'text/plain' }, 'path=results%2Fout.pdf&controllerUrl=http://evil');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/tasks/t1/artifact?path=results%2Fout.pdf',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('encodes project/task ids in the proxied path', async () => {
+    await callGet('a/b', 't t', 200, 'x', { 'content-type': 'text/plain' });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb/tasks/t%20t/artifact',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.ts
+++ b/src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.ts
@@ -36,6 +36,7 @@ export async function GET(
     path,
     {
       forwardBody: false,
+      stream: true,
       passthroughHeaders: ['content-disposition'],
     },
   );

--- a/src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.ts
+++ b/src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/agentteams/projects/{id}/tasks/{taskId}/artifact
+//
+// Proxies the AgentTeams controller artifact endpoint
+// (`GET /api/v1/projects/{id}/tasks/{taskId}/artifact`, agentteams/AgentTeams#1169
+// O19). Query params are forwarded (notably `?path=` to pick a specific
+// deliverable). The controller performs the path whitelist + existence
+// checks; the proxy just streams the binary response through.
+//
+// Content-Disposition is passed through so RFC 5987-encoded filenames
+// (Chinese names) survive the proxy and the browser names the download
+// correctly. Non-2xx statuses (400 invalid path, 404 artifact missing,
+// 403 cross-team) are passed through for the frontend to distinguish.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; taskId: string }> },
+) {
+  const { id, taskId } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskId)}/artifact${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    {
+      forwardBody: false,
+      passthroughHeaders: ['content-disposition'],
+    },
+  );
+}

--- a/src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callPost(
+  projectId: string,
+  taskId: string,
+  controllerStatus: number,
+  controllerBody: unknown,
+  requestBody: string,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), {
+        status: controllerStatus,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.POST(
+    {
+      method: 'POST',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/tasks/${taskId}/cancel`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+      text: () => Promise.resolve(requestBody),
+    } as never,
+    { params: Promise.resolve({ id: projectId, taskId }) },
+  );
+  return response;
+}
+
+describe('POST /api/agentteams/projects/[id]/tasks/[taskId]/cancel (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('forwards the reason body and returns the refreshed workflow', async () => {
+    const res = await callPost(
+      'p1',
+      't1',
+      200,
+      { project_id: 'p1', status: 'active' },
+      '{"reason":"blocked indefinitely"}',
+    );
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/tasks/t1/cancel',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"reason":"blocked indefinitely"}',
+      }),
+    );
+  });
+
+  it('passes through 400 missing reason', async () => {
+    const res = await callPost('p1', 't1', 400, { message: 'reason is required' }, '{}');
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toContain('reason');
+  });
+
+  it('passes through 404 (task not in project)', async () => {
+    const res = await callPost('p1', 'unknown', 404, { message: 'task not found in project' }, '{"reason":"x"}');
+    expect(res.status).toBe(404);
+  });
+
+  it('passes through 409 terminal task', async () => {
+    const res = await callPost('p1', 't1', 409, { message: 'cannot cancel terminal task: completed' }, '{"reason":"x"}');
+    expect(res.status).toBe(409);
+  });
+
+  it('encodes both ids in the proxied path', async () => {
+    await callPost('a/b c', 't/1', 200, { project_id: 'a/b c' }, '{"reason":"x"}');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/tasks/t%2F1/cancel',
+      expect.anything(),
+    );
+  });
+
+  it('forwards team query and drops controllerUrl', async () => {
+    const res = await callPost('p1', 't1', 200, { project_id: 'p1' }, '{"reason":"x"}', 'team=t1&controllerUrl=http://evil');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/tasks/t1/cancel?team=t1',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.ts
+++ b/src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/agentteams/projects/{id}/tasks/{taskId}/cancel
+//
+// Proxies the AgentTeams controller task-cancellation endpoint
+// (`POST /api/v1/projects/{id}/tasks/{taskId}/cancel`,
+// agentteams/AgentTeams#1172). The JSON body ({ reason, replacementTaskId? })
+// is forwarded as-is; `team` is forwarded as a query param for (team,
+// project_id) identity scoping (#1169).
+//
+// Non-2xx statuses are passed through (400 missing reason, 404 task not in
+// project, 409 terminal task, 403 cross-team) so the frontend can surface
+// the controller's exact reason. On success the controller returns 200 with
+// the refreshed workflow JSON.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; taskId: string }> },
+) {
+  const { id, taskId } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskId)}/cancel${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { method: 'POST', forwardBody: true },
+  );
+}

--- a/src/app/api/agentteams/projects/[id]/workflow/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/workflow/route.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callGet(
+  projectId: string,
+  controllerStatus: number,
+  controllerBody: unknown,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), {
+        status: controllerStatus,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.GET(
+    {
+      method: 'GET',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/workflow`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+    } as never,
+    { params: Promise.resolve({ id: projectId }) },
+  );
+  return response;
+}
+
+describe('GET /api/agentteams/projects/[id]/workflow (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('passes through a successful workflow response', async () => {
+    const res = await callGet('p1', 200, {
+      project_id: 'p1',
+      title: 'A',
+      status: 'active',
+      nodes: [],
+      edges: [],
+      next: [],
+      interrupts: [],
+      values: {},
+    });
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/workflow',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('passes through 404 (project not found) without degrading', async () => {
+    const res = await callGet('missing', 404, { error: 'Not Found' });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toContain('Not Found');
+  });
+
+  it('passes through 403 (cross-team forbidden)', async () => {
+    const res = await callGet('p1', 403, { error: 'Forbidden' });
+    expect(res.status).toBe(403);
+  });
+
+  it('encodes the project id in the proxied path', async () => {
+    await callGet('a/b c', 200, {
+      project_id: 'a/b c',
+      nodes: [],
+      edges: [],
+      next: [],
+      interrupts: [],
+      values: {},
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/workflow',
+      expect.anything(),
+    );
+  });
+
+  it('forwards query params (includeTasks) and drops controllerUrl', async () => {
+    const res = await callGet('p1', 200, {
+      project_id: 'p1',
+      nodes: [],
+      edges: [],
+      next: [],
+      interrupts: [],
+      values: {},
+    }, 'includeTasks=true&controllerUrl=http://evil');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/workflow?includeTasks=true',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('keeps an empty query string when no params are forwarded', async () => {
+    const res = await callGet('p1', 200, {
+      project_id: 'p1',
+      nodes: [],
+      edges: [],
+      next: [],
+      interrupts: [],
+      values: {},
+    }, 'controllerUrl=http://evil');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/workflow',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/workflow/route.ts
+++ b/src/app/api/agentteams/projects/[id]/workflow/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/agentteams/projects/{id}/workflow
+//
+// Proxies the AgentTeams controller workflow endpoint
+// (`GET /api/v1/projects/{id}/workflow`, agentteams/AgentTeams#1169).
+//
+// Query parameters are forwarded to the controller (notably
+// `?includeTasks=true`, which attaches per-task TaskMeta as tasks_detail),
+// except the internal `controllerUrl` override consumed by getControllerUrl.
+//
+// Unlike the list route we pass through non-OK statuses (404 project
+// missing, 403 cross-team) so the frontend can distinguish "project not
+// found" from "endpoint unavailable".
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/workflow${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { forwardBody: false },
+  );
+}

--- a/src/app/api/agentteams/projects/route.test.ts
+++ b/src/app/api/agentteams/projects/route.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callGet(routePath: string, controllerStatus: number, controllerBody: unknown) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), {
+        status: controllerStatus,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+
+  // Import the route fresh so proxy-helper reads the stubbed env.
+  const route = await import('./route');
+  const url = new URL(`http://dashboard.test${routePath}`);
+  const response = await route.GET({
+    method: 'GET',
+    nextUrl: { pathname: url.pathname, searchParams: url.searchParams },
+    headers: new Headers(),
+  } as never);
+  return response;
+}
+
+describe('GET /api/agentteams/projects (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('passes through a successful controller response', async () => {
+    const res = await callGet('/api/agentteams/projects', 200, {
+      projects: [{ project_id: 'p1', title: 'A', status: 'active' }],
+      total: 1,
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.projects).toHaveLength(1);
+    expect(data.degraded).toBeUndefined();
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('degrades to an empty list (200) when the controller API is missing (404)', async () => {
+    const res = await callGet('/api/agentteams/projects', 404, { error: 'Not Found' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.projects).toEqual([]);
+    expect(data.degraded).toBe(true);
+    expect(data.degradedReason).toBe('api-not-deployed');
+    expect(data.error).toContain('Not Found');
+  });
+
+  it('degrades to an empty list (200) on server error, marking controller-error', async () => {
+    const res = await callGet('/api/agentteams/projects', 500, { error: 'boom' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.projects).toEqual([]);
+    expect(data.degraded).toBe(true);
+    expect(data.degradedReason).toBe('controller-error');
+  });
+
+  it('keeps the controller error message in the degraded body', async () => {
+    const res = await callGet('/api/agentteams/projects', 500, { error: 'minio unreachable' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.error).toContain('minio unreachable');
+  });
+
+  it('forwards query params to the controller and drops the internal controllerUrl override', async () => {
+    const res = await callGet('/api/agentteams/projects?team=biz&controllerUrl=http://evil', 200, {
+      projects: [],
+      total: 0,
+    });
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects?team=biz',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});

--- a/src/app/api/agentteams/projects/route.ts
+++ b/src/app/api/agentteams/projects/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/agentteams/projects
+//
+// Proxies the AgentTeams controller project list endpoint
+// (`GET /api/v1/projects`, introduced by agentteams/AgentTeams#1169).
+//
+// Query parameters are forwarded to the controller (notably `?team=`, which
+// the W-PR-1 list endpoint supports), except the internal `controllerUrl`
+// override consumed by getControllerUrl.
+//
+// The controller API may not be deployed yet (W-PR-1 not merged / controller
+// not upgraded). In that case the upstream returns 404 and we degrade to an
+// empty list with an `error` hint so the dashboard board still renders
+// (the existing team-tasks board remains the fallback data source).
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.searchParams;
+  const params = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    params.append(key, value);
+  }
+  const qs = params.toString();
+  const path = `/api/v1/projects${qs ? `?${qs}` : ''}`;
+
+  const res = await proxyToAgentTeams(request, getControllerUrl(request), path, {
+    forwardBody: false,
+  });
+
+  if (res.ok) {
+    return res;
+  }
+
+  const status = res.status;
+  let error = `HTTP ${status}`;
+  try {
+    const body = await res.json();
+    if (body && typeof body === 'object' && 'error' in body) {
+      error = String((body as { error: unknown }).error);
+    }
+  } catch {
+    // non-JSON error body; keep the generic message
+  }
+
+  // Distinguish "API not deployed yet" (404 — W-PR-1 not merged / controller
+  // not upgraded) from "controller endpoint exists but failed" (500+ — e.g.
+  // MinIO unreachable). Both degrade to an empty list so the board still
+  // renders, but the frontend can show a different hint for each.
+  const degradedReason: 'api-not-deployed' | 'controller-error' =
+    status >= 500 ? 'controller-error' : 'api-not-deployed';
+
+  return NextResponse.json(
+    {
+      projects: [],
+      total: 0,
+      error,
+      degraded: true,
+      degradedReason,
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/agentteams/projects/route.ts
+++ b/src/app/api/agentteams/projects/route.ts
@@ -38,8 +38,12 @@ export async function GET(request: NextRequest) {
   let error = `HTTP ${status}`;
   try {
     const body = await res.json();
-    if (body && typeof body === 'object' && 'error' in body) {
-      error = String((body as { error: unknown }).error);
+    // Controller errors use `{ message }` (httputil.ErrorResponse); accept
+    // `{ error }` too for middleware-shaped bodies.
+    if (body && typeof body === 'object') {
+      const b = body as { error?: unknown; message?: unknown };
+      if (typeof b.message === 'string' && b.message) error = b.message;
+      else if (typeof b.error === 'string' && b.error) error = b.error;
     }
   } catch {
     // non-JSON error body; keep the generic message

--- a/src/app/api/agentteams/proxy-helper.test.ts
+++ b/src/app/api/agentteams/proxy-helper.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { NextRequest } from 'next/server';
@@ -68,5 +69,59 @@ describe('proxyToAgentTeams DELETE', () => {
 
     server.removeAllListeners('request');
     server.on('request', originalHandler);
+  });
+});
+
+describe('proxyToAgentTeams passthroughHeaders', () => {
+  async function respondWithHeaders() {
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': "attachment; filename*=UTF-8''%E6%96%B9%E6%A1%88.pdf",
+      });
+      res.end('PDF-BYTES');
+    });
+    const request = new NextRequest('http://localhost/api/agentteams/projects/p1/tasks/t1/artifact', {
+      method: 'GET',
+    });
+    const res = await proxyToAgentTeams(
+      request,
+      controllerUrl,
+      '/api/v1/projects/p1/tasks/t1/artifact',
+      { forwardBody: false },
+    );
+    return res;
+  }
+
+  it('does not forward content-disposition by default (existing behavior)', async () => {
+    const res = await respondWithHeaders();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+    expect(res.headers.get('content-disposition')).toBeNull();
+  });
+
+  it('forwards content-disposition when requested via passthroughHeaders', async () => {
+    server.removeAllListeners('request');
+    server.on('request', (req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': "attachment; filename*=UTF-8''%E6%96%B9%E6%A1%88.pdf",
+      });
+      res.end('PDF-BYTES');
+    });
+    const request = new NextRequest('http://localhost/api/agentteams/projects/p1/tasks/t1/artifact', {
+      method: 'GET',
+    });
+    const res = await proxyToAgentTeams(
+      request,
+      controllerUrl,
+      '/api/v1/projects/p1/tasks/t1/artifact',
+      { forwardBody: false, passthroughHeaders: ['content-disposition'] },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-disposition')).toBe(
+      "attachment; filename*=UTF-8''%E6%96%B9%E6%A1%88.pdf",
+    );
   });
 });

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -82,6 +82,9 @@ export async function proxyToAgentTeams(
     method?: string;
     forwardBody?: boolean;
     contentType?: string;
+    /** Stream the upstream body instead of buffering into memory
+     * (large binary downloads, e.g. artifact files). */
+    stream?: boolean;
     /** Extra response headers to pass through to the client (e.g.
      * 'content-disposition' for binary download routes). Only these are
      * forwarded; everything else is filtered. */
@@ -135,6 +138,22 @@ export async function proxyToAgentTeams(
     // For 204 No Content
     if (res.status === 204) {
       return new NextResponse(null, { status: 204 });
+    }
+
+    if (options.stream && res.body) {
+      // Stream the binary body through without buffering (D15).
+      const responseHeaders = new Headers();
+      const resCT = res.headers.get('content-type');
+      if (resCT) responseHeaders.set('content-type', resCT);
+      for (const name of options.passthroughHeaders ?? []) {
+        const value = res.headers.get(name);
+        if (value) responseHeaders.set(name, value);
+      }
+      responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+      return new NextResponse(res.body, {
+        status: res.status,
+        headers: responseHeaders,
+      });
     }
 
     const data = await res.arrayBuffer();

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -82,6 +82,10 @@ export async function proxyToAgentTeams(
     method?: string;
     forwardBody?: boolean;
     contentType?: string;
+    /** Extra response headers to pass through to the client (e.g.
+     * 'content-disposition' for binary download routes). Only these are
+     * forwarded; everything else is filtered. */
+    passthroughHeaders?: string[];
   } = {}
 ): Promise<NextResponse> {
   const { method = request.method, forwardBody = true, contentType } = options;
@@ -137,6 +141,12 @@ export async function proxyToAgentTeams(
     const responseHeaders = new Headers();
     const resCT = res.headers.get('content-type');
     if (resCT) responseHeaders.set('content-type', resCT);
+    // Pass through any explicitly requested headers (e.g. content-disposition
+    // for artifact downloads so RFC 5987 filenames survive the proxy).
+    for (const name of options.passthroughHeaders ?? []) {
+      const value = res.headers.get(name);
+      if (value) responseHeaders.set(name, value);
+    }
     // API responses should never be cached by the browser; stale cached JSON
     // causes the dashboard to show outdated or empty data after restarts.
     responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');

--- a/src/components/dashboard/agent-teams-dashboard.tsx
+++ b/src/components/dashboard/agent-teams-dashboard.tsx
@@ -59,10 +59,12 @@ const ModelsSection = lazy(() => import('./sections/models-section').then(m => (
 const ChatSection = lazy(() => import('./sections/chat/ChatSection').then(m => ({ default: m.ChatSection })));
 const DocsSection = lazy(() => import('./sections/docs-section').then(m => ({ default: m.DocsSection })));
 const TasksSection = lazy(() => import('./sections/tasks-section').then(m => ({ default: m.TasksSection })));
+const ProjectsSection = lazy(() => import('./sections/projects-section').then(m => ({ default: m.ProjectsSection })));
 
 export const sectionMap: Record<string, React.ComponentType> = {
   overview: OverviewSection,
   tasks: TasksSection,
+  projects: ProjectsSection,
   workers: WorkersSection,
   skills: ResourceCenterSection,
   teams: TeamsSection,

--- a/src/components/dashboard/nav-items.test.ts
+++ b/src/components/dashboard/nav-items.test.ts
@@ -9,6 +9,7 @@ describe('Navigation with groups', () => {
       'overview',
       'chat',
       'tasks',
+      'projects',
       'workers',
       'managers',
       'teams',

--- a/src/components/dashboard/nav-items.ts
+++ b/src/components/dashboard/nav-items.ts
@@ -9,6 +9,7 @@ import {
   Brain,
   Sparkles,
   ListTodo,
+  GitBranch,
   type LucideIcon,
 } from 'lucide-react';
 import { useAgentTeamsStore } from '@/lib/agentteams-store';
@@ -35,6 +36,7 @@ export const navItems: NavItem[] = [
   { id: 'chat', label: '聊天', icon: MessageSquare, group: 'core' },
   // 运行时分组
   { id: 'tasks', label: '任务看板', icon: ListTodo, group: 'runtime', hiddenByFlag: 'taskBoard' },
+  { id: 'projects', label: '项目', icon: GitBranch, group: 'runtime' },
   { id: 'workers', label: 'Workers', icon: Bot, group: 'runtime' },
   { id: 'managers', label: 'Managers', icon: Crown, group: 'runtime' },
   { id: 'teams', label: '团队', icon: Users, group: 'runtime' },

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -1,12 +1,29 @@
 'use client';
 
 import { useState } from 'react';
-import { GitBranch, FolderKanban, CircleAlert, Loader2, RefreshCw } from 'lucide-react';
+import { GitBranch, FolderKanban, CircleAlert, Loader2, RefreshCw, Pause, Play, Map as MapIcon, Ban } from 'lucide-react';
+import { toast } from 'sonner';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
 import { SectionHeader } from '@/components/dashboard/section-header';
-import { useProjects, useProjectWorkflow } from '@/hooks/use-projects';
+import {
+  useProjects,
+  useProjectWorkflow,
+  usePauseProject,
+  useResumeProject,
+  useReplanProject,
+  useCancelProjectTask,
+} from '@/hooks/use-projects';
 import { ApiError } from '@/lib/api-error';
 import {
   getTaskArtifactUrl,
@@ -15,44 +32,177 @@ import {
   type WorkflowTaskDetail,
 } from '@/lib/agentteams-projects-api';
 
-// ----- Status config (mirrors tasks-section colors) -----
+// ----- Status config (mirrors tasks-section colors/labels so the two
+// project views on the dashboard look consistent) -----
 
 const PROJECT_STATUS_COLOR: Record<ProjectStatus, string> = {
-  planning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30',
-  active: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
-  paused: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/30',
-  completed: 'bg-sky-500/10 text-sky-600 dark:text-sky-400 border-sky-500/30',
-  unknown: 'bg-muted text-muted-foreground border',
+  planning: 'bg-slate-500/15 text-slate-300 border-slate-500/30',
+  active: 'bg-violet-500/15 text-violet-300 border-violet-500/30',
+  paused: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  completed: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  unknown: 'bg-muted text-muted-foreground border-border',
+};
+
+// Same Chinese labels as tasks-section's PROJECT_STATUS_LABEL.
+const PROJECT_STATUS_LABEL: Record<ProjectStatus, string> = {
+  planning: '规划中',
+  active: '进行中',
+  paused: '已暂停',
+  completed: '已完成',
+  unknown: '未知',
 };
 
 const NODE_STATUS_COLOR: Record<WorkflowNodeStatus, string> = {
-  pending: 'bg-muted text-muted-foreground border',
-  delegated: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30',
-  'in-progress': 'bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/30',
-  completed: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
-  revision: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30',
-  blocked: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/30',
+  pending: 'text-slate-500 bg-slate-500/10 border-slate-500/30',
+  delegated: 'text-blue-500 bg-blue-500/10 border-blue-500/30',
+  'in-progress': 'text-violet-500 bg-violet-500/10 border-violet-500/30',
+  completed: 'text-emerald-500 bg-emerald-500/10 border-emerald-500/30',
+  revision: 'text-amber-500 bg-amber-500/10 border-amber-500/30',
+  blocked: 'text-red-500 bg-red-500/10 border-red-500/30',
 };
+
+// Mirrors tasks-section column labels (待办/已派发/执行中/已完成/阻塞).
+const NODE_STATUS_LABEL: Record<WorkflowNodeStatus, string> = {
+  pending: '待办',
+  delegated: '已派发',
+  'in-progress': '执行中',
+  completed: '已完成',
+  revision: '需修订',
+  blocked: '阻塞',
+};
+
+/** Normalize a raw TaskMeta status to the frontend enum, mirroring the
+ * controller's normalizeTaskStatus (project_handler.go): planned→pending,
+ * assigned→delegated, in_progress/submitted→in-progress, cancelled→blocked.
+ * tasks_detail and loop tasks carry the RAW status, while workflow nodes are
+ * already normalized. */
+function normalizeNodeStatus(raw?: string): WorkflowNodeStatus {
+  switch (raw) {
+    case 'planned':
+    case '':
+      return 'pending';
+    case 'assigned':
+      return 'delegated';
+    case 'in_progress':
+    case 'submitted':
+      return 'in-progress';
+    case 'completed':
+      return 'completed';
+    case 'revision':
+      return 'revision';
+    case 'blocked':
+    case 'cancelled':
+      return 'blocked';
+    default:
+      return 'pending';
+  }
+}
+
+/** Controller terminal statuses (isTerminalTaskStatus): these tasks cannot
+ * be cancelled (409). cancelled itself stays cancellable but is already
+ * terminal in practice, so hide the button there too. */
+const UNCANCELLABLE_STATUSES = new Set(['completed', 'revision', 'blocked', 'cancelled']);
+
+/** Cancel button for one task row (W-PR-2 POST .../tasks/{taskId}/cancel).
+ * Renders only for non-terminal tasks; opens a reason dialog. */
+function CancelTaskButton({
+  projectId,
+  taskId,
+  teamId,
+}: {
+  projectId: string;
+  taskId: string;
+  teamId?: string;
+}) {
+  const cancelMutation = useCancelProjectTask();
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+
+  const handleCancel = () => {
+    cancelMutation.mutate(
+      // Button is disabled while reason is blank; the controller also
+      // 400s on an empty reason as a second line of defense.
+      { projectId, taskId, teamId, reason: reason.trim() },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          setReason('');
+          toast.success('任务已取消', { description: '团队已收到取消通知' });
+        },
+        onError: (err) => toastMutationError('取消任务', err),
+      },
+    );
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={cancelMutation.isPending}
+        className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border border-red-500/30 bg-red-500/5 text-red-700 dark:text-red-400 hover:bg-red-500/15 transition-colors disabled:opacity-50"
+        title="取消任务"
+      >
+        <Ban className="h-3 w-3" />
+        取消
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>取消任务</DialogTitle>
+            <DialogDescription>
+              任务将标记为 cancelled，团队会收到取消通知。原因必填。
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="取消原因（必填）"
+            rows={3}
+            className="text-sm"
+          />
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+              关闭
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleCancel}
+              disabled={cancelMutation.isPending || !reason.trim()}
+            >
+              {cancelMutation.isPending && <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />}
+              确认取消
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
 
 /** One task's TaskMeta row: status/assignee/result + artifact download
  *  links (result_path + each deliverable, via O19 proxy). */
 function TaskDetailRow({
   task,
   projectId,
+  teamId,
 }: {
   task: WorkflowTaskDetail;
   projectId: string;
+  teamId?: string;
 }) {
   const deliverables = Array.isArray(task.deliverables)
     ? task.deliverables.filter((d): d is string => typeof d === 'string')
     : [];
+  const cancellable =
+    !!task.status && !UNCANCELLABLE_STATUSES.has(task.status);
   return (
     <div className="rounded-lg border bg-background/40 p-2 text-xs">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="font-mono text-[10px] text-muted-foreground">{task.task_id}</span>
         {task.status && (
-          <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[task.status as WorkflowNodeStatus] ?? ''}`}>
-            {task.status}
+          <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[normalizeNodeStatus(task.status)]}`}>
+            {NODE_STATUS_LABEL[normalizeNodeStatus(task.status)]}
           </Badge>
         )}
         {task.assigned_to && (
@@ -65,6 +215,9 @@ function TaskDetailRow({
           <span className="text-muted-foreground truncate max-w-[300px]" title={task.summary}>
             {task.summary}
           </span>
+        )}
+        {cancellable && (
+          <CancelTaskButton projectId={projectId} taskId={task.task_id} teamId={teamId} />
         )}
       </div>
       {(task.result_path || deliverables.length > 0) && (
@@ -105,9 +258,22 @@ function ArtifactLink({ href, label }: { href: string; label: string }) {
 function ProjectStatusBadge({ status }: { status: ProjectStatus }) {
   return (
     <Badge className={`text-[10px] gap-1 border ${PROJECT_STATUS_COLOR[status] ?? PROJECT_STATUS_COLOR.unknown}`}>
-      {status}
+      {PROJECT_STATUS_LABEL[status] ?? status}
     </Badge>
   );
+}
+
+/** Surface a project mutation failure with the controller's exact reason
+ * (ApiError carries the upstream status + error string, e.g. 409 "project
+ * is already paused"). */
+function toastMutationError(action: string, error: unknown) {
+  if (error instanceof ApiError) {
+    toast.error(`项目${action}失败（HTTP ${error.status}）`, { description: error.message });
+  } else {
+    toast.error(`项目${action}失败`, {
+      description: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 // ----- Degraded banner (consumes degradedReason from the proxy) -----
@@ -125,7 +291,7 @@ function DegradedBanner({
   const message =
     degradedReason === 'controller-error'
       ? 'Controller 端点存在但调用失败（可能 MinIO 不可达）'
-      : 'Controller 项目 API 未部署（等待 AgentTeams #1169 合并）';
+      : 'Controller 项目 API 不可用（Controller 未升级到含项目 API 的版本）';
   return (
     <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-amber-700 dark:text-amber-400 flex items-start gap-2">
       <CircleAlert className="h-4 w-4 mt-0.5 shrink-0" />
@@ -151,6 +317,102 @@ function WorkflowDetail({
     projectId,
     teamId,
   );
+  const pauseMutation = usePauseProject();
+  const resumeMutation = useResumeProject();
+  const replanMutation = useReplanProject();
+
+  // Pause dialog (reason) + replan dialog (JSON tasks) local state.
+  const [pauseOpen, setPauseOpen] = useState(false);
+  const [pauseReason, setPauseReason] = useState('');
+  const [replanOpen, setReplanOpen] = useState(false);
+  const [replanText, setReplanText] = useState('');
+
+  const mutationTeamId = teamId ?? wf?.team_id;
+
+  const handlePause = () => {
+    pauseMutation.mutate(
+      { projectId, teamId: mutationTeamId, reason: pauseReason.trim() || undefined },
+      {
+        onSuccess: () => {
+          setPauseOpen(false);
+          setPauseReason('');
+          toast.success('项目已暂停', { description: '团队已收到暂停通知' });
+        },
+        onError: (err) => toastMutationError('暂停', err),
+      },
+    );
+  };
+
+  const handleResume = () => {
+    resumeMutation.mutate(
+      { projectId, teamId: mutationTeamId },
+      {
+        onSuccess: () => toast.success('项目已恢复', { description: '任务继续执行' }),
+        onError: (err) => toastMutationError('恢复', err),
+      },
+    );
+  };
+
+  const handleReplan = () => {
+    let tasks: unknown[];
+    try {
+      const parsed = JSON.parse(replanText.trim());
+      if (!Array.isArray(parsed)) {
+        throw new Error('必须是 tasks 数组（JSON）');
+      }
+      tasks = parsed;
+    } catch (parseErr) {
+      toast.error('JSON 解析失败', {
+        description: parseErr instanceof Error ? parseErr.message : String(parseErr),
+      });
+      return;
+    }
+    replanMutation.mutate(
+      { projectId, teamId: mutationTeamId, tasks },
+      {
+        onSuccess: () => {
+          setReplanOpen(false);
+          setReplanText('');
+          toast.success('项目已重规划', { description: '新 DAG 已生效' });
+        },
+        onError: (err) => toastMutationError('重规划', err),
+      },
+    );
+  };
+
+  const openReplanDialog = () => {
+    // Seed the editor with the current graph so adjustments are easy.
+    // tasks_detail has no depends_on field — rebuild dependencies from the
+    // workflow edges (edge source -> target means target depends on source)
+    // so submitting the seed verbatim preserves the original DAG.
+    const dependsOf = new Map<string, string[]>();
+    for (const edge of wf?.edges ?? []) {
+      const list = dependsOf.get(edge.target) ?? [];
+      list.push(edge.source);
+      dependsOf.set(edge.target, list);
+    }
+    const current = (wf?.tasks_detail ?? []).map((t) => ({
+      taskId: t.task_id,
+      title: t.summary ?? t.task_id,
+      ...(t.assigned_to ? { assignedTo: t.assigned_to } : {}),
+      // status deliberately omitted: the controller preserves the previous
+      // status when a task id already exists (and defaults to planned) —
+      // an explicit status here would override in-flight/completed states
+      // and pollute the new plan.
+      ...((dependsOf.get(t.task_id)?.length ?? 0) > 0
+        ? { dependsOn: dependsOf.get(t.task_id) }
+        : {}),
+    }));
+    setReplanText(JSON.stringify(current, null, 2));
+    setReplanOpen(true);
+  };
+
+  const resumeInterrupt = wf?.interrupts.find(
+    (it) => it.action_request?.action === 'resume' && it.config?.allow_accept,
+  );
+
+  const canPause = wf && (wf.status === 'active' || wf.status === 'planning');
+  const canReplan = wf && wf.status === 'active' && (wf.plan_type ?? 'dag') === 'dag';
 
   if (isLoading) {
     return (
@@ -193,10 +455,101 @@ function WorkflowDetail({
           {wf.title}
           <ProjectStatusBadge status={wf.status} />
         </h3>
-        <Button variant="ghost" size="sm" onClick={() => refetch()} disabled={isRefetching}>
-          <RefreshCw className={`h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
-        </Button>
+        <div className="flex items-center gap-1">
+          {canPause && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPauseOpen(true)}
+              disabled={pauseMutation.isPending}
+              className="text-xs"
+            >
+              <Pause className="h-3.5 w-3.5 mr-1" />
+              暂停
+            </Button>
+          )}
+          {canReplan && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={openReplanDialog}
+              disabled={replanMutation.isPending}
+              className="text-xs"
+            >
+              <MapIcon className="h-3.5 w-3.5 mr-1" />
+              重规划
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={() => refetch()} disabled={isRefetching}>
+            <RefreshCw className={`h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
       </div>
+
+      {/* Pause dialog: optional reason (W-PR-2 POST .../pause) */}
+      <Dialog open={pauseOpen} onOpenChange={setPauseOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>暂停项目</DialogTitle>
+            <DialogDescription>
+              暂停后任务停止派发，团队会收到暂停通知。可在中断卡处随时恢复。
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={pauseReason}
+            onChange={(e) => setPauseReason(e.target.value)}
+            placeholder="暂停原因（可选，将通知团队）"
+            rows={3}
+            className="text-sm"
+          />
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setPauseOpen(false)}>
+              取消
+            </Button>
+            <Button
+              size="sm"
+              onClick={handlePause}
+              disabled={pauseMutation.isPending}
+            >
+              {pauseMutation.isPending && <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />}
+              确认暂停
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Replan dialog: JSON tasks payload (W-PR-2 POST .../replan) */}
+      <Dialog open={replanOpen} onOpenChange={setReplanOpen}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>重规划 DAG</DialogTitle>
+            <DialogDescription>
+              粘贴新任务图（tasks 数组：taskId/title/assignedTo/dependsOn/status）。
+              Controller 校验重复任务、未知依赖与环。有任务执行中时会被 409 拒绝。
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={replanText}
+            onChange={(e) => setReplanText(e.target.value)}
+            placeholder='[{"taskId":"t1","title":"任务一","dependsOn":[]}]'
+            rows={10}
+            className="font-mono text-xs"
+          />
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setReplanOpen(false)}>
+              取消
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleReplan}
+              disabled={replanMutation.isPending}
+            >
+              {replanMutation.isPending && <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />}
+              提交重规划
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {wf.team_id && (
         <p className="text-xs text-muted-foreground">
@@ -210,6 +563,11 @@ function WorkflowDetail({
       {wf.interrupts.length > 0 && (
         <div className="space-y-2">
           <p className="text-xs font-semibold text-muted-foreground">中断</p>
+          {wf.pause_reason && (
+            <p className="text-xs text-orange-700 dark:text-orange-400">
+              暂停原因：{wf.pause_reason}
+            </p>
+          )}
           {wf.interrupts.map((it) => (
             <div
               key={it.id}
@@ -225,6 +583,21 @@ function WorkflowDetail({
                   action: {it.action_request.action}
                   {it.config?.allow_accept ? ' · 可接受(恢复)' : ''}
                 </p>
+              )}
+              {it === resumeInterrupt && (
+                <Button
+                  size="sm"
+                  className="mt-1.5 text-xs"
+                  onClick={handleResume}
+                  disabled={resumeMutation.isPending}
+                >
+                  {resumeMutation.isPending ? (
+                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                  ) : (
+                    <Play className="h-3.5 w-3.5 mr-1" />
+                  )}
+                  恢复执行
+                </Button>
               )}
             </div>
           ))}
@@ -262,7 +635,11 @@ function WorkflowDetail({
                   <span className="font-mono text-[10px] text-muted-foreground">{t.task_id}</span>
                   <span className="truncate">{t.title}</span>
                   {t.assigned_to && <span className="text-[10px] text-muted-foreground">{t.assigned_to}</span>}
-                  {t.status && <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[t.status as WorkflowNodeStatus] ?? ''}`}>{t.status}</Badge>}
+                  {t.status && (
+                    <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[normalizeNodeStatus(t.status)]}`}>
+                      {NODE_STATUS_LABEL[normalizeNodeStatus(t.status)]}
+                    </Badge>
+                  )}
                 </div>
               ))}
             </div>
@@ -299,7 +676,7 @@ function WorkflowDetail({
           <div className="flex flex-wrap gap-1.5">
             {statuses.map(([status, count]) => (
               <Badge key={status} className={`text-[10px] border ${NODE_STATUS_COLOR[status as WorkflowNodeStatus] ?? ''}`}>
-                {status}: {count}
+                {NODE_STATUS_LABEL[status as WorkflowNodeStatus] ?? status}: {count}
               </Badge>
             ))}
           </div>
@@ -318,6 +695,7 @@ function WorkflowDetail({
                 key={t.task_id}
                 task={t}
                 projectId={wf.project_id}
+                teamId={mutationTeamId}
               />
             ))}
           </div>
@@ -339,7 +717,7 @@ function WorkflowDetail({
               <div className="flex items-center gap-1.5 shrink-0">
                 {n.assignee && <span className="text-[10px] text-muted-foreground">{n.assignee}</span>}
                 <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[n.status] ?? ''}`}>
-                  {n.status}
+                  {NODE_STATUS_LABEL[n.status] ?? n.status}
                 </Badge>
               </div>
             </div>

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { SectionHeader } from '@/components/dashboard/section-header';
 import { useProjects, useProjectWorkflow } from '@/hooks/use-projects';
+import { ApiError } from '@/lib/api-error';
 import type { ProjectStatus, WorkflowNodeStatus } from '@/lib/agentteams-projects-api';
 
 // ----- Status config (mirrors tasks-section colors) -----
@@ -73,7 +74,7 @@ function WorkflowDetail({
   projectId: string;
   teamId?: string;
 }) {
-  const { data: wf, isLoading, isError, refetch, isRefetching } = useProjectWorkflow(
+  const { data: wf, isLoading, isError, error, refetch, isRefetching } = useProjectWorkflow(
     projectId,
     teamId,
   );
@@ -87,9 +88,23 @@ function WorkflowDetail({
   }
 
   if (isError || !wf) {
+    // 409 = 同一 project_id 在多个团队存在（#1169 (team, project_id) 身份），
+    // 单独提示而非笼统的"不可用"。
+    const ambiguous =
+      error instanceof ApiError && error.status === 409;
     return (
-      <div className="text-center py-10 text-muted-foreground text-sm">
-        无法加载项目工作流（项目不存在或 API 不可用）
+      <div className="text-center py-10 text-muted-foreground text-sm space-y-1">
+        {ambiguous ? (
+          <>
+            <p>该项目 id 在多个团队下存在（Controller 返回 409）。</p>
+            <p className="text-xs">
+              请从左侧选择带正确团队标签的条目重试；若列表只显示一条，请在
+              Controller 侧核对 project meta 的 team 归属。
+            </p>
+          </>
+        ) : (
+          <p>无法加载项目工作流（项目不存在或 API 不可用）</p>
+        )}
       </div>
     );
   }

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -66,8 +66,17 @@ function DegradedBanner({
 
 // ----- Workflow detail panel -----
 
-function WorkflowDetail({ projectId }: { projectId: string }) {
-  const { data: wf, isLoading, isError, refetch, isRefetching } = useProjectWorkflow(projectId);
+function WorkflowDetail({
+  projectId,
+  teamId,
+}: {
+  projectId: string;
+  teamId?: string;
+}) {
+  const { data: wf, isLoading, isError, refetch, isRefetching } = useProjectWorkflow(
+    projectId,
+    teamId,
+  );
 
   if (isLoading) {
     return (
@@ -205,10 +214,17 @@ function WorkflowDetail({ projectId }: { projectId: string }) {
 
 export function ProjectsSection() {
   const { data, isLoading, isError, refetch, isRefetching } = useProjects();
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // (team, project_id) composite selection — the same project id can exist
+  // under two teams (#1169 identity scoping).
+  const [selectedKey, setSelectedKey] = useState<{ id: string; team?: string } | null>(null);
 
   const projects = data?.projects ?? [];
-  const selected = projects.find((p) => p.project_id === selectedId) ?? null;
+  const selected =
+    projects.find(
+      (p) =>
+        p.project_id === selectedKey?.id &&
+        (p.team_id ?? '') === (selectedKey?.team ?? ''),
+    ) ?? null;
 
   return (
     <div className="space-y-4">
@@ -255,10 +271,11 @@ export function ProjectsSection() {
               </p>
               {projects.map((p) => (
                 <button
-                  key={p.project_id}
-                  onClick={() => setSelectedId(p.project_id)}
+                  key={`${p.team_id ?? ''}:${p.project_id}`}
+                  onClick={() => setSelectedKey({ id: p.project_id, team: p.team_id })}
                   className={`w-full text-left rounded-lg border p-2.5 text-xs transition-colors ${
-                    selected?.project_id === p.project_id
+                    selected?.project_id === p.project_id &&
+                    (selected?.team_id ?? '') === (p.team_id ?? '')
                       ? 'border-primary/50 bg-primary/5'
                       : 'border-transparent hover:bg-muted/50'
                   }`}
@@ -283,7 +300,7 @@ export function ProjectsSection() {
           <Card className="glass-card lg:col-span-2">
             <CardContent className="p-4">
               {selected ? (
-                <WorkflowDetail projectId={selected.project_id} />
+                <WorkflowDetail projectId={selected.project_id} teamId={selected.team_id} />
               ) : (
                 <p className="text-center py-10 text-muted-foreground text-sm">
                   选择左侧项目查看工作流

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -8,7 +8,12 @@ import { Button } from '@/components/ui/button';
 import { SectionHeader } from '@/components/dashboard/section-header';
 import { useProjects, useProjectWorkflow } from '@/hooks/use-projects';
 import { ApiError } from '@/lib/api-error';
-import type { ProjectStatus, WorkflowNodeStatus } from '@/lib/agentteams-projects-api';
+import {
+  getTaskArtifactUrl,
+  type ProjectStatus,
+  type WorkflowNodeStatus,
+  type WorkflowTaskDetail,
+} from '@/lib/agentteams-projects-api';
 
 // ----- Status config (mirrors tasks-section colors) -----
 
@@ -28,6 +33,74 @@ const NODE_STATUS_COLOR: Record<WorkflowNodeStatus, string> = {
   revision: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30',
   blocked: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/30',
 };
+
+/** One task's TaskMeta row: status/assignee/result + artifact download
+ *  links (result_path + each deliverable, via O19 proxy). */
+function TaskDetailRow({
+  task,
+  projectId,
+}: {
+  task: WorkflowTaskDetail;
+  projectId: string;
+}) {
+  const deliverables = Array.isArray(task.deliverables)
+    ? task.deliverables.filter((d): d is string => typeof d === 'string')
+    : [];
+  return (
+    <div className="rounded-lg border bg-background/40 p-2 text-xs">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="font-mono text-[10px] text-muted-foreground">{task.task_id}</span>
+        {task.status && (
+          <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[task.status as WorkflowNodeStatus] ?? ''}`}>
+            {task.status}
+          </Badge>
+        )}
+        {task.assigned_to && (
+          <span className="text-[10px] text-muted-foreground">{task.assigned_to}</span>
+        )}
+        {task.result_status && (
+          <span className="text-[10px] text-muted-foreground">验收：{task.result_status}</span>
+        )}
+        {task.summary && (
+          <span className="text-muted-foreground truncate max-w-[300px]" title={task.summary}>
+            {task.summary}
+          </span>
+        )}
+      </div>
+      {(task.result_path || deliverables.length > 0) && (
+        <div className="flex items-center gap-2 flex-wrap pt-1">
+          <span className="text-[10px] text-muted-foreground shrink-0">产物：</span>
+          {task.result_path ? (
+            <ArtifactLink
+              href={getTaskArtifactUrl(projectId, task.task_id)}
+              label="结果文件"
+            />
+          ) : null}
+          {deliverables.map((d) => (
+            <ArtifactLink
+              key={d}
+              href={getTaskArtifactUrl(projectId, task.task_id, d)}
+              label={d.split('/').pop() || d}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ArtifactLink({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border border-amber-500/30 bg-amber-500/5 text-amber-700 dark:text-amber-400 hover:bg-amber-500/15 transition-colors"
+      title={href}
+    >
+      <FolderKanban className="h-3 w-3" />
+      {label}
+    </a>
+  );
+}
 
 function ProjectStatusBadge({ status }: { status: ProjectStatus }) {
   return (
@@ -182,6 +255,18 @@ function WorkflowDetail({
               </div>
             )}
           {wf.loop.goal && <p className="text-muted-foreground pt-1">{wf.loop.goal}</p>}
+          {wf.loop.tasks && wf.loop.tasks.length > 0 && (
+            <div className="pt-2 space-y-1">
+              {wf.loop.tasks.map((t) => (
+                <div key={t.task_id} className="flex items-center gap-2 text-xs">
+                  <span className="font-mono text-[10px] text-muted-foreground">{t.task_id}</span>
+                  <span className="truncate">{t.title}</span>
+                  {t.assigned_to && <span className="text-[10px] text-muted-foreground">{t.assigned_to}</span>}
+                  {t.status && <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[t.status as WorkflowNodeStatus] ?? ''}`}>{t.status}</Badge>}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
@@ -194,6 +279,24 @@ function WorkflowDetail({
               <Badge key={status} className={`text-[10px] border ${NODE_STATUS_COLOR[status as WorkflowNodeStatus] ?? ''}`}>
                 {status}: {count}
               </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Task details (#1169 includeTasks → tasks_detail + O19 artifact download) */}
+      {wf.tasks_detail && wf.tasks_detail.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1.5">
+            任务详情（{wf.tasks_detail.length}）
+          </p>
+          <div className="space-y-1.5">
+            {wf.tasks_detail.map((t) => (
+              <TaskDetailRow
+                key={t.task_id}
+                task={t}
+                projectId={wf.project_id}
+              />
             ))}
           </div>
         </div>

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -243,15 +243,53 @@ function TaskDetailRow({
 }
 
 function ArtifactLink({ href, label }: { href: string; label: string }) {
+  const [downloading, setDownloading] = useState(false);
+  const handleDownload = async () => {
+    setDownloading(true);
+    try {
+      const res = await fetch(href, { cache: 'no-store' });
+      if (!res.ok) {
+        // The proxy passes through the controller's JSON error body — surface
+        // the real reason instead of letting the browser render it as content.
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: string; message?: string };
+          if (typeof body?.message === 'string' && body.message) detail = body.message;
+          else if (typeof body?.error === 'string' && body.error) detail = body.error;
+        } catch {
+          // non-JSON error body; keep the status
+        }
+        toast.error('产物下载失败', { description: detail });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = label;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error('产物下载失败', {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setDownloading(false);
+    }
+  };
   return (
-    <a
-      href={href}
-      className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border border-amber-500/30 bg-amber-500/5 text-amber-700 dark:text-amber-400 hover:bg-amber-500/15 transition-colors"
+    <button
+      type="button"
+      onClick={() => void handleDownload()}
+      disabled={downloading}
+      className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border border-amber-500/30 bg-amber-500/5 text-amber-700 dark:text-amber-400 hover:bg-amber-500/15 transition-colors disabled:opacity-50"
       title={href}
     >
       <FolderKanban className="h-3 w-3" />
       {label}
-    </a>
+    </button>
   );
 }
 

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useState } from 'react';
+import { GitBranch, FolderKanban, CircleAlert, Loader2, RefreshCw } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { SectionHeader } from '@/components/dashboard/section-header';
+import { useProjects, useProjectWorkflow } from '@/hooks/use-projects';
+import type { ProjectStatus, WorkflowNodeStatus } from '@/lib/agentteams-projects-api';
+
+// ----- Status config (mirrors tasks-section colors) -----
+
+const PROJECT_STATUS_COLOR: Record<ProjectStatus, string> = {
+  planning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30',
+  active: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
+  paused: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/30',
+  completed: 'bg-sky-500/10 text-sky-600 dark:text-sky-400 border-sky-500/30',
+  unknown: 'bg-muted text-muted-foreground border',
+};
+
+const NODE_STATUS_COLOR: Record<WorkflowNodeStatus, string> = {
+  pending: 'bg-muted text-muted-foreground border',
+  delegated: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30',
+  'in-progress': 'bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/30',
+  completed: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
+  revision: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30',
+  blocked: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/30',
+};
+
+function ProjectStatusBadge({ status }: { status: ProjectStatus }) {
+  return (
+    <Badge className={`text-[10px] gap-1 border ${PROJECT_STATUS_COLOR[status] ?? PROJECT_STATUS_COLOR.unknown}`}>
+      {status}
+    </Badge>
+  );
+}
+
+// ----- Degraded banner (consumes degradedReason from the proxy) -----
+
+function DegradedBanner({
+  degraded,
+  degradedReason,
+  error,
+}: {
+  degraded?: boolean;
+  degradedReason?: 'api-not-deployed' | 'controller-error';
+  error?: string;
+}) {
+  if (!degraded) return null;
+  const message =
+    degradedReason === 'controller-error'
+      ? 'Controller 端点存在但调用失败（可能 MinIO 不可达）'
+      : 'Controller 项目 API 未部署（等待 AgentTeams #1169 合并）';
+  return (
+    <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-amber-700 dark:text-amber-400 flex items-start gap-2">
+      <CircleAlert className="h-4 w-4 mt-0.5 shrink-0" />
+      <div>
+        <p className="font-medium">项目 API 降级</p>
+        <p className="text-xs opacity-80">{message}</p>
+        {error && <p className="text-xs opacity-60 mt-1 font-mono">{error}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ----- Workflow detail panel -----
+
+function WorkflowDetail({ projectId }: { projectId: string }) {
+  const { data: wf, isLoading, isError, refetch, isRefetching } = useProjectWorkflow(projectId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10 text-muted-foreground text-sm gap-2">
+        <Loader2 className="h-4 w-4 animate-spin" /> 加载工作流…
+      </div>
+    );
+  }
+
+  if (isError || !wf) {
+    return (
+      <div className="text-center py-10 text-muted-foreground text-sm">
+        无法加载项目工作流（项目不存在或 API 不可用）
+      </div>
+    );
+  }
+
+  const taskCount = wf.values?.task_count ?? {};
+  const statuses = Object.entries(taskCount);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold flex items-center gap-1.5">
+          <GitBranch className="h-4 w-4" />
+          {wf.title}
+          <ProjectStatusBadge status={wf.status} />
+        </h3>
+        <Button variant="ghost" size="sm" onClick={() => refetch()} disabled={isRefetching}>
+          <RefreshCw className={`h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
+        </Button>
+      </div>
+
+      {wf.team_id && (
+        <p className="text-xs text-muted-foreground">
+          {wf.team_id ? `团队 ${wf.team_id} · ` : ''}
+          {wf.mode ?? 'project'} · {wf.plan_type ?? 'dag'}
+          {wf.source ? ` · 来源 ${wf.source}` : ''}
+        </p>
+      )}
+
+      {/* Interrupts (paused project surfaces action_request resume) */}
+      {wf.interrupts.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-muted-foreground">中断</p>
+          {wf.interrupts.map((it) => (
+            <div
+              key={it.id}
+              className="rounded-lg border border-orange-500/30 bg-orange-500/5 p-2.5 text-xs"
+            >
+              <p className="font-medium text-orange-700 dark:text-orange-400 flex items-center gap-1.5">
+                <CircleAlert className="h-3.5 w-3.5" />
+                {it.value}
+                {it.description && <span className="font-normal opacity-75">— {it.description}</span>}
+              </p>
+              {it.action_request && (
+                <p className="text-[10px] text-muted-foreground mt-1 font-mono">
+                  action: {it.action_request.action}
+                  {it.config?.allow_accept ? ' · 可接受(恢复)' : ''}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Loop progress */}
+      {wf.loop && (
+        <div className="rounded-lg border p-2.5 text-xs space-y-1">
+          <p className="font-semibold text-muted-foreground">
+            Loop 进度
+            {wf.loop.status && <span className="ml-2 font-normal opacity-75">{wf.loop.status}</span>}
+          </p>
+          {typeof wf.loop.current_iteration === 'number' &&
+            typeof wf.loop.max_iterations === 'number' && (
+              <div className="flex items-center gap-2">
+                <div className="h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full bg-violet-500/70"
+                    style={{
+                      width: `${Math.min(100, (wf.loop.current_iteration / Math.max(1, wf.loop.max_iterations)) * 100)}%`,
+                    }}
+                  />
+                </div>
+                <span className="text-[10px] text-muted-foreground">
+                  {wf.loop.current_iteration}/{wf.loop.max_iterations}
+                </span>
+              </div>
+            )}
+          {wf.loop.goal && <p className="text-muted-foreground pt-1">{wf.loop.goal}</p>}
+        </div>
+      )}
+
+      {/* Task count distribution */}
+      {statuses.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1.5">任务分布</p>
+          <div className="flex flex-wrap gap-1.5">
+            {statuses.map(([status, count]) => (
+              <Badge key={status} className={`text-[10px] border ${NODE_STATUS_COLOR[status as WorkflowNodeStatus] ?? ''}`}>
+                {status}: {count}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Nodes */}
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground mb-1.5">
+          节点（{wf.nodes.length}）
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-1.5">
+          {wf.nodes.map((n) => (
+            <div key={n.id} className="rounded-lg border bg-background/40 p-2 text-xs flex items-center justify-between gap-2">
+              <div className="min-w-0">
+                <p className="truncate font-medium">{n.name}</p>
+                <p className="text-[10px] text-muted-foreground font-mono truncate">{n.id}</p>
+              </div>
+              <div className="flex items-center gap-1.5 shrink-0">
+                {n.assignee && <span className="text-[10px] text-muted-foreground">{n.assignee}</span>}
+                <Badge className={`text-[10px] border ${NODE_STATUS_COLOR[n.status] ?? ''}`}>
+                  {n.status}
+                </Badge>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ----- Main section -----
+
+export function ProjectsSection() {
+  const { data, isLoading, isError, refetch, isRefetching } = useProjects();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const projects = data?.projects ?? [];
+  const selected = projects.find((p) => p.project_id === selectedId) ?? null;
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader
+        title="项目"
+        description="AgentTeams 项目 API（#1169）— 标准项目视图"
+        isLive
+        onRefresh={() => refetch()}
+        isRefreshing={isRefetching}
+      />
+
+      <DegradedBanner
+        degraded={data?.degraded}
+        degradedReason={data?.degradedReason}
+        error={data?.error}
+      />
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-10 text-muted-foreground text-sm gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" /> 加载项目…
+        </div>
+      )}
+
+      {isError && !data && (
+        <div className="text-center py-10 text-muted-foreground text-sm">
+          无法连接项目 API（网络错误或代理不可用）
+        </div>
+      )}
+
+      {!isLoading && !isError && projects.length === 0 && !data?.degraded && (
+        <div className="text-center py-10 text-muted-foreground text-sm">
+          暂无项目——通过 TeamHarness projectflow 创建的项目会显示在这里
+        </div>
+      )}
+
+      {projects.length > 0 && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Project list */}
+          <Card className="glass-card lg:col-span-1">
+            <CardContent className="p-3 space-y-1.5">
+              <p className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1.5">
+                <FolderKanban className="h-3.5 w-3.5" />
+                项目列表（{projects.length}）
+              </p>
+              {projects.map((p) => (
+                <button
+                  key={p.project_id}
+                  onClick={() => setSelectedId(p.project_id)}
+                  className={`w-full text-left rounded-lg border p-2.5 text-xs transition-colors ${
+                    selected?.project_id === p.project_id
+                      ? 'border-primary/50 bg-primary/5'
+                      : 'border-transparent hover:bg-muted/50'
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium truncate">{p.title}</span>
+                    <ProjectStatusBadge status={p.status} />
+                  </div>
+                  <p className="text-[10px] text-muted-foreground font-mono mt-0.5 truncate">
+                    {p.project_id}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                    {p.team_id ? `团队 ${p.team_id} · ` : ''}
+                    {p.plan_type ?? 'dag'} · {p.mode ?? 'project'}
+                  </p>
+                </button>
+              ))}
+            </CardContent>
+          </Card>
+
+          {/* Workflow detail */}
+          <Card className="glass-card lg:col-span-2">
+            <CardContent className="p-4">
+              {selected ? (
+                <WorkflowDetail projectId={selected.project_id} />
+              ) : (
+                <p className="text-center py-10 text-muted-foreground text-sm">
+                  选择左侧项目查看工作流
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -270,6 +270,28 @@ function WorkflowDetail({
         </div>
       )}
 
+      {/* Next runnable tasks (W-PR-1 next: 依赖全完成、当前可执行) */}
+      {wf.next.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-muted-foreground mb-1.5">
+            下一步（{wf.next.length}）
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {wf.next.map((taskId) => {
+              const node = wf.nodes.find((n) => n.id === taskId);
+              return (
+                <Badge
+                  key={taskId}
+                  className="text-[10px] border border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                >
+                  {node?.name ?? taskId}
+                </Badge>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Task count distribution */}
       {statuses.length > 0 && (
         <div>

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -22,10 +22,14 @@ export function useProjects() {
  * dashboard proxy (`GET /api/agentteams/projects/{id}/workflow?includeTasks=true`).
  * Disabled until a project id is selected.
  */
-export function useProjectWorkflow(projectId: string | null) {
+export function useProjectWorkflow(projectId: string | null, teamId?: string) {
   return useQuery({
-    queryKey: ['agentteams-project-workflow', projectId ?? 'none'],
-    queryFn: () => getProjectWorkflow(projectId as string, { includeTasks: true }),
+    queryKey: ['agentteams-project-workflow', teamId ?? 'any', projectId ?? 'none'],
+    queryFn: () =>
+      getProjectWorkflow(projectId as string, {
+        includeTasks: true,
+        teamId,
+      }),
     enabled: !!projectId,
     retry: 1,
   });

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -66,12 +66,16 @@ export function usePauseProject() {
   return useMutation({
     mutationFn: (args: { projectId: string; teamId?: string; reason?: string }) =>
       pauseProject(args.projectId, { reason: args.reason, teamId: args.teamId }),
-    onSuccess: (workflow) => {
+    // Cache keys must match the subscription keys, which are built from the
+    // REQUEST-time teamId (`teamId ?? 'any'`). Using the response's team_id
+    // here writes a key nobody subscribes to when the request had no teamId
+    // but the controller returns one (panel would lag up to refetchInterval).
+    onSuccess: (workflow, args) => {
       queryClient.setQueryData(
-        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        ['agentteams-project-workflow', args.teamId ?? 'any', args.projectId],
         workflow,
       );
-      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+      invalidateProjectQueries(queryClient, args.projectId, args.teamId);
     },
   });
 }
@@ -82,12 +86,12 @@ export function useResumeProject() {
   return useMutation({
     mutationFn: (args: { projectId: string; teamId?: string }) =>
       resumeProject(args.projectId, { teamId: args.teamId }),
-    onSuccess: (workflow) => {
+    onSuccess: (workflow, args) => {
       queryClient.setQueryData(
-        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        ['agentteams-project-workflow', args.teamId ?? 'any', args.projectId],
         workflow,
       );
-      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+      invalidateProjectQueries(queryClient, args.projectId, args.teamId);
     },
   });
 }
@@ -99,12 +103,12 @@ export function useReplanProject() {
   return useMutation({
     mutationFn: (args: { projectId: string; teamId?: string; tasks: unknown[] }) =>
       replanProject(args.projectId, args.tasks, { teamId: args.teamId }),
-    onSuccess: (workflow) => {
+    onSuccess: (workflow, args) => {
       queryClient.setQueryData(
-        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        ['agentteams-project-workflow', args.teamId ?? 'any', args.projectId],
         workflow,
       );
-      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+      invalidateProjectQueries(queryClient, args.projectId, args.teamId);
     },
   });
 }
@@ -125,12 +129,12 @@ export function useCancelProjectTask() {
         replacementTaskId: args.replacementTaskId,
         teamId: args.teamId,
       }),
-    onSuccess: (workflow) => {
+    onSuccess: (workflow, args) => {
       queryClient.setQueryData(
-        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        ['agentteams-project-workflow', args.teamId ?? 'any', args.projectId],
         workflow,
       );
-      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+      invalidateProjectQueries(queryClient, args.projectId, args.teamId);
     },
   });
 }

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { listProjects, getProjectWorkflow } from '@/lib/agentteams-projects-api';
+
+/**
+ * Fetch the AgentTeams project list through the dashboard proxy
+ * (`GET /api/agentteams/projects`). The full ProjectListResponse is
+ * returned so callers can distinguish a real empty list from a degraded
+ * controller (`degraded` / `degradedReason` / `error`).
+ */
+export function useProjects() {
+  return useQuery({
+    queryKey: ['agentteams-projects'],
+    queryFn: () => listProjects(),
+    refetchInterval: 15000,
+    retry: 1,
+    placeholderData: (previousData) => previousData,
+  });
+}
+
+/**
+ * Fetch one project's workflow graph (with task detail) through the
+ * dashboard proxy (`GET /api/agentteams/projects/{id}/workflow?includeTasks=true`).
+ * Disabled until a project id is selected.
+ */
+export function useProjectWorkflow(projectId: string | null) {
+  return useQuery({
+    queryKey: ['agentteams-project-workflow', projectId ?? 'none'],
+    queryFn: () => getProjectWorkflow(projectId as string, { includeTasks: true }),
+    enabled: !!projectId,
+    retry: 1,
+  });
+}

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -1,5 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
-import { listProjects, getProjectWorkflow } from '@/lib/agentteams-projects-api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  listProjects,
+  getProjectWorkflow,
+  pauseProject,
+  resumeProject,
+  replanProject,
+  cancelProjectTask,
+} from '@/lib/agentteams-projects-api';
 
 /**
  * Fetch the AgentTeams project list through the dashboard proxy
@@ -31,6 +38,99 @@ export function useProjectWorkflow(projectId: string | null, teamId?: string) {
         teamId,
       }),
     enabled: !!projectId,
+    // Keep the detail fresh while a project is selected — mutations elsewhere
+    // (e.g. an agent completing tasks) would otherwise never show up without
+    // a manual refresh.
+    refetchInterval: 15000,
     retry: 1,
+  });
+}
+
+/** Shared cache invalidation for project write mutations (#1172): after a
+ * pause/resume/replan the controller returns the refreshed workflow, but we
+ * invalidate the queries anyway so list + detail re-sync with the new
+ * status (the mutation's onSuccess also updates the detail cache directly). */
+function invalidateProjectQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  projectId: string,
+  teamId?: string,
+) {
+  const detailKey = ['agentteams-project-workflow', teamId ?? 'any', projectId];
+  queryClient.invalidateQueries({ queryKey: detailKey });
+  queryClient.invalidateQueries({ queryKey: ['agentteams-projects'] });
+}
+
+/** Pause the currently selected project, then refresh list + detail. */
+export function usePauseProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { projectId: string; teamId?: string; reason?: string }) =>
+      pauseProject(args.projectId, { reason: args.reason, teamId: args.teamId }),
+    onSuccess: (workflow) => {
+      queryClient.setQueryData(
+        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        workflow,
+      );
+      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+    },
+  });
+}
+
+/** Resume a paused project, then refresh list + detail. */
+export function useResumeProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { projectId: string; teamId?: string }) =>
+      resumeProject(args.projectId, { teamId: args.teamId }),
+    onSuccess: (workflow) => {
+      queryClient.setQueryData(
+        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        workflow,
+      );
+      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+    },
+  });
+}
+
+/** Replace a DAG project's plan (JSON tasks payload from the replan dialog),
+ * then refresh list + detail. */
+export function useReplanProject() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { projectId: string; teamId?: string; tasks: unknown[] }) =>
+      replanProject(args.projectId, args.tasks, { teamId: args.teamId }),
+    onSuccess: (workflow) => {
+      queryClient.setQueryData(
+        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        workflow,
+      );
+      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+    },
+  });
+}
+
+/** Cancel a single task in a project, then refresh list + detail. */
+export function useCancelProjectTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      projectId: string;
+      taskId: string;
+      teamId?: string;
+      reason: string;
+      replacementTaskId?: string;
+    }) =>
+      cancelProjectTask(args.projectId, args.taskId, {
+        reason: args.reason,
+        replacementTaskId: args.replacementTaskId,
+        teamId: args.teamId,
+      }),
+    onSuccess: (workflow) => {
+      queryClient.setQueryData(
+        ['agentteams-project-workflow', workflow.team_id ?? 'any', workflow.project_id],
+        workflow,
+      );
+      invalidateProjectQueries(queryClient, workflow.project_id, workflow.team_id);
+    },
   });
 }

--- a/src/lib/agentteams-projects-api.test.ts
+++ b/src/lib/agentteams-projects-api.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { listProjects, getProjectWorkflow, getTaskArtifactUrl } from './agentteams-projects-api';
+import { ApiError, NetworkError } from './api-error';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('listProjects', () => {
+  it('returns projects on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          projects: [
+            { project_id: 'p1', title: 'A', status: 'active', team_id: 'biz' },
+          ],
+          total: 1,
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+
+    const data = await listProjects();
+    expect(data.projects).toHaveLength(1);
+    expect(data.projects[0].project_id).toBe('p1');
+    expect(data.total).toBe(1);
+    expect(data.degraded).toBeUndefined();
+    expect(fetch).toHaveBeenCalledWith('/api/agentteams/projects', {
+      cache: 'no-store',
+    });
+  });
+
+  it('returns empty array when controller API is degraded (200 + error)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ projects: [], total: 0, error: 'HTTP 404', degraded: true }), {
+        status: 200,
+      }),
+    ) as never;
+    const data = await listProjects();
+    expect(data.projects).toEqual([]);
+    expect(data.degraded).toBe(true);
+    expect(data.error).toContain('HTTP 404');
+  });
+
+  it('throws ApiError on 401', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+    ) as never;
+    await expect(listProjects()).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('throws NetworkError when fetch rejects', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('fetch failed')) as never;
+    await expect(listProjects()).rejects.toBeInstanceOf(NetworkError);
+  });
+});
+
+describe('getProjectWorkflow', () => {
+  it('returns workflow on success', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          project_id: 'p1',
+          title: 'A',
+          status: 'active',
+          nodes: [{ id: 't1', name: 'T1', status: 'delegated' }],
+          edges: [],
+          next: ['t1'],
+          interrupts: [],
+          values: { project_id: 'p1', title: 'A', status: 'active' },
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+
+    const wf = await getProjectWorkflow('p1');
+    expect(wf.nodes).toHaveLength(1);
+    expect(wf.nodes[0].status).toBe('delegated');
+    expect(fetch).toHaveBeenCalledWith('/api/agentteams/projects/p1/workflow', {
+      cache: 'no-store',
+    });
+  });
+
+  it('encodes the project id in the URL', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ project_id: 'x', nodes: [], edges: [], next: [], interrupts: [], values: {} }), {
+        status: 200,
+      }),
+    ) as never;
+    await getProjectWorkflow('a/b c');
+    expect(fetch).toHaveBeenCalledWith('/api/agentteams/projects/a%2Fb%20c/workflow', {
+      cache: 'no-store',
+    });
+  });
+
+  it('appends includeTasks=true query when requested', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          project_id: 'p1',
+          nodes: [],
+          edges: [],
+          next: [],
+          interrupts: [],
+          values: {},
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+    await getProjectWorkflow('p1', { includeTasks: true });
+    expect(fetch).toHaveBeenCalledWith('/api/agentteams/projects/p1/workflow?includeTasks=true', {
+      cache: 'no-store',
+    });
+  });
+
+  it('parses extended interrupt fields (action_request/config/description)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          project_id: 'p1',
+          nodes: [],
+          edges: [],
+          next: [],
+          interrupts: [
+            {
+              id: 'project',
+              value: 'paused',
+              action_request: { action: 'resume', args: { project_id: 'p1' } },
+              config: { allow_ignore: false, allow_respond: false, allow_edit: false, allow_accept: true },
+              description: 'project is paused: waiting on review',
+            },
+          ],
+          values: {},
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+
+    const wf = await getProjectWorkflow('p1');
+    expect(wf.interrupts).toHaveLength(1);
+    const interrupt = wf.interrupts[0];
+    expect(interrupt.action_request?.action).toBe('resume');
+    expect(interrupt.action_request?.args).toEqual({ project_id: 'p1' });
+    expect(interrupt.config?.allow_accept).toBe(true);
+    expect(interrupt.description).toContain('waiting on review');
+  });
+
+  it('parses tasks_detail and audit fields when includeTasks=true', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          project_id: 'p1',
+          nodes: [],
+          edges: [],
+          next: [],
+          interrupts: [],
+          values: {},
+          tasks_detail: [
+            {
+              task_id: 't1',
+              project_id: 'p1',
+              status: 'in_progress',
+              spec_path: '/root/agentteams-fs/agents/sysdev/shared/specs/s1.md',
+              assigned_to: 'sysdev',
+              summary: 'halfway',
+              result_status: '',
+              deliverables: [],
+              result_path: '',
+            },
+          ],
+          source: 'team',
+          requester: 'luo',
+          requester_report: { channel: 'qq' },
+          reply_route: { target: 'room' },
+          source_room_id: '!abc',
+          updated_by: 'luo',
+          updated_at: '2026-08-12T00:00:00Z',
+          pause_reason: 'waiting on review',
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+
+    const wf = await getProjectWorkflow('p1', { includeTasks: true });
+    expect(wf.tasks_detail).toHaveLength(1);
+    expect(wf.tasks_detail?.[0].task_id).toBe('t1');
+    expect(wf.tasks_detail?.[0].spec_path).toContain('specs/s1.md');
+    expect(wf.source).toBe('team');
+    expect(wf.requester_report).toEqual({ channel: 'qq' });
+    expect(wf.source_room_id).toBe('!abc');
+    expect(wf.pause_reason).toBe('waiting on review');
+  });
+
+  it('throws ApiError on 404', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Not Found' }), { status: 404 }),
+    ) as never;
+    await expect(getProjectWorkflow('missing')).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('throws NetworkError when fetch rejects', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('fetch failed')) as never;
+    await expect(getProjectWorkflow('p1')).rejects.toBeInstanceOf(NetworkError);
+  });
+});
+
+describe('getTaskArtifactUrl', () => {
+  it('builds the artifact proxy URL without a path', () => {
+    expect(getTaskArtifactUrl('p1', 't1')).toBe('/api/agentteams/projects/p1/tasks/t1/artifact');
+  });
+
+  it('builds the artifact proxy URL with an encoded deliverable path', () => {
+    expect(getTaskArtifactUrl('p1', 't1', 'results/方案.md')).toBe(
+      '/api/agentteams/projects/p1/tasks/t1/artifact?path=results%2F%E6%96%B9%E6%A1%88.md',
+    );
+  });
+
+  it('encodes project/task ids in the URL', () => {
+    expect(getTaskArtifactUrl('a/b', 't t')).toBe(
+      '/api/agentteams/projects/a%2Fb/tasks/t%20t/artifact',
+    );
+  });
+});

--- a/src/lib/agentteams-projects-api.test.ts
+++ b/src/lib/agentteams-projects-api.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { listProjects, getProjectWorkflow, getTaskArtifactUrl } from './agentteams-projects-api';
+import { listProjects, getProjectWorkflow, getTaskArtifactUrl, pauseProject, cancelProjectTask } from './agentteams-projects-api';
 import { ApiError, NetworkError } from './api-error';
 
 const originalFetch = globalThis.fetch;
@@ -230,6 +230,50 @@ describe('getProjectWorkflow', () => {
     const err = await getProjectWorkflow('shared-id').catch((e) => e);
     expect(err).toBeInstanceOf(ApiError);
     expect((err as ApiError).status).toBe(409);
+  });
+
+  it('surfaces the controller message field on errors (httputil.ErrorResponse)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'project not found' }), { status: 404 }),
+    ) as never;
+    const err = await getProjectWorkflow('missing').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).message).toContain('project not found');
+  });
+
+  it('surfaces the controller message on write conflicts (pause 409)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'project is already paused' }), { status: 409 }),
+    ) as never;
+    const err = await pauseProject('p1').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(409);
+    expect((err as ApiError).message).toContain('already paused');
+  });
+
+  it('posts a task cancel with reason + team and returns the workflow', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ project_id: 'p1', status: 'active' }), { status: 200 }),
+    ) as never;
+    const wf = await cancelProjectTask('p1', 't1', { reason: 'blocked', teamId: 'team-a' });
+    expect(wf.project_id).toBe('p1');
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/agentteams/projects/p1/tasks/t1/cancel?team=team-a',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ reason: 'blocked' }),
+      }),
+    );
+  });
+
+  it('surfaces the controller message on cancel 400 (missing reason)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'reason is required' }), { status: 400 }),
+    ) as never;
+    const err = await cancelProjectTask('p1', 't1', { reason: '' }).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(400);
+    expect((err as ApiError).message).toContain('reason is required');
   });
 
   it('throws NetworkError when fetch rejects', async () => {

--- a/src/lib/agentteams-projects-api.test.ts
+++ b/src/lib/agentteams-projects-api.test.ts
@@ -194,11 +194,42 @@ describe('getProjectWorkflow', () => {
     expect(wf.pause_reason).toBe('waiting on review');
   });
 
+  it('passes ?team= when teamId is provided (409 disambiguation, #1169)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ nodes: [], edges: [], values: {} }), { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as never;
+    await getProjectWorkflow('p1', { teamId: 'sysdev-team' });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('team=sysdev-team');
+    expect(url).toContain('/p1/workflow');
+  });
+
+  it('combines includeTasks and team query params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ nodes: [], edges: [], values: {} }), { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as never;
+    await getProjectWorkflow('p1', { includeTasks: true, teamId: 'sysdev-team' });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('includeTasks=true');
+    expect(url).toContain('team=sysdev-team');
+  });
+
   it('throws ApiError on 404', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: 'Not Found' }), { status: 404 }),
     ) as never;
     await expect(getProjectWorkflow('missing')).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('throws ApiError on 409 (ambiguous id across teams)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'ambiguous project id, pass ?team=' }), { status: 409 }),
+    ) as never;
+    const err = await getProjectWorkflow('shared-id').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(409);
   });
 
   it('throws NetworkError when fetch rejects', async () => {

--- a/src/lib/agentteams-projects-api.ts
+++ b/src/lib/agentteams-projects-api.ts
@@ -187,9 +187,15 @@ export async function listProjects(): Promise<ProjectListResponse> {
  * Pass `{ includeTasks: true }` to attach per-task TaskMeta as tasks_detail. */
 export async function getProjectWorkflow(
   projectId: string,
-  options: { includeTasks?: boolean } = {},
+  options: { includeTasks?: boolean; teamId?: string } = {},
 ): Promise<WorkflowResponse> {
-  const qs = options.includeTasks ? '?includeTasks=true' : '';
+  // #1169 (team, project_id) identity: the same id may exist under two
+  // teams. Pass ?team= to disambiguate; without it the controller returns
+  // 409 Conflict. includeTasks and teamId are independent query params.
+  const qsParts: string[] = [];
+  if (options.includeTasks) qsParts.push('includeTasks=true');
+  if (options.teamId) qsParts.push(`team=${encodeURIComponent(options.teamId)}`);
+  const qs = qsParts.length ? `?${qsParts.join('&')}` : '';
   return requestJson<WorkflowResponse>(
     `${PROJECTS_URL}/${encodeURIComponent(projectId)}/workflow${qs}`,
   );

--- a/src/lib/agentteams-projects-api.ts
+++ b/src/lib/agentteams-projects-api.ts
@@ -161,6 +161,25 @@ export interface ProjectListResponse {
 
 const PROJECTS_URL = '/api/agentteams/projects';
 
+/** Extract a human-readable detail from an error response body.
+ * The controller's standard error shape is `{ "message": "..." }`
+ * (httputil.ErrorResponse); the dashboard middleware returns
+ * `{ "error": "..." }`. Accept both so callers surface the real reason. */
+async function extractErrorDetail(res: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await res.json()) as { error?: unknown; message?: unknown };
+    const fromError =
+      payload && typeof payload.error === 'string' && payload.error ? payload.error : '';
+    const fromMessage =
+      payload && typeof payload.message === 'string' && payload.message ? payload.message : '';
+    if (fromMessage) return fromMessage;
+    if (fromError) return fromError;
+  } catch {
+    // non-JSON error body; keep the fallback
+  }
+  return fallback;
+}
+
 async function requestJson<T>(url: string): Promise<T> {
   let res: Response;
   try {
@@ -169,7 +188,8 @@ async function requestJson<T>(url: string): Promise<T> {
     throw new NetworkError(url);
   }
   if (!res.ok) {
-    throw new ApiError(`HTTP ${res.status} from ${url}`, res.status, url);
+    const detail = await extractErrorDetail(res, `HTTP ${res.status}`);
+    throw new ApiError(`${detail} from ${url}`, res.status, url);
   }
   return (await res.json()) as T;
 }
@@ -215,4 +235,92 @@ export function getTaskArtifactUrl(
 ): string {
   const base = `${PROJECTS_URL}/${encodeURIComponent(projectId)}/tasks/${encodeURIComponent(taskId)}/artifact`;
   return path ? `${base}?path=${encodeURIComponent(path)}` : base;
+}
+
+// ----- W-PR-2 human intervention write operations (#1172) -----
+//
+// Each POST returns the controller's refreshed workflow JSON (200). The
+// controller's 409 conflict reasons (already paused / not paused / replan
+// preconditions) are surfaced as ApiError with the upstream status so the
+// UI can show the exact reason.
+
+async function requestPost<T>(url: string, body: unknown): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+      cache: 'no-store',
+    });
+  } catch {
+    throw new NetworkError(url);
+  }
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res, `HTTP ${res.status}`);
+    throw new ApiError(`${detail} from ${url}`, res.status, url);
+  }
+  return (await res.json()) as T;
+}
+
+/** Post a project mutation through the dashboard proxy.
+ * `teamId` disambiguates (team, project_id) identity (#1169). */
+function mutationUrl(projectId: string, action: string, teamId?: string): string {
+  const base = `${PROJECTS_URL}/${encodeURIComponent(projectId)}/${action}`;
+  return teamId ? `${base}?team=${encodeURIComponent(teamId)}` : base;
+}
+
+/** Pause an active project (POST .../pause, body { reason }). */
+export function pauseProject(
+  projectId: string,
+  options: { reason?: string; teamId?: string } = {},
+): Promise<WorkflowResponse> {
+  return requestPost<WorkflowResponse>(
+    mutationUrl(projectId, 'pause', options.teamId),
+    { reason: options.reason ?? '' },
+  );
+}
+
+/** Resume a paused project (POST .../resume, empty body). */
+export function resumeProject(
+  projectId: string,
+  options: { teamId?: string } = {},
+): Promise<WorkflowResponse> {
+  return requestPost<WorkflowResponse>(
+    mutationUrl(projectId, 'resume', options.teamId),
+    {},
+  );
+}
+
+/** Replace a DAG project's plan (POST .../replan, body { tasks }).
+ * The controller validates the new graph (duplicates / unknown deps /
+ * cycles) and normalizes fields; 409 on preconditions (non-dag plan type,
+ * not active, tasks executing). */
+export function replanProject(
+  projectId: string,
+  tasks: unknown[],
+  options: { teamId?: string } = {},
+): Promise<WorkflowResponse> {
+  return requestPost<WorkflowResponse>(
+    mutationUrl(projectId, 'replan', options.teamId),
+    { tasks },
+  );
+}
+
+/** Cancel a single task in a project (POST .../tasks/{taskId}/cancel).
+ * `reason` is required by the controller (400 without it); 409 for terminal
+ * tasks, 404 when the task is not part of the project's graph. */
+export function cancelProjectTask(
+  projectId: string,
+  taskId: string,
+  options: { reason: string; replacementTaskId?: string; teamId?: string },
+): Promise<WorkflowResponse> {
+  const base = `${PROJECTS_URL}/${encodeURIComponent(projectId)}/tasks/${encodeURIComponent(taskId)}/cancel`;
+  const url = options.teamId
+    ? `${base}?team=${encodeURIComponent(options.teamId)}`
+    : base;
+  return requestPost<WorkflowResponse>(url, {
+    reason: options.reason,
+    ...(options.replacementTaskId ? { replacementTaskId: options.replacementTaskId } : {}),
+  });
 }

--- a/src/lib/agentteams-projects-api.ts
+++ b/src/lib/agentteams-projects-api.ts
@@ -1,0 +1,212 @@
+// AgentTeams Projects API client (frontend side).
+//
+// These types mirror the AgentTeams controller API introduced by
+// agentteams/AgentTeams#1169 (W-PR-1) and extended by #1172 (W-PR-2):
+//
+//   GET /api/v1/projects                               -> ProjectListResponse
+//   GET /api/v1/projects/{id}/workflow[?includeTasks]  -> WorkflowResponse
+//   GET /api/v1/projects/{id}/tasks/{taskId}/artifact  -> binary stream
+//
+// All requests go through the Next.js proxy routes under
+// `/api/agentteams/projects/*` (which add the SA-token bearer and are
+// themselves gated by the Higress-session middleware). The workflow
+// payload follows the LangGraph-style shape (nodes/edges/next/interrupts/
+// values) agreed in the W-PR-1 design. Field names/types are verified
+// against `project_handler.go` (workflowResponse / workflowInterrupt /
+// taskDetail / loopMeta structs) and the API doc
+// `docs/zh-cn/usage/project-workflow-api.md` (W-PR-1) — keep in sync when
+// the controller schema changes.
+
+import { ApiError, NetworkError } from '@/lib/api-error';
+
+export type ProjectStatus = 'planning' | 'active' | 'paused' | 'completed' | 'unknown';
+
+export type WorkflowNodeStatus =
+  | 'pending'
+  | 'delegated'
+  | 'in-progress'
+  | 'completed'
+  | 'revision'
+  | 'blocked';
+
+export interface ProjectSummary {
+  project_id: string;
+  title: string;
+  status: ProjectStatus;
+  plan_type?: 'dag' | 'loop';
+  team_id?: string;
+  mode?: 'project' | 'quick';
+}
+
+export interface WorkflowNode {
+  id: string;
+  name: string;
+  status: WorkflowNodeStatus;
+  assignee?: string;
+}
+
+export interface WorkflowEdge {
+  source: string;
+  target: string;
+  conditional?: boolean;
+}
+
+/** Mirrors workflowInterrupt + interruptActionRequest + interruptConfig.
+ * A paused project surfaces as an interrupt with action_request
+ * { action: 'resume', args: { project_id } } and config.allow_accept=true,
+ * so a dashboard can render a "Resume" button directly (W-PR-2 endpoints). */
+export interface WorkflowInterrupt {
+  id: string;
+  value: string;
+  action_request?: InterruptActionRequest;
+  config?: InterruptConfig;
+  description?: string;
+}
+
+export interface InterruptActionRequest {
+  action: string;
+  args?: Record<string, unknown>;
+}
+
+export interface InterruptConfig {
+  allow_ignore: boolean;
+  allow_respond: boolean;
+  allow_edit: boolean;
+  allow_accept: boolean;
+}
+
+export interface WorkflowValues {
+  project_id: string;
+  title: string;
+  status: ProjectStatus;
+  plan_type?: 'dag' | 'loop';
+  team_id?: string;
+  mode?: 'project' | 'quick';
+  /** Task counts per normalized status, e.g. { "pending": 2, "delegated": 1 }. */
+  task_count?: Record<string, number>;
+}
+
+/** Mirrors loopMeta (project_handler.go). */
+export interface WorkflowLoop {
+  goal?: string;
+  stop_condition?: string;
+  iteration_template?: string;
+  current_iteration?: number;
+  max_iterations?: number;
+  status?: string;
+  tasks?: WorkflowLoopTask[];
+  history?: unknown[];
+}
+
+/** Mirrors projectTaskMeta (the loop's executable graph). */
+export interface WorkflowLoopTask {
+  task_id: string;
+  title: string;
+  assigned_to?: string;
+  depends_on?: string[];
+  status?: string;
+}
+
+/** Mirrors taskDetail, returned when ?includeTasks=true. */
+export interface WorkflowTaskDetail {
+  task_id: string;
+  project_id?: string;
+  status?: string;
+  spec_path?: string;
+  assigned_to?: string;
+  summary?: string;
+  result_status?: string;
+  deliverables?: unknown[];
+  result_path?: string;
+  cancel_reason?: string;
+}
+
+export interface WorkflowResponse {
+  project_id: string;
+  title: string;
+  status: ProjectStatus;
+  plan_type?: 'dag' | 'loop';
+  team_id?: string;
+  mode?: 'project' | 'quick';
+  source?: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  next: string[];
+  interrupts: WorkflowInterrupt[];
+  values?: WorkflowValues;
+  loop?: WorkflowLoop;
+  requester?: string;
+  requester_report?: Record<string, unknown>;
+  reply_route?: Record<string, unknown>;
+  source_room_id?: string;
+  /** Populated only when ?includeTasks=true. */
+  tasks_detail?: WorkflowTaskDetail[];
+  /** W-PR-2 human-intervention audit fields. */
+  updated_by?: string;
+  updated_at?: string;
+  pause_reason?: string;
+}
+
+export interface ProjectListResponse {
+  projects: ProjectSummary[];
+  total: number;
+  /** Set when the controller API is not yet available (degraded empty list). */
+  error?: string;
+  degraded?: boolean;
+  /** Why the list degraded: 'api-not-deployed' (404 — W-PR-1 not merged /
+   * controller not upgraded) vs 'controller-error' (500+ — endpoint exists
+   * but failed, e.g. MinIO unreachable). */
+  degradedReason?: 'api-not-deployed' | 'controller-error';
+}
+
+const PROJECTS_URL = '/api/agentteams/projects';
+
+async function requestJson<T>(url: string): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, { cache: 'no-store' });
+  } catch {
+    throw new NetworkError(url);
+  }
+  if (!res.ok) {
+    throw new ApiError(`HTTP ${res.status} from ${url}`, res.status, url);
+  }
+  return (await res.json()) as T;
+}
+
+/** List projects via the dashboard proxy route.
+ *
+ * Returns the full ProjectListResponse so callers can distinguish a real
+ * empty list from a degraded controller (`degraded: true` + `error`).
+ */
+export async function listProjects(): Promise<ProjectListResponse> {
+  return requestJson<ProjectListResponse>(PROJECTS_URL);
+}
+
+/** Fetch a single project workflow graph via the dashboard proxy route.
+ * Pass `{ includeTasks: true }` to attach per-task TaskMeta as tasks_detail. */
+export async function getProjectWorkflow(
+  projectId: string,
+  options: { includeTasks?: boolean } = {},
+): Promise<WorkflowResponse> {
+  const qs = options.includeTasks ? '?includeTasks=true' : '';
+  return requestJson<WorkflowResponse>(
+    `${PROJECTS_URL}/${encodeURIComponent(projectId)}/workflow${qs}`,
+  );
+}
+
+/** Build the dashboard proxy URL for downloading one task's result artifact.
+ *
+ * The artifact is a binary stream (controller GET .../artifact, optional
+ * ?path= for a specific deliverable); it is not fetched through requestJson —
+ * the frontend uses this URL directly, e.g. `<a href={...}>` or window.open.
+ * The controller performs the path whitelist + existence checks.
+ */
+export function getTaskArtifactUrl(
+  projectId: string,
+  taskId: string,
+  path?: string,
+): string {
+  const base = `${PROJECTS_URL}/${encodeURIComponent(projectId)}/tasks/${encodeURIComponent(taskId)}/artifact`;
+  return path ? `${base}?path=${encodeURIComponent(path)}` : base;
+}


### PR DESCRIPTION
# Project API proxy + first dashboard consumer (with human-intervention controls)

## Summary

The dashboard is the first consumer of the standardized AgentTeams project API introduced by agentteams/AgentTeams#1169 and #1172: `GET /api/v1/projects`, `GET /api/v1/projects/{id}/workflow`, `GET /api/v1/projects/{id}/tasks/{taskId}/artifact`, and the lifecycle write endpoints `POST .../pause|resume|replan` plus `POST .../tasks/{taskId}/cancel`. This PR adds a thin proxy layer plus the frontend consumer so the dashboard can read project state and act on it once the controller is upgraded. It locks the API contract early (consumer-driven), so the controller reviewers see a real consumer and the dashboard switches with zero delay after merge.

## What's included

1. `src/lib/agentteams-projects-api.ts`:
   - Full contract types verified against the controller structs: `ProjectSummary` / `WorkflowResponse` (nodes/edges/next/interrupts/values/loop) + `WorkflowInterrupt.action_request/config/description` (a paused project surfaces an interrupt with `action: 'resume'` + `config.allow_accept` — the hook for the Resume button) + `WorkflowTaskDetail` / `WorkflowLoop` + audit fields (`updated_by` / `updated_at` / `pause_reason`)
   - `listProjects()` returns the full `ProjectListResponse` so the frontend can distinguish a real empty list from a degraded controller (`degraded: true` + `error` + `degradedReason`: `'api-not-deployed'` (404) vs `'controller-error'` (500+))
   - `getProjectWorkflow(id, { includeTasks, teamId })` forwards `?includeTasks=true` for per-task TaskMeta
   - Write client: `pauseProject` / `resumeProject` / `replanProject` / `cancelProjectTask` — each POSTs through the proxy and returns the refreshed workflow; errors surface as `ApiError` with the upstream status + message (the controller's standard error shape is `{ "message" }`)
   - `getTaskArtifactUrl(projectId, taskId, path?)` builds the artifact download URL
2. Proxy routes under `src/app/api/agentteams/projects/`:
   - `route.ts` — GET → `/api/v1/projects`; `?team=` and other query params forwarded (minus the internal `controllerUrl` override); **degrades** to `{ projects: [], degraded: true, error }` with 200 when the endpoint is not deployed, so the board still renders
   - `[id]/workflow/route.ts` — GET → `/{id}/workflow`; query params forwarded (`?includeTasks=true`); passes through 404/403/409
   - `[id]/tasks/[taskId]/artifact/route.ts` — GET → the artifact endpoint; `?path=` forwarded; `content-disposition` passed through (RFC 5987 filenames survive); body streamed (no full buffering)
   - `[id]/pause/route.ts`, `[id]/resume/route.ts`, `[id]/replan/route.ts`, `[id]/tasks/[taskId]/cancel/route.ts` — POST proxies; JSON body forwarded as-is; `?team=` forwarded for (team, project_id) identity scoping; 400/404/409 passed through with the controller's exact reason
3. `src/app/api/agentteams/proxy-helper.ts` — new opt-in options: `passthroughHeaders` (e.g. `content-disposition` for binary downloads) and `stream: true` (stream the upstream body instead of buffering). Existing routes unchanged.
4. `src/hooks/use-projects.ts` — `useProjects` (15s polling), `useProjectWorkflow` (15s polling while a project is selected), and mutation hooks `usePauseProject` / `useResumeProject` / `useReplanProject` / `useCancelProjectTask` (react-query, cache sync + invalidation on success).
5. `src/components/dashboard/sections/projects-section.tsx` — the consumer: project list with `(team, project_id)` composite selection and a friendly 409-ambiguity hint; workflow detail (status badge, task-count distribution, node grid, task detail table with artifact download links, loop progress, next-runnable chips, degraded banner); **human intervention controls**: Pause button (reason dialog) on active/planning projects, Resume button rendered directly on the paused-project interrupt, Replan entry (JSON editor seeded from the current graph — dependencies rebuilt from edges, status omitted so the controller preserves previous values), and a per-task 取消 (cancel) button for non-terminal tasks with a required-reason dialog. Status colors/labels mirror the existing tasks board so the two project views look consistent; task rows normalize the raw TaskMeta status the same way the controller does.
6. Tests — 66 new (see Tests).

## Data boundary

- **Depends on agentteams/AgentTeams#1169 and #1172** — the GET endpoints do not exist until #1169 merges, and the write endpoints (pause/resume/replan/cancel) do not exist until #1172 merges. Until then the list route returns a degraded empty list, the other read routes return 404, and the write routes return 404 (endpoint not found) — the UI renders intervention controls only when the workflow reports the matching state, so nothing breaks either way.
- Auth chain is pre-existing: browser → `middleware.ts` Higress session (already gates all `/api/agentteams/*`); route → `proxyToAgentTeams` SA-token bearer. Team scoping, write-side access checks and optimistic concurrency live in the controller.
- The existing MinIO-backed task board (`tasks-section`) remains untouched as the fallback data source, so the dashboard keeps working today.

## Tests

- `src/lib/agentteams-projects-api.test.ts`: 21 tests (list success / degraded-empty / 401 / 404 / network; workflow success / url-encoding / includeTasks / extended interrupt fields / tasks_detail + audit fields; artifact URL; pause 409 message surfaced; cancel success + team query + 400 message surfaced; controller `{ message }` error shape surfaced for both GET and POST paths)
- `src/app/api/agentteams/projects/route.test.ts`: 5 tests (pass-through / degrade 404 / degrade 500 / error message kept / query forwarding + controllerUrl dropped)
- `src/app/api/agentteams/projects/[id]/workflow/route.test.ts`: 6 tests
- `src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.test.ts`: 6 tests (binary stream / content-disposition / 404 / 400 / ?path= / url-encoding)
- `src/app/api/agentteams/projects/[id]/pause/route.test.ts`: 6 tests (reason body / 409 / 403 / 404 / url-encoding / team forwarding)
- `src/app/api/agentteams/projects/[id]/resume/route.test.ts`: 5 tests (action proxied / 409 / 403 / 404 / url-encoding)
- `src/app/api/agentteams/projects/[id]/replan/route.test.ts`: 6 tests (tasks body / 400 / 409 / 404 / url-encoding / team forwarding)
- `src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.test.ts`: 6 tests (reason body / 400 / 404 / 409 / both-ids url-encoding / team forwarding)
- `src/app/api/agentteams/proxy-helper.test.ts`: 4 tests
- `tsc --noEmit` clean (adm-zip baseline only); `eslint` clean on all changed files
- Full suite: 66 project-related tests all green; verified against the origin/main baseline — the same 44 pre-existing suite failures (upstream jsdom env + `node:` routes) with zero new failures

## Related

- agentteams/AgentTeams#1169: `GET /api/v1/projects` + `/{id}/workflow` + `/{id}/tasks/{taskId}/artifact` controller API
- agentteams/AgentTeams#1172: `POST /{id}/pause` + `/{id}/resume` + `/{id}/replan` + `/{id}/tasks/{taskId}/cancel` (+ create/cancel/complete) human intervention write APIs

---

## 摘要

仪表盘是 agentteams/AgentTeams#1169 与 #1172 引入的标准化项目 API 的第一个消费方（项目列表 / 工作流详情 / 产物下载三个读端点，以及暂停 / 恢复 / 重规划 / 取消任务四个生命周期写端点）。本 PR 提供一层薄代理和前端消费方，Controller 升级后仪表盘即可零延迟读状态、做人工干预，同时提前锁定 API 契约（消费方驱动）。

## 包含内容

1. `src/lib/agentteams-projects-api.ts`：
   - 契约类型逐字段对照 Controller 结构体：`ProjectSummary` / `WorkflowResponse`（nodes/edges/next/interrupts/values/loop）+ `WorkflowInterrupt` 的 `action_request`/`config`/`description`（暂停中的项目以 interrupt 形式暴露 `action: 'resume'` + `config.allow_accept`——即 Resume 按钮的挂钩）+ `WorkflowTaskDetail` / `WorkflowLoop` + 审计字段（`updated_by` / `updated_at` / `pause_reason`）
   - `listProjects()` 返回完整 `ProjectListResponse`，前端可区分真实空列表与 Controller 降级（`degraded: true` + `error` + `degradedReason`：`'api-not-deployed'`（404）与 `'controller-error'`（500+））
   - `getProjectWorkflow(id, { includeTasks, teamId })` 转发 `?includeTasks=true` 获取逐任务 TaskMeta
   - 写客户端：`pauseProject` / `resumeProject` / `replanProject` / `cancelProjectTask`——均经代理 POST 并返回刷新后的工作流；错误以 `ApiError` 携带上游状态码与消息（Controller 标准错误体为 `{ "message" }`）
   - `getTaskArtifactUrl(projectId, taskId, path?)` 构造产物下载 URL
2. `src/app/api/agentteams/projects/` 下的代理路由：
   - `route.ts` — GET 代理 → `/api/v1/projects`；`?team=` 等 query 透传（过滤内部 `controllerUrl` 覆写）；端点未部署时**降级**为 200 + `{ projects: [], degraded: true, error }`，看板照常渲染
   - `[id]/workflow/route.ts` — GET 代理 → `/{id}/workflow`；query 透传（`?includeTasks=true`）；404/403/409 透传
   - `[id]/tasks/[taskId]/artifact/route.ts` — GET 代理 → 产物端点；`?path=` 透传；`content-disposition` 透传（RFC 5987 文件名跨代理存活）；流式转发不整体缓冲
   - `[id]/pause/route.ts`、`[id]/resume/route.ts`、`[id]/replan/route.ts`、`[id]/tasks/[taskId]/cancel/route.ts` — POST 代理；JSON body 原样转发；`?team=` 透传用于 (team, project_id) 身份消歧；400/404/409 带 Controller 原始原因透传
3. `src/app/api/agentteams/proxy-helper.ts` — 新增可选参数：`passthroughHeaders`（如二进制下载的 `content-disposition`）与 `stream: true`（流式转发上游 body 而非整体缓冲）。现有路由零改动。
4. `src/hooks/use-projects.ts` — `useProjects`（15s 轮询）、`useProjectWorkflow`（选中项目后 15s 轮询），以及变更 hooks `usePauseProject` / `useResumeProject` / `useReplanProject` / `useCancelProjectTask`（react-query，成功后缓存同步 + 失效刷新）。
5. `src/components/dashboard/sections/projects-section.tsx` — 消费方：项目列表（(team, project_id) 复合选择 + 409 歧义友好提示）；工作流详情（状态徽章、任务分布、节点网格、任务详情表含产物下载链接、loop 进度、下一步可执行 chips、降级横幅）；**人工干预控件**：active/planning 项目的 Pause 按钮（原因对话框）、暂停项目 interrupt 上直接渲染的 Resume 按钮、Replan 入口（JSON 编辑器以当前图作种子——依赖从 edges 反推重建、status 省略让 Controller 保留既有值）、非终态任务的逐任务「取消」按钮（原因必填对话框）。状态配色与文案对齐现有任务看板，两个项目视图观感一致；任务行按与 Controller 相同的方式归一化原始 TaskMeta 状态。
6. 测试 — 新增 66 个（见测试）。

## 数据边界

- **依赖 agentteams/AgentTeams#1169 与 #1172**：#1169 合并前读端点不存在、#1172 合并前写端点不存在。届时列表路由降级返回空列表、其余路由透传 404，前端仅在 workflow 报告对应状态时渲染干预控件——任何阶段都不会破坏现有功能。
- 认证链沿用现有实现：浏览器 → `middleware.ts` Higress 会话（已门禁全部 `/api/agentteams/*`）；路由 → `proxyToAgentTeams` 服务账号 token。团队隔离、写侧权限校验与乐观并发均在 Controller 侧完成。
- 现有基于 MinIO 的任务看板（tasks-section）保持不动作为兜底数据源。

## 测试

- `src/lib/agentteams-projects-api.test.ts`：21 个测试（列表成功 / 降级空 / 401 / 404 / 网络错误；工作流成功 / URL 编码 / includeTasks / interrupt 扩展字段 / tasks_detail + 审计字段；产物 URL；pause 409 消息透出；cancel 成功 + team query + 400 消息透出；GET 与 POST 路径均验证 Controller `{ message }` 错误体解析）
- `src/app/api/agentteams/projects/route.test.ts`：5 个测试（透传 / 404 降级 / 500 降级 / 错误消息保留 / query 转发 + controllerUrl 过滤）
- `src/app/api/agentteams/projects/[id]/workflow/route.test.ts`：6 个测试
- `src/app/api/agentteams/projects/[id]/tasks/[taskId]/artifact/route.test.ts`：6 个测试（二进制流 / content-disposition / 404 / 400 / ?path= / URL 编码）
- `src/app/api/agentteams/projects/[id]/pause/route.test.ts`：6 个测试（reason body / 409 / 403 / 404 / URL 编码 / team 转发）
- `src/app/api/agentteams/projects/[id]/resume/route.test.ts`：5 个测试（动作代理 / 409 / 403 / 404 / URL 编码）
- `src/app/api/agentteams/projects/[id]/replan/route.test.ts`：6 个测试（tasks body / 400 / 409 / 404 / URL 编码 / team 转发）
- `src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.test.ts`：6 个测试（reason body / 400 / 404 / 409 / 双 id URL 编码 / team 转发）
- `src/app/api/agentteams/proxy-helper.test.ts`：4 个测试
- `tsc --noEmit` 干净（仅 adm-zip 基线）；`eslint` 对全部改动文件干净
- 全量：66 个项目相关测试全绿；对照 origin/main 基线验证——同样的 44 个既有 suite 失败（上游 jsdom 环境 + `node:` 路由），零新增失败

## 相关

- agentteams/AgentTeams#1169：`GET /api/v1/projects` + `/{id}/workflow` + `/{id}/tasks/{taskId}/artifact` Controller API
- agentteams/AgentTeams#1172：`POST /{id}/pause` + `/{id}/resume` + `/{id}/replan` + `/{id}/tasks/{taskId}/cancel`（+ create/cancel/complete）人工干预写 API