### PR TITLE
feat(projects): project timeline + worker checkpoint panels

### DIFF
--- a/src/app/api/agentteams/projects/[id]/history/[ts]/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/history/[ts]/route.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+const TS = '1723785123456789020';
+
+async function callGet(
+  projectId: string,
+  ts: string,
+  controllerStatus: number,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: 'paused', title: 't' }), {
+        status: controllerStatus,
+      }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.GET(
+    {
+      method: 'GET',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/history/${ts}`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+    } as never,
+    { params: Promise.resolve({ id: projectId, ts }) },
+  );
+  return response;
+}
+
+describe('GET /api/agentteams/projects/[id]/history/[ts] (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('proxies to the canonical snapshot path with the raw timestamp', async () => {
+    const res = await callGet('p1', TS, 200);
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      `http://controller.test/api/v1/projects/p1/history/${TS}`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('forwards team query and drops controllerUrl', async () => {
+    await callGet('p1', TS, 200, 'team=biz-team&controllerUrl=http://evil');
+    expect(fetch).toHaveBeenCalledWith(
+      `http://controller.test/api/v1/projects/p1/history/${TS}?team=biz-team`,
+      expect.anything(),
+    );
+  });
+
+  it('encodes both id and timestamp segments', async () => {
+    await callGet('a/b c', 'x/9', 200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/history/x%2F9',
+      expect.anything(),
+    );
+  });
+
+  it('passes through 404 (snapshot missing / endpoint not deployed yet)', async () => {
+    const res = await callGet('p1', '123', 404);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/history/[ts]/route.ts
+++ b/src/app/api/agentteams/projects/[id]/history/[ts]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/agentteams/projects/{id}/history/{ts}
+//
+// Proxies one pre-intervention snapshot's raw meta JSON
+// (`GET /api/v1/projects/{id}/history/{ts}` — 19-digit unix nanosecond
+// timestamp, see docs/zh-cn/usage/project-workflow-api.md).
+//
+// Query parameters are forwarded (notably `?team=`), except the internal
+// `controllerUrl` override. Non-OK statuses pass through (404 snapshot
+// missing / endpoint not deployed yet, 403 cross-team).
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ts: string }> },
+) {
+  const { id, ts } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/history/${encodeURIComponent(ts)}${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { forwardBody: false },
+  );
+}

--- a/src/app/api/agentteams/projects/[id]/history/route.test.ts
+++ b/src/app/api/agentteams/projects/[id]/history/route.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callGet(projectId: string, controllerStatus: number, query = '') {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ project_id: projectId, snapshots: [] }),
+        { status: controllerStatus },
+      ),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.GET(
+    {
+      method: 'GET',
+      nextUrl: {
+        pathname: `/api/agentteams/projects/${projectId}/history`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+    } as never,
+    { params: Promise.resolve({ id: projectId }) },
+  );
+  return response;
+}
+
+describe('GET /api/agentteams/projects/[id]/history (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('proxies to the canonical controller path', async () => {
+    const res = await callGet('p1', 200);
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/history',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('forwards team query and drops controllerUrl', async () => {
+    await callGet('p1', 200, 'team=biz-team&controllerUrl=http://evil');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/p1/history?team=biz-team',
+      expect.anything(),
+    );
+  });
+
+  it('encodes the project id in the proxied path', async () => {
+    await callGet('a/b c', 200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/projects/a%2Fb%20c/history',
+      expect.anything(),
+    );
+  });
+
+  it('passes through 404 (project missing / endpoint not deployed yet)', async () => {
+    const res = await callGet('ghost', 404);
+    expect(res.status).toBe(404);
+  });
+
+  it('passes through 403 cross-team', async () => {
+    const res = await callGet('p1', 403);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/agentteams/projects/[id]/history/route.ts
+++ b/src/app/api/agentteams/projects/[id]/history/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/agentteams/projects/{id}/history
+//
+// Proxies the controller's intervention-history list endpoint
+// (`GET /api/v1/projects/{id}/history`, see
+// docs/zh-cn/usage/project-workflow-api.md).
+//
+// Query parameters are forwarded to the controller (notably `?team=`,
+// the (team, project_id) disambiguation), except the internal
+// `controllerUrl` override consumed by getControllerUrl.
+//
+// Non-OK statuses pass through (404 project missing / endpoint not
+// deployed yet, 403 cross-team) so the frontend can render the
+// "active after Controller upgrade" placeholder vs a real error.
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue; // internal override, not proxied
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  const path = `/api/v1/projects/${encodeURIComponent(id)}/history${qs ? `?${qs}` : ''}`;
+
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    path,
+    { forwardBody: false },
+  );
+}

--- a/src/app/api/agentteams/workers/[name]/checkpoints/[sub]/route.test.ts
+++ b/src/app/api/agentteams/workers/[name]/checkpoints/[sub]/route.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+async function callGet(
+  name: string,
+  sub: string,
+  controllerStatus: number,
+  controllerBody: unknown,
+  query = '',
+) {
+  vi.resetModules();
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://controller.test');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(controllerBody), { status: controllerStatus }),
+    ),
+  );
+
+  const route = await import('./route');
+  const response = await route.GET(
+    {
+      method: 'GET',
+      nextUrl: {
+        pathname: `/api/agentteams/workers/${name}/checkpoints/${sub}`,
+        searchParams: new URLSearchParams(query),
+      },
+      headers: new Headers(),
+    } as never,
+    { params: Promise.resolve({ name, sub }) },
+  );
+  return response;
+}
+
+describe('GET /api/agentteams/workers/[name]/checkpoints/[sub] (proxy)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('proxies graph with the limit query', async () => {
+    const res = await callGet('daily-luo', 'graph', 200, { nodes: [] }, 'limit=50');
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/workers/daily-luo/checkpoints/graph?limit=50',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('proxies status without a query', async () => {
+    const res = await callGet('daily-luo', 'status', 200, { auto_enabled: true });
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/workers/daily-luo/checkpoints/status',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('rejects unknown sub with 400 before touching the controller', async () => {
+    const res = await callGet('daily-luo', 'diff', 200, {});
+    expect(res.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('passes through the 502 degradation message for pre-2.1 workers', async () => {
+    const res = await callGet(
+      'legacy',
+      'graph',
+      502,
+      { message: 'checkpoint API unavailable (requires QwenPaw 2.1)' },
+    );
+    expect(res.status).toBe(502);
+    const data = (await res.json()) as { message: string };
+    expect(data.message).toContain('requires QwenPaw 2.1');
+  });
+
+  it('encodes the worker name in the proxied path', async () => {
+    await callGet('a/b c', 'status', 200, {});
+    expect(fetch).toHaveBeenCalledWith(
+      'http://controller.test/api/v1/workers/a%2Fb%20c/checkpoints/status',
+      expect.anything(),
+    );
+  });
+});

--- a/src/app/api/agentteams/workers/[name]/checkpoints/[sub]/route.ts
+++ b/src/app/api/agentteams/workers/[name]/checkpoints/[sub]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from 'next/server';
+import { getControllerUrl, proxyToAgentTeams } from '../../../../proxy-helper';
+
+// Read-only proxy for the controller's worker checkpoint read endpoints:
+//   GET /api/agentteams/workers/{name}/checkpoints/{sub}
+//       → Controller /api/v1/workers/{name}/checkpoints/{sub}
+// sub is limited to `graph` / `status`; the Controller enforces the same
+// whitelist and returns 502 "requires QwenPaw 2.1" for pre-2.1 workers.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string; sub: string }> },
+) {
+  const { name, sub } = await params;
+  if (sub !== 'graph' && sub !== 'status') {
+    return Response.json({ message: 'unsupported checkpoint subpath' }, { status: 400 });
+  }
+  // Forward the query (notably `limit` for graph), except the internal
+  // controllerUrl override consumed by getControllerUrl.
+  const search = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const [key, value] of search.entries()) {
+    if (key === 'controllerUrl') continue;
+    forwarded.append(key, value);
+  }
+  const qs = forwarded.toString();
+  // encode even though the whitelist already pins sub to graph|status —
+  // defense in depth if a future sub is added without the encode
+  return proxyToAgentTeams(
+    request,
+    getControllerUrl(request),
+    `/api/v1/workers/${encodeURIComponent(name)}/checkpoints/${encodeURIComponent(sub)}${qs ? `?${qs}` : ''}`,
+    { forwardBody: false },
+  );
+}

--- a/src/components/dashboard/sections/project-timeline-panel.tsx
+++ b/src/components/dashboard/sections/project-timeline-panel.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+// Project intervention timeline panel (controller history read endpoint).
+// Lists the pre-intervention meta snapshots newest-first; clicking one
+// fetches the raw snapshot and shows the key audit fields.
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { ChevronDown, ChevronRight, ScrollText } from 'lucide-react';
+import {
+  getProjectHistory,
+  getProjectHistorySnapshot,
+  type ProjectHistorySnapshotDetail,
+} from '@/lib/agentteams-projects-api';
+import { loadErrorMessage } from '@/lib/api-error';
+import { formatNanoTimestamp } from '@/lib/format-timestamp';
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ok'; snapshots: { timestamp: string }[] }
+  | { kind: 'error'; message: string };
+
+export function ProjectTimelinePanel({
+  projectId,
+  teamId,
+}: {
+  projectId: string;
+  teamId?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<State>({ kind: 'idle' });
+  const [detail, setDetail] = useState<ProjectHistorySnapshotDetail | null>(null);
+
+  const toggle = () => {
+    if (!open) {
+      // Lazy load: mark loading synchronously from the event handler
+      // (not inside the effect), then let the effect run the fetch.
+      setState({ kind: 'loading' });
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    getProjectHistory(projectId, teamId, controller.signal)
+      .then((resp) => {
+        setState({ kind: 'ok', snapshots: resp.snapshots });
+      })
+      .catch((e: unknown) => {
+        // Aborted (panel closed / component unmounted) — nothing to show.
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        setState({
+          kind: 'error',
+          // 404 = Controller 尚无该端点（未升级）→ 与检查点面板同款占位文案
+          message: loadErrorMessage(e, '时间线加载失败'),
+        });
+      });
+    return () => {
+      controller.abort();
+    };
+  }, [open, projectId, teamId]);
+
+  const openDetail = (ts: string) => {
+    getProjectHistorySnapshot(projectId, ts, teamId)
+      .then((raw) => setDetail(raw))
+      .catch(() => setDetail(null));
+  };
+
+  const rows: [string, unknown][] = detail
+    ? [
+        ['状态', detail.status],
+        ['标题', detail.title],
+        ['操作人', detail.updated_by],
+        ['操作时间', detail.updated_at],
+        ['暂停原因', detail.pause_reason],
+      ]
+    : [];
+
+  // Narrow once: everything below only deals with the resolved list.
+  let listBody: ReactNode = (
+    <span className="text-muted-foreground">加载中…</span>
+  );
+  if (state.kind === 'error') {
+    listBody = <span className="text-muted-foreground">{state.message}</span>;
+  } else if (state.kind === 'ok' && state.snapshots.length === 0) {
+    listBody = <span className="text-muted-foreground">暂无干预记录</span>;
+  } else if (state.kind === 'ok') {
+    listBody = state.snapshots.map((s) => (
+      <button
+        key={s.timestamp}
+        type="button"
+        onClick={() => openDetail(s.timestamp)}
+        className="flex w-full items-center gap-2 text-left text-muted-foreground hover:text-foreground"
+      >
+        <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-muted-foreground/40" />
+        <span>{formatNanoTimestamp(s.timestamp)}</span>
+      </button>
+    ));
+  }
+
+  return (
+    <div className="mt-3 rounded-md border p-3">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5" />
+        )}
+        <ScrollText className="h-3.5 w-3.5" />
+        <span>时间线</span>
+        {state.kind === 'ok' && state.snapshots.length > 0 ? (
+          <span className="rounded-full bg-muted px-1.5 text-xs">
+            {state.snapshots.length}
+          </span>
+        ) : null}
+      </button>
+      {open ? <div className="mt-2 space-y-1 pl-4 text-xs">{listBody}</div> : null}
+      {detail ? (
+        <div className="mt-2 space-y-1 rounded bg-muted/50 p-2 text-xs">
+          {rows.map(([label, value]) =>
+            value === undefined || value === null || value === '' ? null : (
+              <div key={label}>
+                <span className="text-muted-foreground">{label}：</span>
+                <span>{String(value)}</span>
+              </div>
+            ),
+          )}
+          {Array.isArray(detail.tasks) ? (
+            <div>
+              <span className="text-muted-foreground">任务数：</span>
+              <span>{detail.tasks.length}</span>
+            </div>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => setDetail(null)}
+            className="text-muted-foreground underline"
+          >
+            收起
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/dashboard/sections/projects-section.tsx
+++ b/src/components/dashboard/sections/projects-section.tsx
@@ -27,6 +27,7 @@ import {
   useCancelProjectTask,
 } from '@/hooks/use-projects';
 import { ApiError } from '@/lib/api-error';
+import { ProjectTimelinePanel } from './project-timeline-panel';
 import {
   getTaskArtifactUrl,
   type ProjectStatus,
@@ -120,7 +121,7 @@ const WORKFLOW_NODE_FILL: Record<string, DagNodeColor> = {
  * terminal in practice, so hide the button there too. */
 const UNCANCELLABLE_STATUSES = new Set(['completed', 'revision', 'blocked', 'cancelled']);
 
-/** Cancel button for one task row (W-PR-2 POST .../tasks/{taskId}/cancel).
+/** Cancel button for one task row (POST .../tasks/{taskId}/cancel).
  * Renders only for non-terminal tasks; opens a reason dialog. */
 function CancelTaskButton({
   projectId,
@@ -198,7 +199,7 @@ function CancelTaskButton({
 }
 
 /** One task's TaskMeta row: status/assignee/result + artifact download
- *  links (result_path + each deliverable, via O19 proxy). */
+ *  links (result_path + each deliverable, via the artifact proxy). */
 function TaskDetailRow({
   task,
   projectId,
@@ -478,7 +479,7 @@ function WorkflowDetail({
   }
 
   if (isError || !wf) {
-    // 409 = 同一 project_id 在多个团队存在（#1169 (team, project_id) 身份），
+    // 409 = 同一 project_id 在多个团队存在（(team, project_id) 复合身份），
     // 单独提示而非笼统的"不可用"。
     const ambiguous =
       error instanceof ApiError && error.status === 409;
@@ -541,7 +542,7 @@ function WorkflowDetail({
         </div>
       </div>
 
-      {/* Pause dialog: optional reason (W-PR-2 POST .../pause) */}
+      {/* Pause dialog: optional reason (POST .../pause) */}
       <Dialog open={pauseOpen} onOpenChange={setPauseOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -573,7 +574,7 @@ function WorkflowDetail({
         </DialogContent>
       </Dialog>
 
-      {/* Replan dialog: JSON tasks payload (W-PR-2 POST .../replan) */}
+      {/* Replan dialog: JSON tasks payload (POST .../replan) */}
       <Dialog open={replanOpen} onOpenChange={setReplanOpen}>
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
@@ -702,7 +703,7 @@ function WorkflowDetail({
         </div>
       )}
 
-      {/* Next runnable tasks (W-PR-1 next: 依赖全完成、当前可执行) */}
+      {/* Next runnable tasks (next: 依赖全完成、当前可执行) */}
       {wf.next.length > 0 && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground mb-1.5">
@@ -738,7 +739,7 @@ function WorkflowDetail({
         </div>
       )}
 
-      {/* Task details (#1169 includeTasks → tasks_detail + O19 artifact download) */}
+      {/* Task details (includeTasks → tasks_detail + artifact download) */}
       {wf.tasks_detail && wf.tasks_detail.length > 0 && (
         <div>
           <p className="text-xs font-semibold text-muted-foreground mb-1.5">
@@ -756,6 +757,9 @@ function WorkflowDetail({
           </div>
         </div>
       )}
+
+      {/* Intervention timeline (controller history endpoint) */}
+      <ProjectTimelinePanel projectId={wf.project_id} teamId={mutationTeamId} />
 
       {/* Nodes */}
       <div>
@@ -855,7 +859,7 @@ function WorkflowDagView({
   );
 }
 
-/** (team, project_id) composite identity comparison (#1169). Accepts both
+/** (team, project_id) composite identity comparison. Accepts both
  * the selection shape ({ id, team }) and the API summary shape
  * ({ project_id, team_id }). */
 function isSameProject(
@@ -910,7 +914,7 @@ function ProjectCard({
 export function ProjectsSection() {
   const { data, isLoading, isError, refetch, isRefetching } = useProjects();
   // (team, project_id) composite selection — the same project id can exist
-  // under two teams (#1169 identity scoping).
+  // under two teams (identity scoping).
   const [selectedKey, setSelectedKey] = useState<{ id: string; team?: string } | null>(null);
   // Three views, aligned with the workbench plugin's WorkflowBoard:
   // 列表 (list + detail) / 卡片 (card grid) / 拓扑 (DAG).
@@ -924,7 +928,7 @@ export function ProjectsSection() {
     <div className="space-y-4">
       <SectionHeader
         title="项目"
-        description="AgentTeams 项目 API（#1169）— 标准项目视图"
+        description="AgentTeams 项目 API — 标准项目视图"
         isLive
         onRefresh={() => refetch()}
         isRefreshing={isRefetching}

--- a/src/components/dashboard/sections/workers/worker-checkpoint-panel.tsx
+++ b/src/components/dashboard/sections/workers/worker-checkpoint-panel.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+// Worker execution checkpoint panel (controller checkpoint read endpoints).
+// Lazy-loads on first expansion; renders a "需 QwenPaw 2.1" placeholder
+// for pre-2.1 workers (Controller 502 degradation, remembered per session).
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { Bookmark, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  CheckpointUnavailableError,
+  getWorkerCheckpointGraph,
+  getWorkerCheckpointStatus,
+  type CheckpointGraphResponse,
+  type CheckpointStatusResponse,
+} from '@/lib/agentteams-worker-checkpoints';
+import { loadErrorMessage } from '@/lib/api-error';
+
+// Pre-2.1 workers stay unavailable for the session: the Controller will not
+// gain the checkpoint route on its own, so caching the 502 verdict avoids
+// re-hitting it (and the loading flicker on slow networks) on every expand.
+const unavailableWorkers = new Set<string>();
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ok'; status: CheckpointStatusResponse; graph: CheckpointGraphResponse }
+  // Half-degradation: status answered but the graph did not — the auto
+  // flag is still useful, so it stays visible while the list degrades.
+  | { kind: 'partial'; status: CheckpointStatusResponse; graphError: string }
+  | { kind: 'unavailable' }
+  | { kind: 'error'; message: string };
+
+const KIND_STYLE: Record<string, string> = {
+  auto: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+  snap: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+  'pre-restore': 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
+};
+
+// `kind` is an open vocabulary (the Controller may add kinds), so an
+// unknown kind intentionally falls back to the neutral style below instead
+// of failing — an exhaustive Record would reject future kinds at compile
+// time and hide the new badge behind a type error.
+
+function fmtTime(ms: number): string {
+  if (!ms) return '';
+  return new Date(ms).toLocaleString();
+}
+
+function renderNode(n: CheckpointNodeLike): ReactNode {
+  return (
+    <div key={n.ref} className="space-y-0.5">
+      <div className="flex items-center gap-1.5">
+        <span className={`rounded px-1.5 py-0.5 ${KIND_STYLE[n.kind] || 'bg-muted'}`}>
+          {n.kind}
+        </span>
+        <span className="text-muted-foreground">{fmtTime(n.timestamp_ms)}</span>
+        {n.is_head ? <span className="text-orange-500">●</span> : null}
+      </div>
+      {n.query ? (
+        <div className="truncate text-muted-foreground" title={n.query}>
+          {n.query}
+        </div>
+      ) : n.subject ? (
+        <div className="text-muted-foreground">{n.subject}</div>
+      ) : null}
+    </div>
+  );
+}
+
+type CheckpointNodeLike = CheckpointGraphResponse['nodes'][number];
+
+export function WorkerCheckpointPanel({ workerName }: { workerName: string }) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<State>({ kind: 'idle' });
+
+  const toggle = () => {
+    if (!open) {
+      // Lazy load: mark loading synchronously from the event handler
+      // (not inside the effect), then let the effect run the fetch. A
+      // cached "unavailable" verdict (pre-2.1 worker) skips the fetch
+      // entirely — set from the handler to avoid a sync setState in the
+      // effect.
+      if (unavailableWorkers.has(workerName)) {
+        setState({ kind: 'unavailable' });
+      } else {
+        setState({ kind: 'loading' });
+      }
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    if (unavailableWorkers.has(workerName)) return; // toggle set 'unavailable'
+    const controller = new AbortController();
+    (async () => {
+      // allSettled so a status-200 + graph-5xx half-degradation still shows
+      // the auto flag instead of failing the whole panel.
+      const [statusSettled, graphSettled] = await Promise.allSettled([
+        getWorkerCheckpointStatus(workerName, controller.signal),
+        getWorkerCheckpointGraph(workerName, 100, controller.signal),
+      ]);
+      // Aborted (dialog closed / unmounted) — drop both results.
+      if (
+        statusSettled.status === 'rejected' &&
+        statusSettled.reason instanceof DOMException &&
+        statusSettled.reason.name === 'AbortError'
+      ) {
+        return;
+      }
+      // Whole worker unavailable (QwenPaw < 2.1) — remember for the session.
+      if (
+        graphSettled.status === 'rejected' &&
+        graphSettled.reason instanceof CheckpointUnavailableError
+      ) {
+        unavailableWorkers.add(workerName);
+        setState({ kind: 'unavailable' });
+        return;
+      }
+      if (statusSettled.status === 'rejected') {
+        setState({
+          kind: 'error',
+          message: loadErrorMessage(statusSettled.reason, '检查点加载失败'),
+        });
+        return;
+      }
+      const status = statusSettled.value;
+      if (graphSettled.status === 'rejected') {
+        setState({
+          kind: 'partial',
+          status,
+          graphError: loadErrorMessage(graphSettled.reason, '打点列表加载失败'),
+        });
+      } else {
+        setState({ kind: 'ok', status, graph: graphSettled.value });
+      }
+    })();
+    return () => {
+      controller.abort();
+    };
+  }, [open, workerName]);
+
+  // Narrow once: status/graph shared by ok and partial, list only by ok.
+  const status: CheckpointStatusResponse | null =
+    state.kind === 'ok' || state.kind === 'partial' ? state.status : null;
+  const graph: CheckpointGraphResponse | null =
+    state.kind === 'ok' ? state.graph : null;
+  const graphError: string | null =
+    state.kind === 'partial' ? state.graphError : null;
+
+  let body: ReactNode = <span className="text-muted-foreground">加载中…</span>;
+  if (state.kind === 'unavailable') {
+    body = (
+      <span className="text-muted-foreground">
+        该 Worker 需 QwenPaw 2.1 才支持检查点
+      </span>
+    );
+  } else if (state.kind === 'error') {
+    body = <span className="text-muted-foreground">{state.message}</span>;
+  } else if (status) {
+    body = (
+      <>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span
+            className={
+              status.auto_enabled
+                ? 'rounded bg-green-100 px-1.5 py-0.5 text-green-700 dark:bg-green-900 dark:text-green-300'
+                : 'rounded bg-muted px-1.5 py-0.5 text-muted-foreground'
+            }
+          >
+            {status.auto_enabled ? '自动打点 开' : '自动打点 关'}
+          </span>
+          {graph
+            ? graph.summary.total > 0
+              ? [
+                  ['自动', graph.summary.auto, 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'],
+                  ['快照', graph.summary.snapshots, 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'],
+                  ['安全', graph.summary.safety, 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300'],
+                ].map(([label, count, cls]) => (
+                    <span key={String(label)} className={`rounded px-1.5 py-0.5 ${cls}`}>
+                      {label} {count}
+                    </span>
+                  ))
+              : (
+                  <span className="text-muted-foreground">暂无检查点</span>
+                )
+            : null}
+          {graphError ? (
+            <span className="text-muted-foreground">{graphError}</span>
+          ) : null}
+        </div>
+        {graph ? graph.nodes.slice(0, 5).map(renderNode) : null}
+      </>
+    );
+  }
+
+  return (
+    <div className="pt-2">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5" />
+        )}
+        <Bookmark className="h-3.5 w-3.5" />
+        <span>检查点</span>
+        {graph && graph.summary.total > 0 ? (
+          <span className="rounded-full bg-muted px-1.5 text-xs">
+            {graph.summary.total}
+          </span>
+        ) : null}
+      </button>
+      {open ? <div className="mt-2 space-y-1.5 pl-4 text-xs">{body}</div> : null}
+    </div>
+  );
+}

--- a/src/components/dashboard/sections/workers/worker-detail-dialog.tsx
+++ b/src/components/dashboard/sections/workers/worker-detail-dialog.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useWorkerSkills, useUploadWorkerSkill } from '@/hooks/use-agentteams-worker-skills';
 import { PluginDetailBlocks } from '@/components/plugins/plugin-detail-blocks';
+import { WorkerCheckpointPanel } from './worker-checkpoint-panel';
 
 const DETAIL_FIELDS: Array<[string, (_w: WorkerResponse) => string]> = [
   ['名称', (w) => w.name],
@@ -149,6 +150,10 @@ export function WorkerDetailDialog({
 
               {/* Plugin-contributed blocks (extension point: detail-panel) */}
               <PluginDetailBlocks entity="worker" data={worker} />
+
+              {worker?.name ? (
+                <WorkerCheckpointPanel workerName={worker.name} />
+              ) : null}
             </div>
           )}
         </DialogContent>

--- a/src/lib/agentteams-projects-api.test.ts
+++ b/src/lib/agentteams-projects-api.test.ts
@@ -194,7 +194,7 @@ describe('getProjectWorkflow', () => {
     expect(wf.pause_reason).toBe('waiting on review');
   });
 
-  it('passes ?team= when teamId is provided (409 disambiguation, #1169)', async () => {
+  it('passes ?team= when teamId is provided (409 disambiguation)', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ nodes: [], edges: [], values: {} }), { status: 200 }),
     );
@@ -297,5 +297,46 @@ describe('getTaskArtifactUrl', () => {
     expect(getTaskArtifactUrl('a/b', 't t')).toBe(
       '/api/agentteams/projects/a%2Fb/tasks/t%20t/artifact',
     );
+  });
+});
+
+describe('getProjectHistory', () => {
+  it('returns snapshots newest-first as strings', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          project_id: 'p1',
+          snapshots: [
+            { timestamp: '1723785123456789020' },
+            { timestamp: '1723785123456789010' },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ) as never;
+
+    const { getProjectHistory } = await import('./agentteams-projects-api');
+    const data = await getProjectHistory('p1');
+    expect(data.project_id).toBe('p1');
+    expect(data.snapshots).toHaveLength(2);
+    expect(data.snapshots[0].timestamp).toBe('1723785123456789020');
+  });
+
+  it('passes teamId as a query parameter', async () => {
+    const spy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ project_id: 'p1', snapshots: [] }), {
+        status: 200,
+      }),
+    );
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    const { getProjectHistory } = await import('./agentteams-projects-api');
+    await getProjectHistory('p1', 'biz-team');
+    // Structural assertion (not a substring), pinning the real request
+    // shape: projects-api builds URLs by direct concatenation (no
+    // apiUrl trailing slash — unlike the worker-checkpoints client).
+    const url = new URL(String(spy.mock.calls[0][0]), 'http://localhost');
+    expect(url.pathname).toBe('/api/agentteams/projects/p1/history');
+    expect(url.searchParams.get('team')).toBe('biz-team');
   });
 });

--- a/src/lib/agentteams-projects-api.ts
+++ b/src/lib/agentteams-projects-api.ts
@@ -1,23 +1,25 @@
 // AgentTeams Projects API client (frontend side).
 //
-// These types mirror the AgentTeams controller API introduced by
-// agentteams/AgentTeams#1169 (W-PR-1) and extended by #1172 (W-PR-2):
+// These types mirror the AgentTeams controller project API:
 //
 //   GET /api/v1/projects                               -> ProjectListResponse
 //   GET /api/v1/projects/{id}/workflow[?includeTasks]  -> WorkflowResponse
 //   GET /api/v1/projects/{id}/tasks/{taskId}/artifact  -> binary stream
+//   GET /api/v1/projects/{id}/history[?team]           -> ProjectHistoryResponse
+//   GET /api/v1/projects/{id}/history/{ts}[?team]      -> raw meta JSON
 //
 // All requests go through the Next.js proxy routes under
 // `/api/agentteams/projects/*` (which add the SA-token bearer and are
 // themselves gated by the Higress-session middleware). The workflow
 // payload follows the LangGraph-style shape (nodes/edges/next/interrupts/
-// values) agreed in the W-PR-1 design. Field names/types are verified
+// values) agreed in the project-workflow design. Field names/types are verified
 // against `project_handler.go` (workflowResponse / workflowInterrupt /
 // taskDetail / loopMeta structs) and the API doc
-// `docs/zh-cn/usage/project-workflow-api.md` (W-PR-1) — keep in sync when
+// `docs/zh-cn/usage/project-workflow-api.md` — keep in sync when
 // the controller schema changes.
 
 import { ApiError, NetworkError } from '@/lib/api-error';
+import { extractErrorDetail, requestJson } from './api-base';
 
 export type ProjectStatus = 'planning' | 'active' | 'paused' | 'completed' | 'unknown';
 
@@ -54,7 +56,7 @@ export interface WorkflowEdge {
 /** Mirrors workflowInterrupt + interruptActionRequest + interruptConfig.
  * A paused project surfaces as an interrupt with action_request
  * { action: 'resume', args: { project_id } } and config.allow_accept=true,
- * so a dashboard can render a "Resume" button directly (W-PR-2 endpoints). */
+ * so a dashboard can render a "Resume" button directly. */
 export interface WorkflowInterrupt {
   id: string;
   value: string;
@@ -141,7 +143,7 @@ export interface WorkflowResponse {
   source_room_id?: string;
   /** Populated only when ?includeTasks=true. */
   tasks_detail?: WorkflowTaskDetail[];
-  /** W-PR-2 human-intervention audit fields. */
+  /** Human-intervention audit fields. */
   updated_by?: string;
   updated_at?: string;
   pause_reason?: string;
@@ -153,46 +155,16 @@ export interface ProjectListResponse {
   /** Set when the controller API is not yet available (degraded empty list). */
   error?: string;
   degraded?: boolean;
-  /** Why the list degraded: 'api-not-deployed' (404 — W-PR-1 not merged /
-   * controller not upgraded) vs 'controller-error' (500+ — endpoint exists
+  /** Why the list degraded: 'api-not-deployed' (404 — the project API is not
+   * deployed yet) vs 'controller-error' (500+ — endpoint exists
    * but failed, e.g. MinIO unreachable). */
   degradedReason?: 'api-not-deployed' | 'controller-error';
 }
 
 const PROJECTS_URL = '/api/agentteams/projects';
 
-/** Extract a human-readable detail from an error response body.
- * The controller's standard error shape is `{ "message": "..." }`
- * (httputil.ErrorResponse); the dashboard middleware returns
- * `{ "error": "..." }`. Accept both so callers surface the real reason. */
-async function extractErrorDetail(res: Response, fallback: string): Promise<string> {
-  try {
-    const payload = (await res.json()) as { error?: unknown; message?: unknown };
-    const fromError =
-      payload && typeof payload.error === 'string' && payload.error ? payload.error : '';
-    const fromMessage =
-      payload && typeof payload.message === 'string' && payload.message ? payload.message : '';
-    if (fromMessage) return fromMessage;
-    if (fromError) return fromError;
-  } catch {
-    // non-JSON error body; keep the fallback
-  }
-  return fallback;
-}
-
-async function requestJson<T>(url: string): Promise<T> {
-  let res: Response;
-  try {
-    res = await fetch(url, { cache: 'no-store' });
-  } catch {
-    throw new NetworkError(url);
-  }
-  if (!res.ok) {
-    const detail = await extractErrorDetail(res, `HTTP ${res.status}`);
-    throw new ApiError(`${detail} from ${url}`, res.status, url);
-  }
-  return (await res.json()) as T;
-}
+// requestJson / extractErrorDetail now live in ./api-base (shared by all
+// agentteams clients — projects, workers, checkpoints — since PR #86 review).
 
 /** List projects via the dashboard proxy route.
  *
@@ -209,7 +181,7 @@ export async function getProjectWorkflow(
   projectId: string,
   options: { includeTasks?: boolean; teamId?: string } = {},
 ): Promise<WorkflowResponse> {
-  // #1169 (team, project_id) identity: the same id may exist under two
+  // (team, project_id) identity: the same id may exist under two
   // teams. Pass ?team= to disambiguate; without it the controller returns
   // 409 Conflict. includeTasks and teamId are independent query params.
   const qsParts: string[] = [];
@@ -237,7 +209,7 @@ export function getTaskArtifactUrl(
   return path ? `${base}?path=${encodeURIComponent(path)}` : base;
 }
 
-// ----- W-PR-2 human intervention write operations (#1172) -----
+// ----- human intervention write operations -----
 //
 // Each POST returns the controller's refreshed workflow JSON (200). The
 // controller's 409 conflict reasons (already paused / not paused / replan
@@ -264,7 +236,7 @@ async function requestPost<T>(url: string, body: unknown): Promise<T> {
 }
 
 /** Post a project mutation through the dashboard proxy.
- * `teamId` disambiguates (team, project_id) identity (#1169). */
+ * `teamId` disambiguates (team, project_id) identity. */
 function mutationUrl(projectId: string, action: string, teamId?: string): string {
   const base = `${PROJECTS_URL}/${encodeURIComponent(projectId)}/${action}`;
   return teamId ? `${base}?team=${encodeURIComponent(teamId)}` : base;
@@ -323,4 +295,58 @@ export function cancelProjectTask(
     reason: options.reason,
     ...(options.replacementTaskId ? { replacementTaskId: options.replacementTaskId } : {}),
   });
+}
+
+// ----- project intervention history -----
+
+export interface ProjectHistorySnapshot {
+  /** unixNano filename; string — 19-digit nanoseconds exceed JS safe ints. */
+  timestamp: string;
+}
+
+export interface ProjectHistoryResponse {
+  project_id: string;
+  snapshots: ProjectHistorySnapshot[];
+}
+
+/**
+ * Raw meta.json snapshot returned by GET /projects/{id}/history/{timestamp}.
+ * Only the fields the timeline panel renders are typed; the stored meta is
+ * otherwise open (the controller persists whatever the workflow had), so
+ * consumers must keep defensive reads (null/empty checks).
+ */
+export interface ProjectHistorySnapshotDetail {
+  status?: string;
+  title?: string;
+  updated_by?: string;
+  updated_at?: string;
+  pause_reason?: string;
+  tasks?: unknown[];
+}
+
+/** List a project's intervention timeline (newest first). */
+export async function getProjectHistory(
+  projectId: string,
+  teamId?: string,
+  signal?: AbortSignal,
+): Promise<ProjectHistoryResponse> {
+  const qs = teamId ? `?team=${encodeURIComponent(teamId)}` : '';
+  return requestJson<ProjectHistoryResponse>(
+    `${PROJECTS_URL}/${encodeURIComponent(projectId)}/history${qs}`,
+    signal,
+  );
+}
+
+/** Fetch one pre-intervention snapshot's raw meta JSON. */
+export async function getProjectHistorySnapshot(
+  projectId: string,
+  timestamp: string,
+  teamId?: string,
+  signal?: AbortSignal,
+): Promise<ProjectHistorySnapshotDetail> {
+  const qs = teamId ? `?team=${encodeURIComponent(teamId)}` : '';
+  return requestJson<ProjectHistorySnapshotDetail>(
+    `${PROJECTS_URL}/${encodeURIComponent(projectId)}/history/${encodeURIComponent(timestamp)}${qs}`,
+    signal,
+  );
 }

--- a/src/lib/agentteams-worker-checkpoints.test.ts
+++ b/src/lib/agentteams-worker-checkpoints.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getWorkerCheckpointGraph,
+  getWorkerCheckpointStatus,
+  CheckpointUnavailableError,
+} from './agentteams-worker-checkpoints';
+import { ApiError } from './api-error';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockJson(payload: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), { status }),
+  ) as never;
+}
+
+describe('getWorkerCheckpointGraph', () => {
+  it('returns parsed graph with summary', async () => {
+    mockJson({
+      nodes: [{ ref: 'refs/auto/a', kind: 'auto', sha: 'abc', timestamp_ms: 1723 }],
+      sessions: [],
+      summary: { total: 1, auto: 1, snapshots: 0, safety: 0, heads: 1 },
+      truncated: false,
+    });
+    const graph = await getWorkerCheckpointGraph('daily-luo', 100);
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.summary.total).toBe(1);
+    expect(graph.truncated).toBe(false);
+  });
+
+  it('maps 502 "requires QwenPaw 2.1" to CheckpointUnavailableError', async () => {
+    mockJson(
+      { message: 'checkpoint API unavailable (requires QwenPaw 2.1)' },
+      502,
+    );
+    await expect(getWorkerCheckpointGraph('daily-luo')).rejects.toBeInstanceOf(
+      CheckpointUnavailableError,
+    );
+  });
+
+  it('rethrows other errors with the controller message', async () => {
+    mockJson({ message: 'worker not found' }, 404);
+    await expect(getWorkerCheckpointStatus('ghost')).rejects.toThrow(
+      'worker not found',
+    );
+  });
+});
+
+describe('getWorkerCheckpointStatus', () => {
+  it('returns auto flag and presence', async () => {
+    mockJson({ auto_enabled: true, has_checkpoints: true, workspace_dir: '/w' });
+    const status = await getWorkerCheckpointStatus('daily-luo');
+    expect(status.auto_enabled).toBe(true);
+    expect(status.has_checkpoints).toBe(true);
+  });
+
+  it('maps 502 to CheckpointUnavailableError for status too', async () => {
+    mockJson(
+      { message: 'checkpoint API unavailable (requires QwenPaw 2.1)' },
+      502,
+    );
+    await expect(getWorkerCheckpointStatus('daily-luo')).rejects.toBeInstanceOf(
+      CheckpointUnavailableError,
+    );
+  });
+});
+
+describe('CheckpointUnavailableError contract', () => {
+  it('carries an explicit name, status 502 and ApiError lineage', async () => {
+    mockJson(
+      { message: 'checkpoint API unavailable (requires QwenPaw 2.1)' },
+      502,
+    );
+    const err = await getWorkerCheckpointGraph('daily-luo').catch((e) => e);
+    expect(err).toBeInstanceOf(CheckpointUnavailableError);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.name).toBe('CheckpointUnavailableError');
+    expect(err.status).toBe(502);
+  });
+
+  it('502 without the contractual marker stays a plain ApiError (no placeholder)', async () => {
+    mockJson({ message: 'upstream unreachable' }, 502);
+    const err = await getWorkerCheckpointGraph('daily-luo').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).not.toBeInstanceOf(CheckpointUnavailableError);
+    expect(err.status).toBe(502);
+  });
+});

--- a/src/lib/agentteams-worker-checkpoints.ts
+++ b/src/lib/agentteams-worker-checkpoints.ts
@@ -1,0 +1,110 @@
+// Worker execution checkpoint read client.
+//
+//   GET /api/agentteams/workers/{name}/checkpoints/graph  → checkpoint graph
+//   GET /api/agentteams/workers/{name}/checkpoints/status → auto flag + presence
+//
+// A worker on QwenPaw < 2.1 has no checkpoint router; the Controller
+// translates the upstream 404 into a 502 whose message contains
+// "requires QwenPaw 2.1" — surfaced here as CheckpointUnavailableError so
+// UIs can render a placeholder instead of an error.
+//
+// Reuses the shared requestJson (./api-base) so the fetch mode and error
+// shape (ApiError with upstream status) stay consistent with the other
+// agentteams clients.
+
+import { apiUrl, requestJson } from './api-base';
+import { ApiError } from './api-error';
+
+const WORKERS_URL = '/api/agentteams/workers';
+
+export interface CheckpointNode {
+  ref: string;
+  kind: string; // auto | snap | pre-restore | sha
+  session_key: string;
+  name: string;
+  commit: string;
+  sha: string;
+  timestamp_ms: number;
+  subject: string;
+  query: string | null;
+  channel: string;
+  is_head: boolean;
+  user_id: string;
+  session_title?: string;
+}
+
+export interface CheckpointGraphResponse {
+  nodes: CheckpointNode[];
+  sessions: unknown[];
+  summary: {
+    total: number;
+    auto: number;
+    snapshots: number;
+    safety: number;
+    heads: number;
+  };
+  truncated: boolean;
+}
+
+export interface CheckpointStatusResponse {
+  auto_enabled: boolean;
+  has_checkpoints: boolean;
+  workspace_dir: string;
+}
+
+/**
+ * Worker runs QwenPaw < 2.1 (Controller 502 degradation).
+ * Extends the shared ApiError so `instanceof ApiError` + `status` keep
+ * working for generic error handling; `name` is set explicitly so the
+ * type survives cross-module aggregation / log serialization.
+ */
+export class CheckpointUnavailableError extends ApiError {
+  constructor(message: string) {
+    super(message, 502, 'worker-checkpoints');
+    this.name = 'CheckpointUnavailableError';
+  }
+}
+
+/**
+ * 502 degradation contract (Controller, worker_checkpoints.go): the Controller
+ * rewords the pre-2.1 upstream 404 into a 502 whose body message contains
+ * this marker. The string is a stable cross-repo contract between the
+ * Controller and this client — if the Controller rewords it (even to
+ * "QwenPaw 2.1.0"), the "needs QwenPaw 2.1" placeholder silently breaks, so
+ * any such Controller change must update this check in the same release.
+ */
+const CHECKPOINT_UNAVAILABLE_MARKER = 'requires QwenPaw 2.1';
+
+/** Wrap the shared requestJson errors: map the contractual 502 to
+ * CheckpointUnavailableError, pass everything else through untouched. */
+async function fetchCheckpoint<T>(path: string, signal?: AbortSignal): Promise<T> {
+  try {
+    return await requestJson<T>(apiUrl(path), signal);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 502 && e.message.includes(CHECKPOINT_UNAVAILABLE_MARKER)) {
+      throw new CheckpointUnavailableError(e.message);
+    }
+    throw e;
+  }
+}
+
+export async function getWorkerCheckpointGraph(
+  workerName: string,
+  limit = 100,
+  signal?: AbortSignal,
+): Promise<CheckpointGraphResponse> {
+  return fetchCheckpoint<CheckpointGraphResponse>(
+    `${WORKERS_URL}/${encodeURIComponent(workerName)}/checkpoints/graph?limit=${limit}`,
+    signal,
+  );
+}
+
+export async function getWorkerCheckpointStatus(
+  workerName: string,
+  signal?: AbortSignal,
+): Promise<CheckpointStatusResponse> {
+  return fetchCheckpoint<CheckpointStatusResponse>(
+    `${WORKERS_URL}/${encodeURIComponent(workerName)}/checkpoints/status`,
+    signal,
+  );
+}

--- a/src/lib/api-base.ts
+++ b/src/lib/api-base.ts
@@ -7,6 +7,7 @@
  *
  * Usage:  fetch(apiUrl('/api/auth/login'), { ... })
  */
+import { ApiError, NetworkError } from './api-error';
 export function apiUrl(path: string): string {
   // NEXT_PUBLIC_BASE_PATH is baked at build time by Next.js.
   const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
@@ -14,4 +15,47 @@ export function apiUrl(path: string): string {
   // Ensure the path has a trailing slash without mutating query values.
   const normalized = pathname.endsWith('/') ? pathname : `${pathname}/`;
   return `${base}${normalized}${query ? `?${query}` : ''}`;
+}
+
+/** Extract a human-readable detail from an error response body.
+ * The controller's standard error shape is `{ "message": "..." }`
+ * (httputil.ErrorResponse); the dashboard middleware returns
+ * `{ "error": "..." }`. Accept both so callers surface the real reason. */
+export async function extractErrorDetail(res: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await res.json()) as { error?: unknown; message?: unknown };
+    const fromError =
+      payload && typeof payload.error === 'string' && payload.error ? payload.error : '';
+    const fromMessage =
+      payload && typeof payload.message === 'string' && payload.message ? payload.message : '';
+    if (fromMessage) return fromMessage;
+    if (fromError) return fromError;
+  } catch {
+    // non-JSON error body; keep the fallback
+  }
+  return fallback;
+}
+
+/** GET a JSON API route via the dashboard proxy.
+ *
+ * Shared by all agentteams clients (projects / workers / checkpoints) so the
+ * fetch mode (`cache: 'no-store'`) and error shape (`ApiError` with the
+ * upstream status) stay consistent across the repo. Callers may pass an
+ * AbortSignal to cancel the request (e.g. on component unmount); omitted =
+ * never aborts (existing behavior). */
+export async function requestJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, { cache: 'no-store', signal });
+  } catch (e) {
+    // Aborted requests surface as a plain Error('AbortError') — keep them
+    // distinguishable from real network failures.
+    if (e instanceof DOMException && e.name === 'AbortError') throw e;
+    throw new NetworkError(url);
+  }
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res, `HTTP ${res.status}`);
+    throw new ApiError(`${detail} from ${url}`, res.status, url);
+  }
+  return (await res.json()) as T;
 }

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -52,6 +52,28 @@ export function formatErrorMessage(err: unknown, fallback = '操作失败'): str
 }
 
 /**
+ * Short display message for consumer panels: strips the " from <url>" suffix
+ * that requestJson appends to ApiError messages, so the UI shows the real
+ * reason without the endpoint path.
+ */
+export function shortErrorMessage(e: unknown): string {
+  const raw = e instanceof Error ? e.message : String(e);
+  return raw.replace(/ from .*$/, '');
+}
+
+/**
+ * Unified load-failure message for read-only consumer panels (project
+ * timeline / worker checkpoints). A 404 means the Controller does not expose
+ * the endpoint yet (pre-upgrade) — show the actionable "active after
+ * Controller upgrade" placeholder instead of a raw error. Both panels MUST
+ * use this helper so the 404 fallback wording stays identical.
+ */
+export function loadErrorMessage(e: unknown, noun: string): string {
+  if (e instanceof ApiError && e.status === 404) return 'Controller 升级后自动生效';
+  return `${noun}：${shortErrorMessage(e)}`;
+}
+
+/**
  * Human-readable message for a failed worker delete. A 409 from the controller
  * usually means the worker is still attached to a team; turn the raw JSON error
  * into an actionable hint (which team to detach it from) instead of dumping the

--- a/src/lib/format-timestamp.test.ts
+++ b/src/lib/format-timestamp.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { nanoToMs, formatNanoTimestamp } from './format-timestamp';
+
+describe('nanoToMs', () => {
+  it('parses a 19-digit nanosecond string exactly (BigInt path)', () => {
+    // 1_755_000_000_123_456_789 ns → 1_755_000_000_123.456_789 ms (truncated)
+    expect(nanoToMs('1755000000123456789')).toBe(1755000000123);
+  });
+
+  it('does not drift on values beyond Number.MAX_SAFE_INTEGER', () => {
+    // 9_007_199_254_740_993 ns ≈ 9_007_199_254_740.993 ms: Number(input)
+    // alone would round the 19-digit input; BigInt keeps it exact.
+    const ms = nanoToMs('9007199254740993000');
+    expect(ms).toBe(9007199254740);
+  });
+
+  it('accepts 13-digit millisecond strings (unit fallback)', () => {
+    expect(nanoToMs('1755000000000')).toBe(1755000000000);
+  });
+
+  it('rejects 0, negatives, non-numeric and empty input', () => {
+    expect(nanoToMs('0')).toBeNull();
+    expect(nanoToMs('-123')).toBeNull();
+    expect(nanoToMs('12a34')).toBeNull();
+    expect(nanoToMs('')).toBeNull();
+    expect(nanoToMs('1.5e12')).toBeNull();
+  });
+});
+
+describe('formatNanoTimestamp', () => {
+  it('formats a valid nanosecond timestamp to a locale string', () => {
+    const out = formatNanoTimestamp('1755000000123456789');
+    expect(out).not.toBe('1755000000123456789');
+    expect(() => new Date(out).valueOf()).not.toThrow();
+  });
+
+  it('returns unparseable input verbatim (no fake unix-seconds slice)', () => {
+    expect(formatNanoTimestamp('garbage')).toBe('garbage');
+    expect(formatNanoTimestamp('')).toBe('');
+    expect(formatNanoTimestamp('0')).toBe('0');
+  });
+});

--- a/src/lib/format-timestamp.ts
+++ b/src/lib/format-timestamp.ts
@@ -1,0 +1,35 @@
+// Timestamp formatting for agentteams read clients.
+//
+// The controller's project history API returns 19-digit unix **nanosecond**
+// strings. 19 digits exceed Number.MAX_SAFE_INTEGER, so the conversion must
+// go through BigInt — a plain `Number(ts) / 1e6` would round the input and
+// drift the displayed time by seconds.
+
+/**
+ * Parse a decimal timestamp string to milliseconds, or null when it cannot
+ * be interpreted:
+ * - 14-19 digits: nanoseconds (the history API contract; 19 is the normal case)
+ * - 1-13 digits:  treated as milliseconds (defensive unit fallback)
+ * - non-numeric / empty / zero: null — callers show the raw value instead
+ *   of a fake unix-seconds number
+ */
+export function nanoToMs(ts: string): number | null {
+  const trimmed = typeof ts === 'string' ? ts.trim() : '';
+  if (!/^\d+$/.test(trimmed) || trimmed === '0') return null;
+  try {
+    // BigInt (function call, not an `n` literal — tsconfig target < ES2020)
+    const NS_PER_MS = BigInt(1000000);
+    const ms =
+      trimmed.length <= 13 ? Number(trimmed) : Number(BigInt(trimmed) / NS_PER_MS);
+    return Number.isFinite(ms) && ms > 0 ? ms : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Format a project history timestamp for display; unparseable input is
+ * returned verbatim (never truncated into a misleading unix-seconds look). */
+export function formatNanoTimestamp(ts: string): string {
+  const ms = nanoToMs(ts);
+  return ms === null ? ts : new Date(ms).toLocaleString();
+}


### PR DESCRIPTION
# Projects: project timeline + worker checkpoint panels

## Summary

Consumes the two new read timelines from agentteams/AgentTeams#1186 in the dashboard:

- **Project intervention timeline** — a project's pre-intervention `meta.json` snapshots (written by #1172), shown in the workflow detail panel: newest-first list, click a snapshot to inspect who did what (status / updated_by / pause_reason).
- **Worker execution checkpoints** — each worker's QwenPaw checkpoint graph (auto snapshots after every response round + manual `/checkpoint snapshot`), shown in the worker detail dialog: auto-on/off flag, kind-colored summary badges and the most recent points. Workers on QwenPaw < 2.1 render a "needs QwenPaw 2.1" placeholder (Controller 502 degradation, surfaced as `CheckpointUnavailableError`, remembered for the session).

Both panels lazy-load on first expansion, so the list/detail views are unaffected until opened.

## What's included

1. `src/app/api/agentteams/workers/[name]/checkpoints/[sub]/route.ts` (new) — read-only proxy for `graph` / `status` (subpath whitelisted + encoded; Controller enforces the same whitelist and returns the 502 degradation for pre-2.1 workers).
2. `src/lib/agentteams-projects-api.ts` — `getProjectHistory(projectId, teamId?)` (snapshot list, timestamps as strings — 19-digit nanoseconds exceed JS safe ints) and `getProjectHistorySnapshot(projectId, timestamp, teamId?)` (raw meta).
3. `src/lib/agentteams-worker-checkpoints.ts` (new) — `getWorkerCheckpointGraph` / `getWorkerCheckpointStatus` reusing the shared `requestJson`; the contractual 502 "requires QwenPaw 2.1" mapped to `CheckpointUnavailableError` (extends `ApiError`, explicit `name`).
4. `src/components/dashboard/sections/project-timeline-panel.tsx` (new) — lazy timeline panel: list + snapshot detail (status/title/updated_by/updated_at/pause_reason/tasks count); 404 → "active after Controller upgrade" placeholder.
5. `src/components/dashboard/sections/workers/worker-checkpoint-panel.tsx` (new) — lazy checkpoint panel: `Promise.allSettled` so a status-200 + graph-5xx half-degradation still shows the auto flag; 502-unavailable verdict cached per session (no 502 spam on re-expand); summary badges + up to 5 recent points.
6. Wired into `projects-section.tsx` (WorkflowDetail) and `worker-detail-dialog.tsx`.
7. Shared client refactoring (review round 1): `requestJson` / `extractErrorDetail` moved from `agentteams-projects-api.ts` to `api-base.ts` (exported, byte-identical — zero behavior change; optional `AbortSignal` passthrough) so all agentteams clients share one fetch mode, error shape and cancellation; `shortErrorMessage` / `loadErrorMessage` added to `api-error.ts` so both panels share the identical 404 fallback wording.
8. `src/lib/format-timestamp.ts` (new) — `nanoToMs` / `formatNanoTimestamp`: the 19-digit ns→ms conversion goes through BigInt (plain `Number` would round beyond MAX_SAFE_INTEGER and drift by seconds); 13-digit ms accepted as a defensive fallback; unparseable input is returned verbatim instead of a fake unix-seconds slice.
9. Tests — 15 new: 6 timestamp (19-digit ns exactness beyond MAX_SAFE_INTEGER / ms fallback / 0 / negative / non-numeric / empty) + 5 checkpoint client (graph parse / 502 → CheckpointUnavailableError / other errors relayed / status parse / status 502) + 2 error-contract (explicit `name` + `ApiError` lineage + status 502; 502 without the marker stays a plain `ApiError`) + 2 history client (snapshot list + structural URL assertion: pathname + parsed query, not substring).

## Data boundary

- Read-only: consumes the two GET endpoints proxied to the Controller; no writes.
- Same authorization as the existing project/worker reads: team-scoped callers only see their own teams (Controller hides out-of-scope as 404).
- Degradation: pre-2.1 workers show a placeholder instead of an error; un-upgraded Controllers (no history/checkpoint routes) show "active after upgrade" via the 404 path.
- **502 wording contract**: the Controller (AgentTeams#1186, `worker_checkpoints.go`) rewords the pre-2.1 upstream 404 into a 502 whose body message contains `requires QwenPaw 2.1`. That string is a stable cross-repo contract with this dashboard's placeholder check (`CHECKPOINT_UNAVAILABLE_MARKER`). Chose a documented string contract over a new `error_code` field to avoid an upstream PR for one string; any Controller reword must update this check in the same release (noted in the client's header comment).

## Tests

- New: 15 tests, all green (timestamp + checkpoint client + error contract + history client)
- Full suite against the latest main baseline: same 45 pre-existing suite failures (43 upstream jsdom env + 2 from the upstream skill-distribution commit's own new test file — `React.act is not a function`, jsdom env), zero new failures, zero failures touching this PR's files
- `tsc --noEmit` clean (adm-zip baseline only); `eslint` clean on all changed files (incl. `react-hooks/set-state-in-effect`)

## Related

- agentteams/AgentTeams#1186: Controller read endpoints for project history + worker checkpoints (merged — this PR's dependency is satisfied; deployment of a Controller carrying #1186 activates the endpoints)
- agentteams/AgentTeams#1172: project history write side (snapshot before every intervention)

---

## 摘要

在 dashboard 中消费 agentteams/AgentTeams#1186 新增的两条只读时间线：

- **项目干预时间线** — 项目的干预前 `meta.json` 快照（#1172 写侧），在工作流详情面板展示：最新在前的列表，点击快照查看谁做了什么（status / updated_by / pause_reason）。
- **Worker 执行检查点** — 每个 Worker 的 QwenPaw 检查点图（每轮回复自动快照 + 手动 `/checkpoint snapshot`），在 Worker 详情弹窗展示：自动打点开关、kind 色标汇总徽标与最近打点。QwenPaw < 2.1 的 Worker 渲染「需 QwenPaw 2.1」占位（Controller 502 降级，经 `CheckpointUnavailableError` 识别，会话内记忆不重复打 502）。

两个面板均首次展开时懒加载，列表/详情视图在展开前不受影响。

## 包含内容

1. `src/app/api/agentteams/workers/[name]/checkpoints/[sub]/route.ts`（新增）— `graph` / `status` 只读代理（sub 白名单 + encode 双保险；Controller 侧同样白名单，并对 2.1 前的 Worker 返回 502 降级）。
2. `src/lib/agentteams-projects-api.ts` — `getProjectHistory(projectId, teamId?)`（快照列表，时间戳为字符串——19 位纳秒超出 JS 安全整数）与 `getProjectHistorySnapshot(projectId, timestamp, teamId?)`（原始 meta）。
3. `src/lib/agentteams-worker-checkpoints.ts`（新增）— `getWorkerCheckpointGraph` / `getWorkerCheckpointStatus`，复用共享 `requestJson`；契约性 502「requires QwenPaw 2.1」映射为 `CheckpointUnavailableError`（继承 `ApiError`，显式 `name`）。
4. `src/components/dashboard/sections/project-timeline-panel.tsx`（新增）— 懒加载时间线面板：列表 + 快照详情（status/标题/操作人/操作时间/暂停原因/任务数）；404 → 「Controller 升级后自动生效」占位。
5. `src/components/dashboard/sections/workers/worker-checkpoint-panel.tsx`（新增）— 懒加载检查点面板：`Promise.allSettled` 半降级（status 200 + graph 5xx 仍显示自动打点徽标）；502 不可用判定会话内缓存（重复展开不重复打 502）；汇总徽标 + 最近 5 条。
6. 接入 `projects-section.tsx`（WorkflowDetail）与 `worker-detail-dialog.tsx`。
7. 共享 client 重构（review 一轮）：`requestJson` / `extractErrorDetail` 从 `agentteams-projects-api.ts` 移至 `api-base.ts`（导出，逐字相同——零行为变化；新增可选 `AbortSignal` 透传），所有 agentteams client 统一 fetch 模式、错误形状与取消；`api-error.ts` 新增 `shortErrorMessage` / `loadErrorMessage`，两面板 404 兜底文案完全一致。
8. `src/lib/format-timestamp.ts`（新增）— `nanoToMs` / `formatNanoTimestamp`：19 位 ns→ms 换算走 BigInt（裸 `Number` 在超过 MAX_SAFE_INTEGER 时会四舍五入、漂移数秒）；13 位 ms 作防御性兜底；无法解析的输入原样返回，不产生伪 unix-秒切片。
9. 测试 — 新增 15 个：6 个时间戳（超 MAX_SAFE_INTEGER 的 19 位 ns 精确性 / ms 兜底 / 0 / 负数 / 非数字 / 空）+ 5 个检查点 client（graph 解析 / 502 → CheckpointUnavailableError / 其他错误透传 / status 解析 / status 502）+ 2 个错误契约（显式 `name` + `ApiError` 血统 + status 502；无 marker 的 502 保持普通 `ApiError`）+ 2 个 history client（快照列表 + URL 结构断言：pathname + 解析后的 query，而非子串）。

## 数据边界

- 只读：仅消费代理到 Controller 的两个 GET 端点，无写入。
- 与现有项目/Worker 读取同授权：团队范围调用方只能看自己团队（Controller 对越界隐藏为 404）。
- 降级：2.1 前 Worker 显示占位而非错误；未升级 Controller（无 history/checkpoint 路由）经 404 路径显示「升级后生效」。
- **502 文案契约**：Controller（AgentTeams#1186，`worker_checkpoints.go`）把 2.1 前 Worker 的上游 404 改写为 body 含 `requires QwenPaw 2.1` 的 502。该字符串是 Controller 与本 dashboard 占位判定（`CHECKPOINT_UNAVAILABLE_MARKER`）之间的稳定跨仓契约。选「文档化字符串契约」而非新增 `error_code` 字段，避免为一个字符串开上游 PR；Controller 若改文案必须同 release 更新本检查（已写入 client 头注释）。

## 测试

- 新增 15 测试全绿（时间戳 + checkpoint client + 错误契约 + history client）
- 全量对照最新 main 基线：同样 45 个既有 suite 失败（43 上游 jsdom 环境 + 2 个来自上游技能分发 commit 自带新测试文件——`React.act is not a function`，jsdom 环境问题），零新增失败，零涉及本 PR 文件
- `tsc --noEmit` 干净（仅 adm-zip 基线）；`eslint` 对全部改动文件干净（含 `react-hooks/set-state-in-effect`）

## 相关

- agentteams/AgentTeams#1186：Controller 项目历史 + Worker 检查点读端点（已合并——本 PR 依赖已满足；部署含 #1186 的 Controller 后端点生效）
- agentteams/AgentTeams#1172：项目历史写侧（每次干预前快照）