### PR TITLE
feat(projects): workflow three views (list/card/topo) with shared DAG renderer

### DIFF
--- a/src/components/dashboard/project-dag-svg.tsx
+++ b/src/components/dashboard/project-dag-svg.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useMemo } from 'react';
+import { layoutProjectDag, type ProjectDag } from '@/lib/project-dag';
+
+/** SVG node colors, keyed by status. Callers pass their own table
+ * (task-board statuses vs workflow statuses) so the renderer stays shared. */
+export interface DagNodeColor {
+  fill: string;
+  stroke: string;
+  text: string;
+}
+
+/**
+ * Shared top-down DAG renderer (dependency graph as an SVG). Used by the
+ * task board (MinIO data) and the projects section (workflow API data).
+ *
+ * Layout is computed inside via layoutProjectDag; pass `dag` plus a
+ * status→color table. Ready nodes (all deps completed, from `next`) get a
+ * cyan dashed border + dot.
+ */
+export function ProjectDagSvg({
+  dag,
+  nodeColors,
+  nodeWidth = 190,
+  nodeHeight = 40,
+  gapY = 64,
+  title,
+}: {
+  dag: ProjectDag;
+  nodeColors: Record<string, DagNodeColor>;
+  nodeWidth?: number;
+  nodeHeight?: number;
+  gapY?: number;
+  /** aria-label for the rendered graph. */
+  title?: string;
+}) {
+  const W = nodeWidth;
+  const H = nodeHeight;
+  const GY = gapY;
+
+  const layout = useMemo(
+    () => layoutProjectDag(dag, { nodeWidth: W, nodeHeight: H, gapY: GY }),
+    [dag, W, H, GY],
+  );
+  const { width, height, positions } = layout;
+
+  if (dag.nodes.length === 0) return null;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={title ?? '项目任务依赖图'}
+    >
+      {dag.edges.map((e, i) => {
+        const a = positions.get(e.source);
+        const b = positions.get(e.target);
+        if (!a || !b) return null;
+        const x1 = a.x + W / 2;
+        const y1 = a.y + H;
+        const x2 = b.x + W / 2;
+        const y2 = b.y;
+        const my = (y1 + y2) / 2;
+        return (
+          <path
+            key={`edge-${i}`}
+            d={`M ${x1} ${y1} C ${x1} ${my}, ${x2} ${my}, ${x2} ${y2}`}
+            fill="none"
+            stroke="rgba(148,163,184,0.55)"
+            strokeWidth={1.2}
+            markerEnd="url(#dag-arrow)"
+          />
+        );
+      })}
+      <defs>
+        <marker id="dag-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
+          <path d="M0,0 L7,3 L0,6 Z" fill="rgba(148,163,184,0.7)" />
+        </marker>
+      </defs>
+      {dag.nodes.map((n) => {
+        const p = positions.get(n.id);
+        if (!p) return null;
+        const colors = nodeColors[n.status] ?? nodeColors.unknown;
+        // ~14 CJK glyphs at 11px fit inside the default 190px node width.
+        const label = n.title.length > 14 ? `${n.title.slice(0, 14)}…` : n.title;
+        return (
+          <g key={n.id}>
+            <title>{n.title}</title>
+            <rect
+              x={p.x}
+              y={p.y}
+              width={W}
+              height={H}
+              rx={7}
+              fill={colors.fill}
+              stroke={n.ready ? '#22d3ee' : colors.stroke}
+              strokeWidth={n.ready ? 1.8 : 1}
+              strokeDasharray={n.ready ? '5 3' : undefined}
+            />
+            {n.ready && (
+              <circle cx={p.x + 10} cy={p.y + H / 2} r={3} fill="#22d3ee" />
+            )}
+            <text
+              x={p.x + 18}
+              y={p.y + H / 2 + 4}
+              fontSize={11}
+              fill={colors.text}
+              fontFamily="inherit"
+            >
+              {label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/components/dashboard/project-dag-svg.tsx
+++ b/src/components/dashboard/project-dag-svg.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { layoutProjectDag, type ProjectDag } from '@/lib/project-dag';
 
 /** SVG node colors, keyed by status. Callers pass their own table
@@ -39,6 +39,10 @@ export function ProjectDagSvg({
   const H = nodeHeight;
   const GY = gapY;
 
+  // Per-instance marker id — the task board and the projects topo view can
+  // render on the same page; a shared document id would make url(#...) always
+  // resolve to the first instance.
+  const markerId = useId();
   const layout = useMemo(
     () => layoutProjectDag(dag, { nodeWidth: W, nodeHeight: H, gapY: GY }),
     [dag, W, H, GY],
@@ -71,12 +75,12 @@ export function ProjectDagSvg({
             fill="none"
             stroke="rgba(148,163,184,0.55)"
             strokeWidth={1.2}
-            markerEnd="url(#dag-arrow)"
+            markerEnd={`url(#${markerId})`}
           />
         );
       })}
       <defs>
-        <marker id="dag-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
+        <marker id={markerId} markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
           <path d="M0,0 L7,3 L0,6 Z" fill="rgba(148,163,184,0.7)" />
         </marker>
       </defs>

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -97,7 +97,9 @@ function normalizeNodeStatus(raw?: string): WorkflowNodeStatus {
     case 'cancelled':
       return 'blocked';
     default:
-      return 'pending';
+      // Unknown/future controller statuses render as blocked rather than
+      // "待办" — a task we don't understand should not look actionable.
+      return 'blocked';
   }
 }
 
@@ -853,6 +855,20 @@ function WorkflowDagView({
   );
 }
 
+/** (team, project_id) composite identity comparison (#1169). Accepts both
+ * the selection shape ({ id, team }) and the API summary shape
+ * ({ project_id, team_id }). */
+function isSameProject(
+  a: { project_id?: string; id?: string; team_id?: string; team?: string } | null,
+  b: { project_id?: string; id?: string; team_id?: string; team?: string } | null,
+): boolean {
+  if (!a || !b) return false;
+  return (
+    (a.project_id ?? a.id ?? '') === (b.project_id ?? b.id ?? '') &&
+    (a.team_id ?? a.team ?? '') === (b.team_id ?? b.team ?? '')
+  );
+}
+
 // ----- Project card (card view) -----
 
 function ProjectCard({
@@ -902,11 +918,7 @@ export function ProjectsSection() {
 
   const projects = data?.projects ?? [];
   const selected =
-    projects.find(
-      (p) =>
-        p.project_id === selectedKey?.id &&
-        (p.team_id ?? '') === (selectedKey?.team ?? ''),
-    ) ?? null;
+    projects.find((p) => isSameProject(p, selectedKey)) ?? null;
 
   return (
     <div className="space-y-4">
@@ -977,8 +989,7 @@ export function ProjectsSection() {
                   key={`${p.team_id ?? ''}:${p.project_id}`}
                   onClick={() => setSelectedKey({ id: p.project_id, team: p.team_id })}
                   className={`w-full text-left rounded-lg border p-2.5 text-xs transition-colors ${
-                    selected?.project_id === p.project_id &&
-                    (selected?.team_id ?? '') === (p.team_id ?? '')
+                    isSameProject(selected, p)
                       ? 'border-primary/50 bg-primary/5'
                       : 'border-transparent hover:bg-muted/50'
                   }`}
@@ -1021,10 +1032,7 @@ export function ProjectsSection() {
               <ProjectCard
                 key={`${p.team_id ?? ''}:${p.project_id}`}
                 project={p}
-                selected={
-                  selected?.project_id === p.project_id &&
-                  (selected?.team_id ?? '') === (p.team_id ?? '')
-                }
+                selected={isSameProject(selected, p)}
                 onSelect={() => setSelectedKey({ id: p.project_id, team: p.team_id })}
               />
             ))}
@@ -1052,8 +1060,7 @@ export function ProjectsSection() {
                   key={`${p.team_id ?? ''}:${p.project_id}`}
                   onClick={() => setSelectedKey({ id: p.project_id, team: p.team_id })}
                   className={`w-full text-left rounded-lg border p-2.5 text-xs transition-colors ${
-                    selected?.project_id === p.project_id &&
-                    (selected?.team_id ?? '') === (p.team_id ?? '')
+                    isSameProject(selected, p)
                       ? 'border-primary/50 bg-primary/5'
                       : 'border-transparent hover:bg-muted/50'
                   }`}

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { GitBranch, FolderKanban, CircleAlert, Loader2, RefreshCw, Pause, Play, Map as MapIcon, Ban } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { GitBranch, FolderKanban, CircleAlert, Loader2, RefreshCw, Pause, Play, Map as MapIcon, Ban, List, LayoutGrid } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -16,6 +16,8 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { SectionHeader } from '@/components/dashboard/section-header';
+import { ProjectDagSvg, type DagNodeColor } from '@/components/dashboard/project-dag-svg';
+import { buildWorkflowDag } from '@/lib/project-dag';
 import {
   useProjects,
   useProjectWorkflow,
@@ -28,6 +30,7 @@ import { ApiError } from '@/lib/api-error';
 import {
   getTaskArtifactUrl,
   type ProjectStatus,
+  type ProjectSummary,
   type WorkflowNodeStatus,
   type WorkflowTaskDetail,
 } from '@/lib/agentteams-projects-api';
@@ -97,6 +100,18 @@ function normalizeNodeStatus(raw?: string): WorkflowNodeStatus {
       return 'pending';
   }
 }
+
+/** SVG node colors for the workflow DAG view — same palette family as
+ * NODE_STATUS_COLOR (badges) mapped to the shared ProjectDagSvg renderer. */
+const WORKFLOW_NODE_FILL: Record<string, DagNodeColor> = {
+  pending: { fill: 'rgba(148,163,184,0.12)', stroke: '#94a3b8', text: '#94a3b8' },
+  assigned: { fill: 'rgba(59,130,246,0.14)', stroke: '#3b82f6', text: '#93c5fd' },
+  in_progress: { fill: 'rgba(139,92,246,0.16)', stroke: '#8b5cf6', text: '#a78bfa' },
+  completed: { fill: 'rgba(16,185,129,0.14)', stroke: '#10b981', text: '#34d399' },
+  failed: { fill: 'rgba(239,68,68,0.14)', stroke: '#ef4444', text: '#f87171' },
+  blocked: { fill: 'rgba(245,158,11,0.14)', stroke: '#f59e0b', text: '#fbbf24' },
+  unknown: { fill: 'rgba(148,163,184,0.08)', stroke: '#64748b', text: '#94a3b8' },
+};
 
 /** Controller terminal statuses (isTerminalTaskStatus): these tasks cannot
  * be cancelled (409). cancelled itself stays cancellable but is already
@@ -766,6 +781,114 @@ function WorkflowDetail({
   );
 }
 
+// ----- Workflow DAG view (topo) -----
+
+function WorkflowDagView({
+  projectId,
+  teamId,
+}: {
+  projectId: string;
+  teamId?: string;
+}) {
+  const { data: wf, isLoading, isError } = useProjectWorkflow(projectId, teamId);
+  const dag = useMemo(
+    () =>
+      wf
+        ? buildWorkflowDag(
+            wf.nodes.map((n) => ({ id: n.id, name: n.name, status: n.status })),
+            wf.edges.map((e) => ({ source: e.source, target: e.target })),
+            wf.next,
+          )
+        : { nodes: [], edges: [], externalDeps: [] as string[] },
+    [wf],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10 text-muted-foreground text-sm gap-2">
+        <Loader2 className="h-4 w-4 animate-spin" /> 加载工作流…
+      </div>
+    );
+  }
+  if (isError || !wf) {
+    return (
+      <p className="text-center py-10 text-muted-foreground text-sm">
+        无法加载工作流（项目不存在或 API 不可用）
+      </p>
+    );
+  }
+  if (dag.nodes.length === 0) {
+    return (
+      <p className="text-center py-10 text-muted-foreground text-sm">
+        该项目暂无任务节点
+      </p>
+    );
+  }
+  if (dag.edges.length === 0 && dag.nodes.length <= 1) {
+    return (
+      <p className="text-center py-10 text-muted-foreground text-sm italic">
+        该项目任务之间暂无依赖关系
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1.5">
+        <GitBranch className="h-3 w-3" />
+        依赖图
+        <span className="text-[10px] text-muted-foreground/70 font-normal">
+          {dag.nodes.length} 任务 · {dag.edges.length} 依赖
+          {dag.externalDeps.length > 0 && ` · ${dag.externalDeps.length} 外部依赖`}
+        </span>
+      </p>
+      <div className="rounded-lg border bg-background/40 overflow-x-auto p-2">
+        <ProjectDagSvg
+          dag={dag}
+          nodeColors={WORKFLOW_NODE_FILL}
+          title={`${wf.title} 任务依赖图`}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ----- Project card (card view) -----
+
+function ProjectCard({
+  project,
+  selected,
+  onSelect,
+}: {
+  project: ProjectSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full text-left rounded-lg border p-3 text-xs transition-colors ${
+        selected
+          ? 'border-primary/50 bg-primary/5'
+          : 'border-muted hover:bg-muted/50'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-semibold truncate">{project.title}</span>
+        <ProjectStatusBadge status={project.status} />
+      </div>
+      <p className="text-[10px] text-muted-foreground font-mono mt-1 truncate">
+        {project.project_id}
+      </p>
+      <p className="text-[10px] text-muted-foreground mt-1">
+        {project.team_id ? `团队 ${project.team_id} · ` : ''}
+        {project.plan_type ?? 'dag'} · {project.mode ?? 'project'}
+      </p>
+    </button>
+  );
+}
+
 // ----- Main section -----
 
 export function ProjectsSection() {
@@ -773,6 +896,9 @@ export function ProjectsSection() {
   // (team, project_id) composite selection — the same project id can exist
   // under two teams (#1169 identity scoping).
   const [selectedKey, setSelectedKey] = useState<{ id: string; team?: string } | null>(null);
+  // Three views, aligned with the workbench plugin's WorkflowBoard:
+  // 列表 (list + detail) / 卡片 (card grid) / 拓扑 (DAG).
+  const [view, setView] = useState<'list' | 'card' | 'topo'>('list');
 
   const projects = data?.projects ?? [];
   const selected =
@@ -790,6 +916,27 @@ export function ProjectsSection() {
         isLive
         onRefresh={() => refetch()}
         isRefreshing={isRefetching}
+        actions={
+          <div className="flex items-center gap-1">
+            {(
+              [
+                { key: 'list', label: '列表', icon: List },
+                { key: 'card', label: '卡片', icon: LayoutGrid },
+                { key: 'topo', label: '拓扑', icon: GitBranch },
+              ] as const
+            ).map((v) => (
+              <Button
+                key={v.key}
+                variant={view === v.key ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setView(v.key)}
+              >
+                <v.icon className="h-3.5 w-3.5 mr-1" />
+                {v.label}
+              </Button>
+            ))}
+          </div>
+        }
       />
 
       <DegradedBanner
@@ -816,7 +963,7 @@ export function ProjectsSection() {
         </div>
       )}
 
-      {projects.length > 0 && (
+      {projects.length > 0 && view === 'list' && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
           {/* Project list */}
           <Card className="glass-card lg:col-span-1">
@@ -860,6 +1007,75 @@ export function ProjectsSection() {
               ) : (
                 <p className="text-center py-10 text-muted-foreground text-sm">
                   选择左侧项目查看工作流
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {projects.length > 0 && view === 'card' && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {projects.map((p) => (
+              <ProjectCard
+                key={`${p.team_id ?? ''}:${p.project_id}`}
+                project={p}
+                selected={
+                  selected?.project_id === p.project_id &&
+                  (selected?.team_id ?? '') === (p.team_id ?? '')
+                }
+                onSelect={() => setSelectedKey({ id: p.project_id, team: p.team_id })}
+              />
+            ))}
+          </div>
+          {selected && (
+            <Card className="glass-card">
+              <CardContent className="p-4">
+                <WorkflowDetail projectId={selected.project_id} teamId={selected.team_id} />
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {projects.length > 0 && view === 'topo' && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <Card className="glass-card lg:col-span-1">
+            <CardContent className="p-3 space-y-1.5">
+              <p className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1.5">
+                <GitBranch className="h-3.5 w-3.5" />
+                选择项目（{projects.length}）
+              </p>
+              {projects.map((p) => (
+                <button
+                  key={`${p.team_id ?? ''}:${p.project_id}`}
+                  onClick={() => setSelectedKey({ id: p.project_id, team: p.team_id })}
+                  className={`w-full text-left rounded-lg border p-2.5 text-xs transition-colors ${
+                    selected?.project_id === p.project_id &&
+                    (selected?.team_id ?? '') === (p.team_id ?? '')
+                      ? 'border-primary/50 bg-primary/5'
+                      : 'border-transparent hover:bg-muted/50'
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium truncate">{p.title}</span>
+                    <ProjectStatusBadge status={p.status} />
+                  </div>
+                  <p className="text-[10px] text-muted-foreground font-mono mt-0.5 truncate">
+                    {p.project_id}
+                  </p>
+                </button>
+              ))}
+            </CardContent>
+          </Card>
+          <Card className="glass-card lg:col-span-2">
+            <CardContent className="p-4">
+              {selected ? (
+                <WorkflowDagView projectId={selected.project_id} teamId={selected.team_id} />
+              ) : (
+                <p className="text-center py-10 text-muted-foreground text-sm">
+                  选择左侧项目查看依赖图
                 </p>
               )}
             </CardContent>

--- a/src/components/dashboard/sections/tasks-section.tsx
+++ b/src/components/dashboard/sections/tasks-section.tsx
@@ -44,7 +44,8 @@ import {
   type PlanItem,
 } from '@/hooks/use-task-board';
 import { useTaskStore } from '@/lib/task-store';
-import { buildProjectDag, layoutProjectDag } from '@/lib/project-dag';
+import { buildProjectDag } from '@/lib/project-dag';
+import { ProjectDagSvg, type DagNodeColor } from '@/components/dashboard/project-dag-svg';
 
 // ----- Status config -----
 
@@ -444,7 +445,7 @@ function ProjectPlanPreview({ project }: { project: BoardProject }) {
 
 // ----- Project DAG view -----
 
-const DAG_NODE_FILL: Record<TaskStatus, { fill: string; stroke: string; text: string }> = {
+const DAG_NODE_FILL: Record<string, DagNodeColor> = {
   pending: { fill: 'rgba(148,163,184,0.12)', stroke: '#94a3b8', text: '#94a3b8' },
   assigned: { fill: 'rgba(148,163,184,0.18)', stroke: '#94a3b8', text: '#cbd5e1' },
   in_progress: { fill: 'rgba(139,92,246,0.16)', stroke: '#8b5cf6', text: '#a78bfa' },
@@ -459,16 +460,6 @@ function ProjectDagView({ project, tasks }: { project: BoardProject; tasks: Boar
     () => buildProjectDag(tasks, project.runId),
     [tasks, project.runId],
   );
-  // Layout is computed unconditionally (before any early return) to satisfy
-  // the Rules of Hooks — layoutProjectDag is safe on an empty dag.
-  const W = 190;
-  const H = 40;
-  const GY = 64;
-  const layout = useMemo(
-    () => layoutProjectDag(dag, { nodeWidth: W, nodeHeight: H, gapY: GY }),
-    [dag],
-  );
-  const { width: svgW, height: svgH, positions: pos } = layout;
 
   if (dag.nodes.length === 0) return null;
   if (dag.edges.length === 0 && dag.nodes.length <= 1) {
@@ -496,68 +487,7 @@ function ProjectDagView({ project, tasks }: { project: BoardProject; tasks: Boar
         </span>
       </p>
       <div className="rounded-lg border bg-background/40 overflow-x-auto p-2">
-        <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} role="img" aria-label={`${project.name} 任务依赖图`}>
-          {dag.edges.map((e, i) => {
-            const a = pos.get(e.source);
-            const b = pos.get(e.target);
-            if (!a || !b) return null;
-            const x1 = a.x + W / 2;
-            const y1 = a.y + H;
-            const x2 = b.x + W / 2;
-            const y2 = b.y;
-            const my = (y1 + y2) / 2;
-            return (
-              <path
-                key={`edge-${i}`}
-                d={`M ${x1} ${y1} C ${x1} ${my}, ${x2} ${my}, ${x2} ${y2}`}
-                fill="none"
-                stroke="rgba(148,163,184,0.55)"
-                strokeWidth={1.2}
-                markerEnd="url(#dag-arrow)"
-              />
-            );
-          })}
-          <defs>
-            <marker id="dag-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
-              <path d="M0,0 L7,3 L0,6 Z" fill="rgba(148,163,184,0.7)" />
-            </marker>
-          </defs>
-          {dag.nodes.map((n) => {
-            const p = pos.get(n.id);
-            if (!p) return null;
-            const colors = DAG_NODE_FILL[n.status] ?? DAG_NODE_FILL.unknown;
-            // ~14 CJK glyphs at 11px fit inside W=190.
-            const label = n.title.length > 14 ? `${n.title.slice(0, 14)}…` : n.title;
-            return (
-              <g key={n.id}>
-                <title>{n.title}</title>
-                <rect
-                  x={p.x}
-                  y={p.y}
-                  width={W}
-                  height={H}
-                  rx={7}
-                  fill={colors.fill}
-                  stroke={n.ready ? '#22d3ee' : colors.stroke}
-                  strokeWidth={n.ready ? 1.8 : 1}
-                  strokeDasharray={n.ready ? '5 3' : undefined}
-                />
-                {n.ready && (
-                  <circle cx={p.x + 10} cy={p.y + H / 2} r={3} fill="#22d3ee" />
-                )}
-                <text
-                  x={p.x + 18}
-                  y={p.y + H / 2 + 4}
-                  fontSize={11}
-                  fill={colors.text}
-                  fontFamily="inherit"
-                >
-                  {label}
-                </text>
-              </g>
-            );
-          })}
-        </svg>
+        <ProjectDagSvg dag={dag} nodeColors={DAG_NODE_FILL} title={`${project.name} 任务依赖图`} />
       </div>
     </div>
   );

--- a/src/lib/project-dag.test.ts
+++ b/src/lib/project-dag.test.ts
@@ -236,6 +236,19 @@ describe('buildWorkflowDag', () => {
     expect(readyOf.get('t2')).toBe(true); // deps done, not completed
   });
 
+  it('trusts an EMPTY next array (paused project: nothing is ready)', () => {
+    const dag = buildWorkflowDag(
+      [
+        { id: 't1', name: 'A', status: 'completed' },
+        { id: 't2', name: 'B', status: 'pending' },
+      ],
+      [{ source: 't1', target: 't2' }],
+      [], // provided but empty — must NOT fall back to local derivation
+    );
+    const readyOf = new Map(dag.nodes.map((n) => [n.id, n.ready]));
+    expect(readyOf.get('t2')).toBe(false);
+  });
+
   it('tracks external dependencies (edge source not in nodes)', () => {
     const dag = buildWorkflowDag(
       [{ id: 't2', name: 'B', status: 'pending' }],

--- a/src/lib/project-dag.test.ts
+++ b/src/lib/project-dag.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from 'vitest';
-import { buildProjectDag, layoutProjectDag, type ProjectDag } from './project-dag';
+import { buildProjectDag, buildWorkflowDag, layoutProjectDag, type ProjectDag } from './project-dag';
 import type { BoardTask } from '@/hooks/use-task-board';
 
 function task(
@@ -165,5 +165,83 @@ describe('layoutProjectDag', () => {
     expect(layout.positions.size).toBe(0);
     expect(layout.width).toBe(0);
     expect(layout.height).toBe(40); // default nodeHeight fallback
+  });
+});
+
+describe('buildWorkflowDag', () => {
+  it('maps workflow nodes/edges to a ProjectDag (chain + status remap)', () => {
+    const dag = buildWorkflowDag(
+      [
+        { id: 't1', name: '采集', status: 'completed' },
+        { id: 't2', name: '整理', status: 'in-progress' },
+        { id: 't3', name: '报告', status: 'pending' },
+      ],
+      [
+        { source: 't1', target: 't2' },
+        { source: 't2', target: 't3' },
+      ],
+    );
+    expect(dag.nodes).toHaveLength(3);
+    expect(dag.edges).toHaveLength(2);
+    const byId = new Map(dag.nodes.map((n) => [n.id, n]));
+    expect(byId.get('t1')!.status).toBe('completed');
+    expect(byId.get('t2')!.status).toBe('in_progress'); // in-progress → in_progress
+    expect(byId.get('t3')!.status).toBe('pending');
+    // layers: t1=0, t2=1, t3=2
+    expect(byId.get('t1')!.layer).toBe(0);
+    expect(byId.get('t2')!.layer).toBe(1);
+    expect(byId.get('t3')!.layer).toBe(2);
+  });
+
+  it('remaps delegated/revision/blocked statuses', () => {
+    const dag = buildWorkflowDag(
+      [
+        { id: 'a', name: 'A', status: 'delegated' },
+        { id: 'b', name: 'B', status: 'revision' },
+        { id: 'c', name: 'C', status: 'blocked' },
+      ],
+      [],
+    );
+    const statusOf = new Map(dag.nodes.map((n) => [n.id, n.status]));
+    expect(statusOf.get('a')).toBe('assigned'); // delegated → assigned
+    expect(statusOf.get('b')).toBe('blocked'); // revision → blocked (amber)
+    expect(statusOf.get('c')).toBe('blocked');
+  });
+
+  it('marks ready from the provided next array', () => {
+    const dag = buildWorkflowDag(
+      [
+        { id: 't1', name: 'A', status: 'completed' },
+        { id: 't2', name: 'B', status: 'pending' },
+        { id: 't3', name: 'C', status: 'pending' },
+      ],
+      [{ source: 't1', target: 't2' }, { source: 't1', target: 't3' }],
+      ['t2'], // t2 ready, t3 blocked on something
+    );
+    const readyOf = new Map(dag.nodes.map((n) => [n.id, n.ready]));
+    expect(readyOf.get('t2')).toBe(true);
+    expect(readyOf.get('t3')).toBe(false);
+  });
+
+  it('derives ready locally when next is absent', () => {
+    const dag = buildWorkflowDag(
+      [
+        { id: 't1', name: 'A', status: 'completed' },
+        { id: 't2', name: 'B', status: 'pending' },
+      ],
+      [{ source: 't1', target: 't2' }],
+    );
+    const readyOf = new Map(dag.nodes.map((n) => [n.id, n.ready]));
+    expect(readyOf.get('t1')).toBe(false); // completed tasks are not ready
+    expect(readyOf.get('t2')).toBe(true); // deps done, not completed
+  });
+
+  it('tracks external dependencies (edge source not in nodes)', () => {
+    const dag = buildWorkflowDag(
+      [{ id: 't2', name: 'B', status: 'pending' }],
+      [{ source: 'ghost', target: 't2' }],
+    );
+    expect(dag.edges).toHaveLength(0); // ghost edge dropped from the graph
+    expect(dag.externalDeps).toContain('ghost');
   });
 });

--- a/src/lib/project-dag.ts
+++ b/src/lib/project-dag.ts
@@ -214,10 +214,11 @@ export function buildWorkflowDag(
 
   const dagNodes: DagNode[] = nodes.map((n) => {
     const deps = edges.filter((e) => e.target === n.id).map((e) => e.source);
-    // Local readiness derivation when `next` is absent: all deps completed
-    // and this task not completed.
+    // Readiness trusts the controller's `next` array whenever it is provided
+    // (even empty — a paused/completed project has no runnable tasks). The
+    // local derivation only kicks in when `next` is entirely absent.
     const allDepsDone = deps.every((d) => completedSet.has(d));
-    const ready = readySet.size > 0 ? readySet.has(n.id) : allDepsDone && n.status !== 'completed';
+    const ready = next ? readySet.has(n.id) : allDepsDone && n.status !== 'completed';
     return {
       id: n.id,
       title: n.name || n.id,

--- a/src/lib/project-dag.ts
+++ b/src/lib/project-dag.ts
@@ -176,3 +176,104 @@ export function buildProjectDag(
 
   return { nodes, edges, externalDeps: Array.from(externalDeps) };
 }
+
+/** Map a normalized workflow node status (controller normalizeTaskStatus:
+ * pending | delegated | in-progress | completed | revision | blocked) to the
+ * task-board status space for the shared DAG color table. revision (needs
+ * rework) renders as blocked-amber; blocked stays blocked. */
+const WORKFLOW_STATUS_MAP: Record<string, TaskStatus> = {
+  pending: 'pending',
+  delegated: 'assigned',
+  'in-progress': 'in_progress',
+  completed: 'completed',
+  revision: 'blocked',
+  blocked: 'blocked',
+  failed: 'failed',
+  unknown: 'unknown',
+};
+
+/**
+ * Build a ProjectDag from a workflow API response (nodes/edges/next) instead
+ * of the MinIO board tasks. The controller's workflow endpoints expose
+ * normalized statuses and explicit edges, so this only needs a status
+ * remap — no dependsOn filtering.
+ *
+ * `ready` mirrors the W-PR-1 `next` array (tasks whose dependencies are all
+ * completed), falling back to local derivation when `next` is not provided.
+ */
+export function buildWorkflowDag(
+  nodes: Array<{ id: string; name?: string; status?: string }>,
+  edges: Array<{ source: string; target: string }>,
+  next?: string[],
+): ProjectDag {
+  const readySet = new Set(next ?? []);
+  const completedSet = new Set(
+    nodes.filter((n) => n.status === 'completed').map((n) => n.id),
+  );
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+
+  const dagNodes: DagNode[] = nodes.map((n) => {
+    const deps = edges.filter((e) => e.target === n.id).map((e) => e.source);
+    // Local readiness derivation when `next` is absent: all deps completed
+    // and this task not completed.
+    const allDepsDone = deps.every((d) => completedSet.has(d));
+    const ready = readySet.size > 0 ? readySet.has(n.id) : allDepsDone && n.status !== 'completed';
+    return {
+      id: n.id,
+      title: n.name || n.id,
+      status: WORKFLOW_STATUS_MAP[n.status ?? ''] ?? 'unknown',
+      ready,
+      layer: 0,
+    };
+  });
+
+  const dagEdges: DagEdge[] = edges
+    .filter((e) => byId.has(e.source) && byId.has(e.target))
+    .map((e) => ({ source: e.source, target: e.target }));
+  const externalDeps = Array.from(
+    new Set(
+      edges
+        .filter((e) => !byId.has(e.source) && byId.has(e.target))
+        .map((e) => e.source),
+    ),
+  );
+
+  // Iterative layering (same as buildProjectDag): layer = max(dep layer) + 1.
+  const layerOf = new Map<string, number>();
+  const maxPasses = dagNodes.length + 1;
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let changed = false;
+    for (const node of dagNodes) {
+      const deps = dagEdges.filter((e) => e.target === node.id).map((e) => e.source);
+      if (deps.length === 0) {
+        if (layerOf.get(node.id) !== 0) {
+          layerOf.set(node.id, 0);
+          changed = true;
+        }
+        continue;
+      }
+      let maxDep = -1;
+      for (const d of deps) {
+        const l = layerOf.get(d);
+        if (l === undefined) {
+          maxDep = -1;
+          break;
+        }
+        if (l > maxDep) maxDep = l;
+      }
+      if (maxDep >= 0) {
+        const nextLayer = maxDep + 1;
+        if (layerOf.get(node.id) !== nextLayer) {
+          layerOf.set(node.id, nextLayer);
+          changed = true;
+        }
+      }
+    }
+    if (!changed) break;
+  }
+  for (const node of dagNodes) {
+    node.layer = layerOf.get(node.id) ?? 0;
+  }
+
+  return { nodes: dagNodes, edges: dagEdges, externalDeps };
+}


### PR DESCRIPTION
# Projects section: workflow three views (list / card / topo)

## Summary

Adds three interchangeable views to the dashboard projects section — 📋 list, 🗂️ card and 🌳 topo (dependency graph) — aligned with the visual language of the project-workflow consumers elsewhere. The topo view renders the workflow API's nodes/edges as a top-down DAG, and the existing MinIO task board's SVG renderer is extracted into a shared component so both data sources draw the same graph style.

为仪表盘项目页新增三种可切换视图——📋 列表、🗂️ 卡片、🌳 拓扑（依赖图），与其他项目工作流消费方的视觉语言对齐。拓扑视图将工作流 API 的 nodes/edges 渲染为自上而下的 DAG；同时把现有 MinIO 任务看板的 SVG 渲染器抽取为共享组件，两套数据源共用同一绘图风格。

## What's included

1. `src/lib/project-dag.ts` — new `buildWorkflowDag(nodes, edges, next?)`: builds a `ProjectDag` from a workflow API response (normalized statuses + explicit edges), remapping workflow statuses onto the board's status space (`delegated→assigned`, `in-progress→in_progress`, `revision→blocked`) and deriving readiness from the controller's `next` array (with a local derivation fallback).
2. `src/components/dashboard/project-dag-svg.tsx` — **new shared component** `ProjectDagSvg`: the top-down DAG SVG renderer (edges, markers, ready-node cyan dashes) extracted from `tasks-section`, parameterized by a status→color table so each caller passes its own palette. The arrow marker uses `useId()` so multiple DAG instances on one page don't collide.
3. `src/components/dashboard/sections/tasks-section.tsx` — `ProjectDagView` now renders through the shared `ProjectDagSvg` (no behavior change; ~60 lines removed from the section).
4. `src/components/dashboard/sections/projects-section.tsx`:
   - view switcher in the section header (列表 / 卡片 / 拓扑, same button pattern as the task board's view toggle)
   - **list** — the existing two-column layout (project list + workflow detail), unchanged
   - **card** — project card grid (title/status badge/team/plan type), clicking a card selects it and renders the workflow detail below
   - **topo** — project picker + `WorkflowDagView` rendering the selected project's nodes/edges via `buildWorkflowDag` + `ProjectDagSvg` with a workflow-specific palette
   - selection comparison extracted into `isSameProject()` (composite team+id identity); unknown/future statuses normalize to `blocked` (never look actionable as 待办)
5. Tests — 6 new `buildWorkflowDag` tests (chain + status remap, delegated/revision/blocked remap, ready from `next`, local ready derivation, empty-`next` paused project, external deps).

## Data boundary

- The three views read the workflow already proxied by the projects API consumer (agentteams/AgentTeams#1169) — no new API surface.
- The shared DAG renderer is a pure refactor of the existing task-board graph — same layout algorithm (`layoutProjectDag`), same edge/node style.
- No change to data sources or auth: list/card/topo all read the workflow already fetched for the detail view.

## Tests

- `src/lib/project-dag.test.ts`: +6 tests (chain layers + status remap / delegated-revision-blocked remap / ready from `next` / local ready derivation / empty-`next` paused project / external dependencies); 17 total all green
- Full suite verified against the latest main baseline — same 43 pre-existing suite failures (upstream jsdom env + `node:` routes), zero new failures
- `tsc --noEmit` clean (adm-zip baseline only); `eslint` clean on all changed files

## Related

- agentteams/AgentTeams#1169: projects/workflow API consumed by this section

---

## 摘要

为仪表盘项目页新增三种可切换视图——📋 列表、🗂️ 卡片、🌳 拓扑（依赖图），与其他项目工作流消费方的视觉语言对齐。拓扑视图将工作流 API 的 nodes/edges 渲染为自上而下的 DAG；同时把现有 MinIO 任务看板的 SVG 渲染器抽取为共享组件，两套数据源共用同一绘图风格。

## 包含内容

1. `src/lib/project-dag.ts` — 新增 `buildWorkflowDag(nodes, edges, next?)`：从工作流 API 响应构建 `ProjectDag`（归一化状态 + 显式 edges），状态重映射到看板状态空间（`delegated→assigned`、`in-progress→in_progress`、`revision→blocked`），就绪判定取自 Controller 的 `next` 数组（缺省时本地推导兜底）。
2. `src/components/dashboard/project-dag-svg.tsx` — **新共享组件** `ProjectDagSvg`：从 tasks-section 抽取的自上而下 DAG SVG 渲染器（边、箭头、就绪节点青色虚线），颜色表参数化，调用方各自传入调色板。箭头 marker 用 `useId()`，同页多 DAG 实例不冲突。
3. `src/components/dashboard/sections/tasks-section.tsx` — `ProjectDagView` 改为经共享 `ProjectDagSvg` 渲染（行为不变；该 section 删减约 60 行）。
4. `src/components/dashboard/sections/projects-section.tsx`：
   - 页头视图切换（列表 / 卡片 / 拓扑，沿用任务看板切换按钮模式）
   - **列表** — 现有双栏布局（项目列表 + 工作流详情），不变
   - **卡片** — 项目卡片网格（标题/状态徽章/团队/计划类型），点击选中并在下方渲染工作流详情
   - **拓扑** — 项目选择器 + `WorkflowDagView`，经 `buildWorkflowDag` + `ProjectDagSvg` 渲染所选项目依赖图（工作流专用配色）
   - 选中比较提取为 `isSameProject()`（团队+项目 id 复合身份）；未知/未来状态归一化为 `blocked`（绝不显示成可行动的「待办」）
5. 测试 — 新增 6 个 `buildWorkflowDag` 测试（链式分层 + 状态重映射 / delegated-revision-blocked 重映射 / `next` 就绪 / 本地就绪推导 / 空 `next` 暂停项目 / 外部依赖）。

## 数据边界

- 三种视图读取的正是项目 API 消费方（agentteams/AgentTeams#1169）已代理的工作流数据——无新增 API 面。
- 共享 DAG 渲染器是现有任务看板图的纯重构——同一布局算法（`layoutProjectDag`）、同一连线与节点样式。
- 数据源与认证零变更：三种视图都读取详情视图已拉取的工作流数据。

## 测试

- `src/lib/project-dag.test.ts`：+6 测试（链式分层+状态重映射 / delegated-revision-blocked 重映射 / `next` 就绪 / 本地就绪推导 / 空 `next` 暂停项目 / 外部依赖）；17 个全绿
- 全量对照最新 main 基线验证——同样 43 个既有 suite 失败（上游 jsdom 环境 + `node:` 路由），零新增失败
- `tsc --noEmit` 干净（仅 adm-zip 基线）；`eslint` 对全部改动文件干净

## 相关

- agentteams/AgentTeams#1169：本节消费的项目/工作流 API
