### PR TITLE
feat(tasks): task board primary source switches to Controller API with MinIO fallback

### DIFF
--- a/src/components/dashboard/sections/tasks-section.tsx
+++ b/src/components/dashboard/sections/tasks-section.tsx
@@ -43,6 +43,7 @@ import {
   type ProjectStatus,
   type PlanItem,
 } from '@/hooks/use-task-board';
+import { useApiTaskBoard } from '@/hooks/use-projects';
 import { useTaskStore } from '@/lib/task-store';
 import { buildProjectDag } from '@/lib/project-dag';
 import { ProjectDagSvg, type DagNodeColor } from '@/components/dashboard/project-dag-svg';
@@ -503,13 +504,55 @@ export function TasksSection() {
   const clearTasks = useTaskStore((s) => s.clearTasks);
   const liveCount = useTaskStore(useShallow((s) => Object.keys(s.tasks).length));
 
-  const board = useMergedTaskBoard({ refetchInterval: 8000 });
+  // D5 双轨：主源 = Controller projects/workflow API（standardized），
+  // 降级 = MinIO 直读看板（API 未部署/Controller 故障时 fallback）。
+  // Matrix 实时事件（useTaskStore）作为叠加层两轨共享。
+  const apiBoard = useApiTaskBoard();
+  const minioBoard = useMergedTaskBoard({
+    refetchInterval: 8000,
+    enabled: apiBoard.degraded,
+  });
+  const primary = apiBoard.degraded ? minioBoard : apiBoard;
   useLogTaskBoardScan(
-    board.matchedPrefixes,
-    board.scannedKeys,
-    board.bucket,
-    board.error,
+    minioBoard.matchedPrefixes,
+    minioBoard.scannedKeys,
+    minioBoard.bucket,
+    minioBoard.error,
   );
+
+  // Live Matrix workflow events fill in runIds the board doesn't know about
+  // and refresh statuses. Subscribed reactively (not getState snapshot) so
+  // live updates re-merge into the board.
+  const live = useTaskStore(useShallow((s) => s.tasks));
+  const board = useMemo(() => {
+    const byId = new Map<string, (typeof primary.tasks)[number]>();
+    for (const t of primary.tasks) byId.set(t.runId, t);
+    for (const [, e] of Object.entries(live)) {
+      const existing = byId.get(e.runId);
+      const liveTask = {
+        runId: e.runId,
+        title: e.title,
+        status: e.status as TaskStatus,
+        assignedTo: e.senderMatrixUserId,
+        roomId: e.roomId,
+        projectId: existing?.projectId,
+        dependsOn: existing?.dependsOn ?? [],
+        createdAt: e.createdAt,
+        completedAt: existing?.completedAt,
+        outcome: existing?.outcome ?? null,
+        spec: existing?.spec,
+        source: 'matrix-live',
+      };
+      byId.set(
+        e.runId,
+        existing ? { ...existing, status: liveTask.status } : liveTask,
+      );
+    }
+    return {
+      ...primary,
+      tasks: Array.from(byId.values()).sort((a, b) => b.createdAt - a.createdAt),
+    };
+  }, [primary, live]);
 
   const { data: managers } = useManagers();
   const { data: workers } = useWorkers();
@@ -583,7 +626,9 @@ export function TasksSection() {
         title="任务看板"
         description={
           matrixLoggedIn
-            ? 'Manager 拆分 / Worker 执行的实时进度,以 MinIO 持久化 + Matrix 实时为双数据源'
+            ? apiBoard.degraded
+              ? 'Controller 项目 API 降级 — 回退 MinIO 持久化 + Matrix 实时双数据源'
+              : 'Controller 项目 API 主源（#1169）— 项目/任务实时进度，Matrix 事件叠加'
             : '需要先登录 Matrix 才能拉取实时数据'
         }
         actions={
@@ -621,7 +666,11 @@ export function TasksSection() {
               size="sm"
               onClick={handleReload}
               disabled={board.isLoading}
-              title="清空 Matrix 缓存并重新拉取 MinIO 任务"
+              title={
+              apiBoard.degraded
+                ? '清空 Matrix 缓存并重新拉取 MinIO 任务'
+                : '清空 Matrix 实时叠加并重新拉取 Controller 项目 API'
+            }
             >
               <RefreshCw className={`h-3.5 w-3.5 mr-1 ${board.isLoading ? 'animate-spin' : ''}`} />
               刷新
@@ -667,22 +716,23 @@ export function TasksSection() {
         ))}
       </div>
 
-      {/* Diagnostic banner */}
-      {board.bucket && board.scannedKeys.length === 0 && !board.isLoading && (
+      {/* Diagnostic banner (MinIO fallback only — the API primary source
+          reports its own degraded state via the projects section). */}
+      {apiBoard.degraded && minioBoard.bucket && minioBoard.scannedKeys.length === 0 && !minioBoard.isLoading && (
         <Card className="glass-card border-amber-500/30 bg-amber-500/5">
           <CardContent className="p-3 flex items-start gap-2 text-xs">
             <Database className="h-3.5 w-3.5 text-amber-500 mt-0.5 shrink-0" />
             <div className="space-y-1">
               <p className="font-medium text-amber-700 dark:text-amber-400">
-                MinIO 暂未发现任务数据
+                MinIO 暂未发现任务数据（Controller API 已降级）
               </p>
               <p className="text-muted-foreground">
-                Bucket <code className="font-mono">{board.bucket}</code> · 扫描路径{' '}
+                Bucket <code className="font-mono">{minioBoard.bucket}</code> · 扫描路径{' '}
                 <code className="font-mono">shared/tasks/, shared/projects/, agents/*/task-history.json</code>
-                {board.matchedPrefixes.length > 0 && (
+                {minioBoard.matchedPrefixes.length > 0 && (
                   <>
                     {' '}· 匹配:{' '}
-                    <code className="font-mono">{board.matchedPrefixes.join(', ')}</code>
+                    <code className="font-mono">{minioBoard.matchedPrefixes.join(', ')}</code>
                   </>
                 )}
               </p>

--- a/src/hooks/use-projects.test.ts
+++ b/src/hooks/use-projects.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { workflowToBoard } from './use-projects';
+import type { WorkflowResponse, ProjectSummary, WorkflowNodeStatus } from '@/lib/agentteams-projects-api';
+
+function proj(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
+  return {
+    project_id: 'p1',
+    title: 'P',
+    status: 'active',
+    team_id: 't1',
+    ...overrides,
+  };
+}
+
+function wf(overrides: Partial<WorkflowResponse> = {}): WorkflowResponse {
+  return {
+    project_id: 'p1',
+    title: 'P',
+    status: 'active',
+    nodes: [],
+    edges: [],
+    next: [],
+    interrupts: [],
+    ...overrides,
+  };
+}
+
+describe('workflowToBoard (D5 API primary mapping)', () => {
+  it('maps projects to BoardProject shape', () => {
+    const wfs = new Map([['p1', wf()]]);
+    const { projects } = workflowToBoard([proj()], wfs);
+    expect(projects).toHaveLength(1);
+    expect(projects[0].runId).toBe('p1');
+    expect(projects[0].name).toBe('P');
+    expect(projects[0].status).toBe('active');
+    expect(projects[0].source).toBe('api');
+    expect(projects[0].roomId).toBe(''); // no source_room_id
+  });
+
+  it('maps nodes to tasks with status remap + dependsOn rebuilt from edges', () => {
+    const wfs = new Map([
+      ['p1', wf({
+        source_room_id: '!room',
+        nodes: [
+          { id: 't1', name: '采集', status: 'completed' },
+          { id: 't2', name: '整理', status: 'in-progress', assignee: 'alice' },
+          { id: 't3', name: '报告', status: 'pending' },
+        ],
+        edges: [
+          { source: 't1', target: 't2' },
+          { source: 't2', target: 't3' },
+        ],
+      })],
+    ]);
+    const { tasks } = workflowToBoard([proj()], wfs);
+    const byId = new Map(tasks.map((t) => [t.runId, t]));
+    expect(byId.get('t1')!.status).toBe('completed');
+    expect(byId.get('t2')!.status).toBe('in_progress'); // in-progress → in_progress
+    expect(byId.get('t2')!.assignedTo).toBe('alice');
+    expect(byId.get('t2')!.dependsOn).toEqual(['t1']);
+    expect(byId.get('t3')!.dependsOn).toEqual(['t2']);
+    expect(byId.get('t1')!.projectId).toBe('p1');
+    expect(byId.get('t2')!.source).toBe('api');
+  });
+
+  it('maps tasks_detail outcome + spec (summary)', () => {
+    const wfs = new Map([
+      ['p1', wf({
+        nodes: [{ id: 't1', name: 'A', status: 'completed' }],
+        edges: [],
+        tasks_detail: [
+          {
+            task_id: 't1',
+            status: 'completed',
+            result_status: 'SUCCESS_WITH_NOTES',
+            summary: '摘要文本',
+          },
+        ],
+      })],
+    ]);
+    const { tasks } = workflowToBoard([proj()], wfs);
+    expect(tasks[0].outcome).toBe('SUCCESS_WITH_NOTES');
+    expect(tasks[0].spec).toBe('摘要文本');
+  });
+
+  it('maps revision/blocked statuses to blocked; unknown to unknown', () => {
+    const wfs = new Map([
+      ['p1', wf({
+        nodes: [
+          { id: 'a', name: 'A', status: 'revision' },
+          // Controller normalizes cancelled→blocked already; these casts
+          // exercise the mapper's defensive branches.
+          { id: 'b', name: 'B', status: 'cancelled' as WorkflowNodeStatus },
+          { id: 'c', name: 'C', status: 'weird-future' as WorkflowNodeStatus },
+        ],
+        edges: [],
+      })],
+    ]);
+    const { tasks } = workflowToBoard([proj()], wfs);
+    const statusOf = new Map(tasks.map((t) => [t.runId, t.status]));
+    expect(statusOf.get('a')).toBe('blocked');
+    expect(statusOf.get('b')).toBe('blocked');
+    expect(statusOf.get('c')).toBe('unknown');
+  });
+
+  it('skips projects without a workflow response (tasks empty, project kept)', () => {
+    const { tasks, projects } = workflowToBoard([proj(), proj({ project_id: 'p2' })], new Map());
+    expect(projects).toHaveLength(2);
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('surfaces requester as leader', () => {
+    const wfs = new Map([['p1', wf({ requester: '@manager:hs' })]]);
+    const { projects } = workflowToBoard([proj()], wfs);
+    expect(projects[0].leader).toBe('@manager:hs');
+  });
+});

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -1,4 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient, useQueries } from '@tanstack/react-query';
 import {
   listProjects,
   getProjectWorkflow,
@@ -6,7 +7,10 @@ import {
   resumeProject,
   replanProject,
   cancelProjectTask,
+  type ProjectSummary,
+  type WorkflowResponse,
 } from '@/lib/agentteams-projects-api';
+import type { BoardProject, BoardTask, TaskStatus } from '@/hooks/use-task-board';
 
 /**
  * Fetch the AgentTeams project list through the dashboard proxy
@@ -137,4 +141,167 @@ export function useCancelProjectTask() {
       invalidateProjectQueries(queryClient, args.projectId, args.teamId);
     },
   });
+}
+
+// ----- Task board primary source (D5): Controller API over MinIO -----
+
+/** Workflow node status → board TaskStatus (same remap as buildWorkflowDag). */
+function workflowStatusToTaskStatus(status?: string): TaskStatus {
+  switch (status) {
+    case 'pending':
+    case 'planned':
+    case '':
+      return 'pending';
+    case 'delegated':
+    case 'assigned':
+      return 'assigned';
+    case 'in-progress':
+    case 'in_progress':
+    case 'submitted':
+      return 'in_progress';
+    case 'completed':
+      return 'completed';
+    case 'failed':
+    case 'error':
+      return 'failed';
+    case 'blocked':
+    case 'cancelled':
+    case 'revision':
+      return 'blocked';
+    default:
+      return 'unknown';
+  }
+}
+
+function resultStatusToOutcome(resultStatus?: string): BoardTask['outcome'] {
+  switch (resultStatus) {
+    case 'SUCCESS':
+      return 'SUCCESS';
+    case 'SUCCESS_WITH_NOTES':
+      return 'SUCCESS_WITH_NOTES';
+    case 'REVISION_NEEDED':
+      return 'REVISION_NEEDED';
+    case 'BLOCKED':
+      return 'BLOCKED';
+    default:
+      return null;
+  }
+}
+
+/** Map the Controller projects + workflows to the task-board shapes so the
+ * existing board UI renders from the API primary source (D5). Dependencies
+ * are rebuilt from workflow edges (edge source → target means target depends
+ * on source) — this is also the D8 data-source upgrade for the DAG view. */
+export function workflowToBoard(
+  projects: ProjectSummary[],
+  workflows: Map<string, WorkflowResponse>,
+): { tasks: BoardTask[]; projects: BoardProject[] } {
+  const boardTasks: BoardTask[] = [];
+  const boardProjects: BoardProject[] = [];
+
+  for (const proj of projects) {
+    const wf = workflows.get(proj.project_id);
+    boardProjects.push({
+      runId: proj.project_id,
+      name: proj.title,
+      status: proj.status,
+      roomId: wf?.source_room_id ?? '',
+      leader: wf?.requester || undefined,
+      workers: [],
+      phases: [], // plan.md phases are MinIO-only; the API board renders tasks directly
+      createdAt: 0,
+      completedAt: undefined,
+      source: 'api',
+    });
+    if (!wf) continue;
+
+    // Dependencies: edge source -> target means target depends on source.
+    const dependsOf = new Map<string, string[]>();
+    for (const edge of wf.edges) {
+      const list = dependsOf.get(edge.target) ?? [];
+      list.push(edge.source);
+      dependsOf.set(edge.target, list);
+    }
+
+    // Per-task detail (result_status → outcome) when includeTasks was fetched.
+    const detailByTask = new Map(
+      (wf.tasks_detail ?? []).map((t) => [t.task_id, t]),
+    );
+
+    for (const node of wf.nodes) {
+      const detail = detailByTask.get(node.id);
+      boardTasks.push({
+        runId: node.id,
+        title: node.name || node.id,
+        status: workflowStatusToTaskStatus(node.status),
+        assignedTo: node.assignee ?? '',
+        projectId: proj.project_id,
+        roomId: wf.source_room_id ?? '',
+        dependsOn: dependsOf.get(node.id) ?? [],
+        createdAt: 0,
+        completedAt: detail?.status === 'completed' ? undefined : undefined,
+        outcome: resultStatusToOutcome(detail?.result_status),
+        spec: detail?.summary || undefined,
+        source: 'api',
+      });
+    }
+  }
+
+  return { tasks: boardTasks, projects: boardProjects };
+}
+
+/** Primary task-board source: Controller projects + per-project workflow
+ * (cap 20), mapped to the board shapes. Falls back to the MinIO board when
+ * the API is degraded (list 404 = not deployed / 500 = controller error). */
+export function useApiTaskBoard() {
+  const listQuery = useProjects();
+  const queryClient = useQueryClient();
+
+  const projects = useMemo(
+    () => (listQuery.data?.projects ?? []).slice(0, 20),
+    [listQuery.data?.projects],
+  );
+
+  // Degraded = list endpoint responded with a degraded payload (404 API not
+  // deployed / 500 controller error) OR the request failed entirely (network
+  // / proxy down). In both cases the caller falls back to the MinIO board —
+  // otherwise the board would render blank on a proxy outage.
+  const degraded = listQuery.data?.degraded === true || listQuery.isError === true;
+
+  const workflowQueries = useQueries({
+    queries: projects.map((p) => ({
+      queryKey: ['agentteams-project-workflow', p.team_id ?? 'any', p.project_id],
+      queryFn: () =>
+        getProjectWorkflow(p.project_id, { includeTasks: true, teamId: p.team_id }),
+      enabled: !degraded,
+      retry: 1,
+      staleTime: 15000,
+    })),
+  });
+
+  // Pure mapping, recomputed per render: <20 projects / ~100 tasks makes
+  // this O(n) trivially cheap, and avoiding memo dependencies on the
+  // useQueries results array (whose reference stability is not guaranteed)
+  // removes a whole class of stale-memo bugs.
+  const workflows = new Map<string, WorkflowResponse>();
+  workflowQueries.forEach((q, i) => {
+    if (q.data && projects[i]) workflows.set(projects[i].project_id, q.data);
+  });
+  const board = workflowToBoard(projects, workflows);
+
+  return {
+    ...board,
+    degraded,
+    degradedReason: listQuery.data?.degradedReason,
+    isLoading: listQuery.isLoading,
+    isRefetching: listQuery.isRefetching,
+    // Refresh must re-pull the per-project workflows too — the list query
+    // alone would leave stale workflow data behind (staleTime 15s).
+    refetch: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['agentteams-project-workflow'],
+      });
+      void listQuery.refetch();
+    },
+  };
 }


### PR DESCRIPTION
# Task board: Controller API primary source with MinIO fallback

## Summary

Switches the dashboard task board's primary data source from the direct-MinIO scan to the standardized Controller project API (agentteams/AgentTeams#1169), keeping the existing MinIO + Matrix live path as a fallback when the API is not deployed or the controller fails. Task dependencies now come from the workflow API's edges, which also upgrades the board's DAG view to the workflow graph data.

## What's included

1. `src/hooks/use-projects.ts`:
   - `workflowToBoard(projects, workflows)` — pure mapping from `ProjectSummary[]` + per-project `WorkflowResponse` to the board shapes (`BoardTask[]` / `BoardProject[]`): nodes→tasks (status remap `delegated→assigned`, `in-progress→in_progress`, `revision/blocked/cancelled→blocked`, unknown→unknown), `dependsOn` rebuilt from workflow edges, `outcome` from `tasks_detail.result_status`, `spec` from `tasks_detail.summary`, `requester`→leader.
   - `useApiTaskBoard()` — primary-source hook: project list + per-project workflow (cap 20, cache keys shared with the projects section) mapped through `workflowToBoard`; exposes `degraded` / `degradedReason` (a degraded payload **or** a failed list request — network/proxy outages also fall back to MinIO); `refetch` re-pulls both the list and the per-project workflows.
2. `src/components/dashboard/sections/tasks-section.tsx`:
   - dual-track data flow: API primary (`useApiTaskBoard`) → MinIO fallback (`useMergedTaskBoard`, enabled only when degraded); Matrix live events remain the shared overlay on both tracks.
   - the MinIO diagnostic banner only renders in the fallback mode; the section description reflects the active source.
3. Tests — 6 new `workflowToBoard` tests (project mapping / node+edge mapping with dependsOn rebuild / outcome+spec / defensive status remaps / missing workflow handling / requester→leader).

## Data boundary

- No new API surface — the board now reads the same proxied endpoints the projects section already uses (`/api/agentteams/projects` + `/{id}/workflow?includeTasks=true`).
- Fallback semantics unchanged from the existing board: when the list degrades (404 = API not deployed / 500 = controller error), the board renders from MinIO + Matrix exactly as before.
- `phases` (plan.md plan preview) stays MinIO-only: the API board renders tasks directly and shows the existing no-plan hint.

## Tests

- `src/hooks/use-projects.test.ts`: +6 tests; all green
- Full suite verified against the latest main baseline — same 43 pre-existing suite failures (upstream jsdom env + `node:` routes), zero new failures
- `tsc --noEmit` clean (adm-zip baseline only); `eslint` clean on changed files

## Related

- agentteams/AgentTeams#1169: projects/workflow API (the new primary source)

---

## 摘要

将仪表盘任务看板的主数据源从直读 MinIO 切换为标准化 Controller 项目 API（agentteams/AgentTeams#1169），保留现有 MinIO + Matrix 实时路径作为 API 未部署或 Controller 故障时的降级。任务依赖改从工作流 API 的 edges 获取，看板 DAG 视图也随之升级为工作流图数据。

## 包含内容

1. `src/hooks/use-projects.ts`：
   - `workflowToBoard(projects, workflows)` — 从 `ProjectSummary[]` + 每项目 `WorkflowResponse` 到看板形状（`BoardTask[]` / `BoardProject[]`）的纯映射：nodes→tasks（状态重映射 `delegated→assigned`、`in-progress→in_progress`、`revision/blocked/cancelled→blocked`、未知→unknown），`dependsOn` 从工作流 edges 反推重建，`outcome` 取自 `tasks_detail.result_status`，`spec` 取自 `tasks_detail.summary`，`requester`→leader。
   - `useApiTaskBoard()` — 主源 hook：项目列表 + 每项目工作流（上限 20，缓存 key 与项目页共享）经 `workflowToBoard` 映射；透出 `degraded` / `degradedReason`（降级载荷**或**列表请求失败——网络/代理中断同样回退 MinIO）；`refetch` 同时重拉列表与每项目工作流。
2. `src/components/dashboard/sections/tasks-section.tsx`：
   - 双轨数据流：API 主源（`useApiTaskBoard`）→ MinIO 降级（`useMergedTaskBoard`，仅在降级时启用）；Matrix 实时事件作为两轨共享的叠加层。
   - MinIO 诊断横幅仅在降级模式渲染；页头描述反映当前数据源。
3. 测试 — 新增 6 个 `workflowToBoard` 测试（项目映射 / 节点+边映射与 dependsOn 重建 / outcome+spec / 防御性状态重映射 / 缺工作流处理 / requester→leader）。

## 数据边界

- 无新增 API 面——看板现在读取项目页已在用的同一套代理端点（`/api/agentteams/projects` + `/{id}/workflow?includeTasks=true`）。
- 降级语义与现有看板一致：列表降级时（404 = API 未部署 / 500 = Controller 故障），看板照旧从 MinIO + Matrix 渲染。
- `phases`（plan.md 计划预览）仍属 MinIO 专属：API 看板直接渲染任务并显示现有「暂无 plan.md 计划阶段」提示。

## 测试

- `src/hooks/use-projects.test.ts`：+6 测试；全部通过
- 全量对照最新 main 基线验证——同样 43 个既有 suite 失败（上游 jsdom 环境 + `node:` 路由），零新增失败
- `tsc --noEmit` 干净（仅 adm-zip 基线）；`eslint` 对改动文件干净

## 相关

- agentteams/AgentTeams#1169：项目/工作流 API（新主源）