### PR TITLE
feat: org.agentteams.run v1 protocol + server-side governance complete + ChatRoom split (phase1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ test
 prompt
 
 server.log
+# Audit log (default location is ${cwd}/logs/audit.log.jsonl; overridable via
+# AGENTTEAMS_AUDIT_LOG_PATH)
+/logs/
 # Skills directory
 /skills/
 # Agent configurations

--- a/.monkeycode/MEMORY.md
+++ b/.monkeycode/MEMORY.md
@@ -64,9 +64,11 @@ Entries discovered by the Agent while performing [specific task description] sho
 - Category: Operations & Deployment | Environment Configuration | Workflow & Collaboration
 - Instructions:
   - 服务端审计默认落 `${cwd}/logs/audit.log.jsonl`，生产部署必须通过 `AGENTTEAMS_AUDIT_LOG_PATH` 指向持久化卷（默认路径已加入 `.gitignore` `/logs/`）。rotate 策略：单文件 ≥10 MB 或每日触发；归档保留 30 份
-  - 写操作路由的 RBAC 现在服务端强制：workers/teams/managers/humans 的 POST/PUT/DELETE/wake/sleep/ensure-ready 调用 `enforceServerSideRbac`（src/lib/server-auth.ts），403 写 warning 审计。skills/storage/projects/gateway/mcps/models-probe 等路由**未**接入，下一个 PR 推进
+  - 写操作路由的 RBAC 现在服务端强制：workers/teams/managers/humans 的 POST/PUT/DELETE/wake/sleep/ensure-ready 走 `enforceServerSideRbac`（带 accessibleWorkers/accessibleTeams 范围检查）；storage/skills/projects/gateway/debug-log/wen-tian/mcps/worker 文件/team 文件 等全局资源走 `enforceLevelOnlyRbac`（纯等级判断）。两类 403 都自动写 warning 审计
   - middleware 在 Higress session 验证通过后注入 `x-agentteams-user` / `x-agentteams-user-level`，proxy-helper 透传给 Controller。修改相关代码时记得：identity 头来自 middleware 不是浏览器，不要直接 `request.headers.get('authorization')` 当成 user 头
   - `recordToolCalls(workerName, eventId, blockCount, now?, structuredKeys?)` 第 5 个参数 `structuredKeys` 是 v1 协议（`org.agentteams.run`）结构化 tool_call 的 id 列表。传入时跳过 event-delta 计数，仅按 id 去重。纯 v0/无结构化数据时维持原 eventId 增量语义
   - `usePersistedDraft(roomId)` 暴露 `setValueLocal`（不写 storage）专供 edit session 回填——直接用 `setValue` 会把编辑中的内容持久化，下次进房间会看到。ChatRoom.tsx 的 handleRequestEditLast / handleCancelEdit 都用 setValueLocal
-  - feature-implementer skill 要求每个 task 完成后停下来等用户确认，不要自动推进下一 task。本次按此规范逐项推进 P0-1 / P0-2 / P1-4 Phase1，每项独立 commit + 验证
+  - feature-implementer skill 要求每个 task 完成后停下来等用户确认，不要自动推进下一 task。本次按此规范逐项推进 P0-1 / P0-2 / P1-4 Phase1 / RBAC 扩展 / 审计 viewer，每项独立 commit + 验证
   - PR 风格沿用项目约定：标题 `type(scope): summary`，正文包含验证证据（vitest 数字）、兼容性声明、风险与关注点
+  - `GET /api/agentteams/audit` 是 admin-only 入口；前端 `useAuditEvents` hook 把 403 当 data 返回而非抛错，UI 走 inline notice 分支渲染"需要管理员权限"
+  - 仍未接 RBAC 的写路由：`/api/agentteams/setup/*`（装机入口必须在 RBAC 前可达）、`/api/agentteams/packages/*`（由 Controller 侧 gate）、`/api/agentteams/models/probe`（只读）；所有 GET 路由保持开放

--- a/.monkeycode/MEMORY.md
+++ b/.monkeycode/MEMORY.md
@@ -57,3 +57,16 @@ Entries discovered by the Agent while performing [specific task description] sho
   - typecheck 必须用 ./node_modules/.bin/tsc --noEmit 或 npm run typecheck；直接 npx tsc 会误装废弃的 tsc@2.0.4 包报错
   - vitest 4 已移除 --reporter=basic，直接运行 ./node_modules/.bin/vitest run 或 npm test
   - 验证顺序：typecheck -> eslint（仅改动的文件）-> vitest run（全量 129 文件约 3 分钟）
+
+[Project Knowledge Summary]
+- Date: 2026-08-25
+- Context: 推进服务端治理 + ChatRoom 重构时落定的项目约定
+- Category: Operations & Deployment | Environment Configuration | Workflow & Collaboration
+- Instructions:
+  - 服务端审计默认落 `${cwd}/logs/audit.log.jsonl`，生产部署必须通过 `AGENTTEAMS_AUDIT_LOG_PATH` 指向持久化卷（默认路径已加入 `.gitignore` `/logs/`）。rotate 策略：单文件 ≥10 MB 或每日触发；归档保留 30 份
+  - 写操作路由的 RBAC 现在服务端强制：workers/teams/managers/humans 的 POST/PUT/DELETE/wake/sleep/ensure-ready 调用 `enforceServerSideRbac`（src/lib/server-auth.ts），403 写 warning 审计。skills/storage/projects/gateway/mcps/models-probe 等路由**未**接入，下一个 PR 推进
+  - middleware 在 Higress session 验证通过后注入 `x-agentteams-user` / `x-agentteams-user-level`，proxy-helper 透传给 Controller。修改相关代码时记得：identity 头来自 middleware 不是浏览器，不要直接 `request.headers.get('authorization')` 当成 user 头
+  - `recordToolCalls(workerName, eventId, blockCount, now?, structuredKeys?)` 第 5 个参数 `structuredKeys` 是 v1 协议（`org.agentteams.run`）结构化 tool_call 的 id 列表。传入时跳过 event-delta 计数，仅按 id 去重。纯 v0/无结构化数据时维持原 eventId 增量语义
+  - `usePersistedDraft(roomId)` 暴露 `setValueLocal`（不写 storage）专供 edit session 回填——直接用 `setValue` 会把编辑中的内容持久化，下次进房间会看到。ChatRoom.tsx 的 handleRequestEditLast / handleCancelEdit 都用 setValueLocal
+  - feature-implementer skill 要求每个 task 完成后停下来等用户确认，不要自动推进下一 task。本次按此规范逐项推进 P0-1 / P0-2 / P1-4 Phase1，每项独立 commit + 验证
+  - PR 风格沿用项目约定：标题 `type(scope): summary`，正文包含验证证据（vitest 数字）、兼容性声明、风险与关注点

--- a/.monkeycode/specs/chatroom-split/design.md
+++ b/.monkeycode/specs/chatroom-split/design.md
@@ -1,0 +1,61 @@
+# ChatRoom.tsx 拆分（Phase 1）
+
+## 背景
+
+src/components/dashboard/sections/chat/ChatRoom.tsx 已经 1040 行，承担着 15+ useState、20+ handler、5 个独立关注点（draft/upload/drag/drop/scroll/worker-pane）。每加一个交互都要动这个文件，已经成为 Chat 区演进的主要阻力。
+
+完整拆分需要 3-5 个独立 PR 渐进推进，每个阶段都必须是行为不变的可独立验证提交。
+
+## 目标（Phase 1）
+
+抽出两个高内聚、自包含、与 composer 解耦的关注点：
+
+1. **draft persistence** — 把每房间的输入草稿持久化逻辑（lines 95-118）抽到 `src/components/dashboard/sections/chat/hooks/usePersistedDraft.ts`
+2. **file upload + drag-and-drop** — 把上传状态机 + drop overlay + file → Matrix mxc + send（lines 82-84、397-439、519-543）抽到 `src/components/dashboard/sections/chat/hooks/useFileUpload.ts` 和 `useFileDropZone.ts`，导出 `DragDropOverlay` 组件
+
+行为完全不变；只移动代码、不重构语义。
+
+## 非目标
+
+- 不动 composer（chat-composer.tsx）内部
+- 不动 upload mutation 本身（src/hooks/use-matrix.ts 的 useMatrixUploadMedia）
+- 不动 MessageList / ScrollPanel / ThreadPanel
+- 不改 worker pane、reply、edit、drag-resize 等其它 ChatRoom 内部逻辑
+
+## 设计
+
+### usePersistedDraft(roomId)
+- 返回 `[value, setValue, clear]`，封装 localStorage 读写（key: `agentteams-chat-draft:${roomId}`）
+- 内部用 adjust-state-during-render 模式在 roomId 变化时恢复草稿（与原 ChatRoom 一致）
+- 暴露 `clear()` 用于发送/取消编辑后清空（替代散落的 `persistDraft('')` 调用）
+- 失败（storage 不可用）静默 fallback 到内存
+
+### useFileUpload({ roomId, isLoggedIn, userId, ... })
+- 接收 matrix mutations 与 local message 操作（pushLocal/patchLocal/removeLocal/pushSystemNotice）作为参数
+- 返回 `{ isUploading, upload(file) }`
+- 内部处理：image 判定 → upload mutation → send mutation → local message 三态（sending/sent/error）+ 错误时 pushSystemNotice
+
+### useFileDropZone({ onFiles })
+- 监听 container ref 的 drag enter/over/leave/drop 事件
+- 内部维护 dragCounterRef 处理子元素冒泡
+- 返回 `{ dragActive, dropZoneProps }`，dropZoneProps 包含 4 个事件 handler
+
+### DragDropOverlay
+- 受控展示组件，接受 `{ active: boolean, label?: string }`，绝对定位覆盖整个 chat area
+- 文案 + 视觉风格由本组件决定
+
+## 验收
+
+- [ ] usePersistedDraft 单测：写入 → 切换 room → 恢复 → 清除 → 空字符串不写存储
+- [ ] useFileUpload 单测：image file 走 m.image、非 image 走 m.file、上传失败时 pushSystemNotice 被调用
+- [ ] useFileDropZone 单测：drag enter/leave/drop 计数正确、非 File 类型 drag 不触发
+- [ ] DragDropOverlay 单测：active=true 时显示、false 时不显示
+- [ ] ChatRoom.tsx 行数下降到约 940-960（-80~100 行）
+- [ ] ChatRoom.test.tsx 全部用例继续通过（行为不变）
+- [ ] typecheck / lint / 全量 test 通过
+
+## 后续 Phase（不在本 PR）
+
+- Phase 2: worker pane resize 抽 `useWorkerPane` hook
+- Phase 3: edit session / reply / 系统通知抽 `useChatActions` hook
+- Phase 4: 把 ChatRoom 进一步拆成 `<ChatHeader>` + `<ChatTimeline>` + `<ChatSidebar>` 三个独立展示组件

--- a/.monkeycode/specs/chatroom-split/tasklist.md
+++ b/.monkeycode/specs/chatroom-split/tasklist.md
@@ -1,0 +1,21 @@
+# ChatRoom.tsx 拆分（Phase 1） — Task List
+
+- [x] 1. 新增 `src/components/dashboard/sections/chat/hooks/usePersistedDraft.ts`：基于 roomId 的 localStorage 持久化 hook，返回 `{ value, setValue, setValueLocal, clear }`，adjust-state-during-render 恢复模式
+- [x] 2. 新增 `src/components/dashboard/sections/chat/hooks/useFileUpload.ts`：封装 image/file 上传到 Matrix + 发送 m.image/m.file 消息的完整流程，接受 mutation 函数 + local message helpers 作为参数
+- [x] 3. 新增 `src/components/dashboard/sections/chat/hooks/useFileDropZone.ts`：基于 container ref 的 drop zone hook，返回 `{ dragActive, dropZoneProps }`，正确处理子元素 drag 冒泡
+- [x] 4. 新增 `src/components/dashboard/sections/chat/components/DragDropOverlay.tsx`：受控展示组件，absolute 覆盖整个区域显示拖拽提示
+- [x] 5. ChatRoom.tsx 接入 4 个新模块：删除原 draft/upload/drag 内联代码，替换为 hook/组件调用；行为不变
+- [x] 6. 单测：usePersistedDraft 7 例、useFileUpload 5 例、useFileDropZone 4 例、DragDropOverlay 3 例；ChatRoom.test.tsx 不改（行为不变）
+- [x] 7. typecheck + lint + 全量 138 文件 1207 用例通过；CHANGELOG Unreleased "Improvements" 段记录
+
+## 验收结果
+
+- ChatRoom.tsx: 1040 → 966 行（-74，-7%）
+- 全量测试: 0 回归，+19 新用例
+- typecheck / eslint: 全绿
+
+## 后续 Phase（不在本 PR）
+
+- Phase 2: worker pane resize 抽 `useWorkerPane` hook
+- Phase 3: edit session / reply / 系统通知抽 `useChatActions` hook
+- Phase 4: 把 ChatRoom 进一步拆成 `<ChatHeader>` + `<ChatTimeline>` + `<ChatSidebar>` 三个独立展示组件

--- a/.monkeycode/specs/runtime-block-protocol/design.md
+++ b/.monkeycode/specs/runtime-block-protocol/design.md
@@ -1,0 +1,54 @@
+# Runtime Block Protocol — Dashboard 侧契约与归一化
+
+## 背景
+
+Dashboard 当前通过 13 级文本启发式规则（src/lib/a2ui/normalize.ts:63）将 Matrix 消息归一化为块序列。该管线对未携带任何结构化字段的 runtime（Hermes / openhuman / qwenpaw）有效，但脆弱：每接入新 runtime 都需加规则，且无法携带跨消息的运行上下文。
+
+`org.agentteams.run` 解析器（src/lib/a2ui/parser.ts:65 `parseAgentRunBlocks`）已实现为生产者提供者的接入点，但目前是 opt-in 兼容通道——上游无生产者，且协议字段定义薄弱（见 parser.ts:65 注释："AgentTeams itself does not define this Matrix event schema"）。
+
+## 目标
+
+将 `org.agentteams.run` 从"临时占位"升级为有版本号、有标准化字段、有测试覆盖的协议契约，使上游运行时开始发结构化块后 Dashboard 可平滑切换；同时为工具调用台账增加结构化 ID 的优先级读取，使 worker-card 的"24h 工具调用数"在多端可见。
+
+## 非目标
+
+- 不要求 Dashboard 重写 normalize 主循环。本任务只固化 `org.agentteams.run` 的契约与降级路径。
+- 不动上游 AgentTeams runtime 发消息的代码（属另一仓库）。
+- 不动 Tool Guard 文本协议（属 P0-2 范围）。
+
+## 契约规范
+
+`org.agentteams.run` 在 Matrix `content` 中存在时是单一对象：
+
+```ts
+{
+  version: "1",
+  run_id: string,        // 关联同一次执行的多条消息
+  step_id?: string,      // 当前步骤；工具调用时填
+  blocks: Array<
+    | { type: "text"; text: string; isStreaming?: boolean }
+    | { type: "thinking"; content: string; isStreaming?: boolean }
+    | { type: "tool_call"; payload: { tool_name: string; arguments: Record<string, unknown>; result?: unknown; status: "pending" | "running" | "succeeded" | "failed"; tool_call_id?: string; started_at?: number; finished_at?: number } }
+    | { type: "confirmation"; payload: { tool_name: string; parameters?: string; external_files?: string; confirmation_id: string; expires_at?: number } }
+    | { type: "error"; payload: { kind: "cancelled" | "failed" | "quiet"; title: string } }
+  >
+}
+```
+
+- `version`：缺省 `"0"`（当前 opc-in 形态）；本任务规范引入 `"1"`。
+- `run_id`：可选但强烈推荐；缺省时降级到事件 ID 派生。
+- `confirmation_id`：未来 Tool Guard 协议化所需保留字段；本次仅透传不消费。
+- 已知未实现但保留：每块独立 `isStreaming` 与顶层 `isStreaming` 协同（沿用 parser.ts:83 的现有规则）。
+
+## 降级路径
+
+- `version === "0"` 或缺省：保留当前 13 级文本规则归一化路径，仅用 `parseAgentRunBlocks` 现有的"按 blocks 数组里 type 字符串映射"逻辑。
+- `version === "1"`：优先消费 blocks 数组；若某 block 字段不全（如 tool_call 缺 status），按缺省值填充并打 console.warn（仅开发态）。
+- 解析失败：与现有"降级到文本"行为一致（normalize.ts 调用点不被破坏）。
+
+## 验收
+
+- [ ] `parseAgentRunBlocks` 新增 `version` 区分分支，v1 路径覆盖 text/thinking/tool_call/confirmation/error 五种块。
+- [ ] tool_call 块 `tool_call_id` 字段被 `recordToolCalls` 优先采用为去重键。
+- [ ] 新增单测覆盖：v0/v1 各类型块、字段缺失降级、版本不识别降级、tool_call_id 去重。
+- [ ] `npm run typecheck` / `npm run lint` / `npm test` 全绿。

--- a/.monkeycode/specs/runtime-block-protocol/tasklist.md
+++ b/.monkeycode/specs/runtime-block-protocol/tasklist.md
@@ -1,0 +1,22 @@
+# Runtime Block Protocol — Task List
+
+## 任务列表
+
+- [x] 1. 在 src/lib/a2ui/protocol.ts 新增 RuntimeBlock v0/v1 discriminated union 类型与版本探测函数 `resolveProtocolVersion`。无运行时副作用，便于上游未来直接复用。
+- [x] 2. 在 src/lib/a2ui/parser.ts 改造 `parseAgentRunBlocks`：按 version 分流，v1 路径走规范化字段（tool_call.status、thinking.isStreaming 等），v0 保持现有透传语义。失败/未知版本一律返回 undefined 让上游走文本启发式。
+- [x] 3. 在 src/lib/a2ui/protocol.ts 配套导出 `normalizeToolCallPayload(v1Block)` 与 `normalizeConfirmationPayload(v1Block)` 两个规范化工具，保证下游消费者（MessageBubble、tool-call-counter）拿到统一形态。
+- [x] 4. 在 src/lib/tool-call-counter.ts 增加 `recordToolCalls` 对结构化 `tool_call_id` 的优先级读取：若 v1 block 含 `tool_call_id` 则按该键去重，否则保留现有 `(eventId, toolName, argsHash)` 复合键。
+- [x] 5. 单测：parser.test.ts 新增 `describe('parseAgentRunBlocks v1')` 覆盖五类块、字段缺失降级、未知 version 降级；tool-call-counter.test.ts 新增结构化 id 去重用例。
+- [x] 6. 跑 typecheck + lint + test 验证；记录改动到 CHANGELOG Unreleased "Improvements" 段。
+
+## 范围外
+
+- 不动 normalize.ts 的 13 级规则顺序。
+- 不动 Tool Guard 文本识别（parser.ts:281 `parseToolGuardConfirmation`）。
+- 不改 MessageBubble 渲染逻辑（结构化字段已通过 runtimeHint 透传）。
+
+## 验证
+
+- typecheck：`./node_modules/.bin/tsc --noEmit` 通过
+- lint：`./node_modules/.bin/eslint <改动文件>` 通过
+- test：`./node_modules/.bin/vitest run` 全量 131 文件 1167 用例通过

--- a/.monkeycode/specs/server-side-rbac-audit/design.md
+++ b/.monkeycode/specs/server-side-rbac-audit/design.md
@@ -1,0 +1,55 @@
+# Server-side RBAC + Audit
+
+## 背景
+
+Dashboard 当前有两个治理层面的薄弱环节：
+- **审计**：src/lib/audit-store.ts 是 zustand + localStorage，仅 src/hooks/use-agentteams-mutations.ts 的 14 处调用。被用户/浏览器清空即失忆，多端不可见。
+- **RBAC**：src/lib/rbac-engine.ts 写完了完整的规则引擎，但服务端 middleware（src/middleware.ts:55）只校验"是否有 Higress session"，rbac-engine 仅在 human-detail-dialog 等 UI 展示。任何人持有效 session 即可执行任意管理操作。
+
+## 目标
+
+1. 审计事件落到服务端 JSONL 文件，客户端 store 降级为展示缓存；任何被服务端接收的 mutation 在服务端也写一条不可篡改的记录。
+2. middleware 解析 Higress session 背后的用户名/角色，注入到请求头；mutation API 在写 Controller 之前按 rbac-engine 做服务端细粒度校验。
+3. 不引入新数据库依赖。
+
+## 非目标
+
+- 不改 Higress Console 的会话机制。
+- 不引入 SQLite / better-sqlite3 / Prisma / Drizzle 等任何服务端 DB。
+- 不动 rbac-engine 的规则语义（保持现有 3 级权限 + custom rules 模型）。
+- 不改客户端 mutation 流程的用户体验（toast / store 行为不变）。
+
+## 设计
+
+### 服务端审计
+- 路径：`/var/log/agentteams/audit.log.jsonl`（可通过 `AGENTTEAMS_AUDIT_LOG_PATH` 覆盖，默认 `${cwd}/logs/audit.log.jsonl`）
+- 格式：每行一个 JSON 对象，含 `id`（ULID/时间戳+随机）、`timestamp`、`actor`、`actor_level`、`entity_type`、`entity_name`、`action`、`details`、`severity`、`source_ip`
+- rotate：文件达到 10 MB 或当日 0 点触发 rotate，旧的归档为 `audit.log.YYYY-MM-DD.jsonl`（最多保留 30 份）
+- 写入用 `fs.appendFile` 单次 syscall，避免高频 mutation 触发 IO 抖动；rotate 用单独子进程异步执行
+- 新增 `src/app/api/agentteams/audit/route.ts`：
+  - POST 写入（由 mutation 流程异步触发，失败仅记 warn 不阻塞业务）
+  - GET 列表（分页 + 时间范围 + entity 过滤；仅 admin 级别可见）
+  - 路径仍受 middleware 保护
+
+### 用户身份注入
+- 扩展 `src/lib/api-auth.ts` 的 `validateHigressSession`：在调用 `/v1/consumers` 时同时取回 `name` 与 `level`，返回 `{ valid, user: { name, level } }`
+- `src/middleware.ts` 在通过验证后通过 `x-agentteams-user` 与 `x-agentteams-user-level` 两个请求头把身份传下去
+- proxy-helper.ts 增加白名单头部 `x-agentteams-user*`，透传给 Controller（写操作可被 Controller 审计关联）
+- 新增 `src/lib/server-auth.ts`：从请求头读取身份并构造 `HumanResponse` 供 rbac-engine 使用
+
+### 服务端 RBAC
+- 在 src/lib/rbac-engine.ts 导出 `permissionToActionMap`：把 mutation 路由映射到 Permission 枚举
+- `src/app/api/agentteams/` 下写操作路由（workers POST/DELETE/wake/sleep/ensure-ready，teams POST/DELETE，managers POST/DELETE）在调用 Controller 前调用 `enforceServerSideRbac(req, action, resourceType, resourceName)`；失败返回 403 并自动写一条 severity=warning 的审计
+- 读操作（GET）暂不强制 RBAC（防止与既有 Human 列表语义冲突；后续按需收紧）
+
+## 验收
+
+- [ ] `validateHigressSession` 返回 `{ valid, user }`，缓存结构兼容
+- [ ] middleware 通过验证时写入 `x-agentteams-user` / `x-agentteams-user-level` 请求头
+- [ ] proxy-helper 透传上述头给 Controller（白名单方式）
+- [ ] 写操作路由（workers/teams/managers POST/DELETE/wake/sleep/ensure-ready）在写 Controller 前调用服务端 RBAC；403 响应包含可读原因
+- [ ] 每次 mutation 成功/失败均向服务端审计 POST 一条 JSONL 记录
+- [ ] 服务端审计 JSONL 文件按 10 MB 自动 rotate，保留 30 份
+- [ ] `GET /api/agentteams/audit` 仅 admin 级别可见
+- [ ] typecheck / lint / test 全绿；现有 14 处 auditMutation 调用保持客户端 UX 不变
+- [ ] CHANGELOG Unreleased 记录

--- a/.monkeycode/specs/server-side-rbac-audit/tasklist.md
+++ b/.monkeycode/specs/server-side-rbac-audit/tasklist.md
@@ -1,0 +1,17 @@
+# Server-side RBAC + Audit — Task List
+
+- [x] 1. 新增 `src/lib/audit-log.ts`：JSONL append + 10 MB rotate + 路径配置（环境变量 `AGENTTEAMS_AUDIT_LOG_PATH`，默认 `${cwd}/logs/audit.log.jsonl`）。导出 `appendAuditEvent(input)` 与 `listAuditEvents(query)`，单测覆盖 rotate 与并发追加
+- [x] 2. 扩展 `src/lib/api-auth.ts` 的 `validateHigressSession`：从 `/v1/consumers` 响应提取 `name`/`level`，返回 `{ valid, user }`；缓存结构兼容（增加 `user` 字段）。同步更新所有调用点（plugins/route、plugins/[id]/route、higress/access）解构 `.valid`
+- [x] 3. `src/middleware.ts`：在 401 检查通过后，通过 `NextResponse.next({ request: { headers: ... } })` 注入 `x-agentteams-user` / `x-agentteams-user-level`
+- [x] 4. `src/app/api/agentteams/proxy-helper.ts`：在 auth-token 注入后增加白名单头 `x-agentteams-user` / `x-agentteams-user-level` 透传给 Controller
+- [x] 5. 新增 `src/lib/server-auth.ts`：从 NextRequest 读取用户头 → 构造 `HumanResponse` → 调用 rbac-engine `checkPermission`；导出 `enforceServerSideRbac(req, action, resourceType, resourceName)`（无身份头时默认放行，由 middleware 网关决定）
+- [x] 6. 改造写操作路由（worker create/update/delete/wake/sleep/ensure-ready，team create/update/delete，manager create/update/delete，human create/update/delete）：在调用 Controller 前调用 `enforceServerSideRbac`，403 时通过 server-auth 内部审计写入 warning 事件
+- [x] 7. 新增 `src/app/api/agentteams/audit/route.ts`：POST 写入（仅 admin 内部，受 middleware 保护）、GET 列表（分页 + 时间 + entity 过滤，admin-only）
+- [x] 8. `src/lib/audit-store.ts`：把 `auditMutation` 扩展为同时写本地 store 与服务端 `/api/agentteams/audit` POST（失败仅 warn）。hooks 层无改动
+- [x] 9. 测试：audit-log 6 例、server-auth 5 例、audit API route 5 例、worker route RBAC 3 例；access.test.ts 与 plugins/route.test.ts mock 适配新 SessionValidation 形状
+- [x] 10. typecheck + lint + 全量 134 文件 1188 用例通过；CHANGELOG Unreleased 记录
+
+## 范围外（后续 PR）
+
+- skills / storage / projects / gateway / debug-log / wen-tian / mcps / models/probe / packages / setup / presign 等写路由暂未加 RBAC，按 Controller 侧权限执行
+- audit GET 暂无前端 viewer；按 spec 路线图规划

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@
   - `useFileUpload(input)` — file → Matrix mxc + m.image/m.file 发送状态机
   - `useFileDropZone({ onFiles })` + `<DragDropOverlay>` — drag-and-drop 文件上传层
   - ChatRoom.tsx 由 1040 行降至 966 行；行为不变
+- **RBAC 扩展到所有写路由**：新增 `enforceLevelOnlyRbac`（基于权限等级，无资源范围检查）处理 storage / skills / projects / gateway / debug-log / wen-tian / mcps / worker 文件操作 等全局资源；worker/team 资源继续走 `enforceServerSideRbac`。403 时按 entity_type 写 audit 记录
+- **rbac-engine 扩展**：`checkPermissionByLevel(level, action)` —— 用于全局资源路由的纯等级决策
 
 ### Improvements
-- 新增测试：parser v1 路径 11 例、tool-call-counter 结构化 id 去重 7 例、audit-log 6 例、server-auth 5 例、audit API route 5 例、worker route RBAC 3 例、usePersistedDraft 7 例、useFileUpload 5 例、useFileDropZone 4 例、DragDropOverlay 3 例；access.test.ts 与 plugins/route.test.ts mock 适配新 SessionValidation 形状。全量 1207 个用例通过
+- 新增测试：parser v1 路径 11 例、tool-call-counter 结构化 id 去重 7 例、audit-log 6 例、server-auth 5 + 5 例（enforceLevelOnlyRbac）、audit API route 5 例、worker route RBAC 3 例、usePersistedDraft 7 例、useFileUpload 5 例、useFileDropZone 4 例、DragDropOverlay 3 例。全量 1212 个用例通过
 
 ### Contributors
 - @monkeycode-ai（平台 AI 协作者）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   - ChatRoom.tsx 由 1040 行降至 966 行；行为不变
 - **RBAC 扩展到所有写路由**：新增 `enforceLevelOnlyRbac`（基于权限等级，无资源范围检查）处理 storage / skills / projects / gateway / debug-log / wen-tian / mcps / worker 文件操作 等全局资源；worker/team 资源继续走 `enforceServerSideRbac`。403 时按 entity_type 写 audit 记录
 - **rbac-engine 扩展**：`checkPermissionByLevel(level, action)` —— 用于全局资源路由的纯等级决策
+- **审计 viewer**：新增"审计"侧边栏 section（admin-only），通过 `GET /api/agentteams/audit` 渲染服务端 JSONL 事件表格，支持 entity_type 过滤与 15s 轮询；非 admin 看到友好提示而非 403 报错
+- **新 hook `useAuditEvents`**：TanStack Query 包装 `/api/agentteams/audit`，封装 403 错误体不抛出
 
 ### Improvements
 - 新增测试：parser v1 路径 11 例、tool-call-counter 结构化 id 去重 7 例、audit-log 6 例、server-auth 5 + 5 例（enforceLevelOnlyRbac）、audit API route 5 例、worker route RBAC 3 例、usePersistedDraft 7 例、useFileUpload 5 例、useFileDropZone 4 例、DragDropOverlay 3 例。全量 1212 个用例通过

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,14 @@
   - `src/lib/server-auth.ts` 提供 `enforceServerSideRbac`，workers/teams/managers/humans 的写操作路由（POST/PUT/DELETE/wake/sleep/ensure-ready）调用 rbac-engine 做服务端细粒度校验；403 时自动写一条 warning 审计
   - `src/app/api/agentteams/audit/route.ts` 新增：POST 写入（服务端镜像客户端审计事件），GET 列表（admin-only，按时间/entity 过滤）
   - `auditMutation` 客户端 helper 自动向服务端镜像审计事件，失败仅 warn 不阻塞 mutation
+- **ChatRoom 拆分（Phase 1）**：抽出三个独立模块
+  - `usePersistedDraft(roomId)` — 每房间的输入草稿持久化 hook（含 setValueLocal 不写 storage 的 setInput-only 接口，保留 edit session 回填行为）
+  - `useFileUpload(input)` — file → Matrix mxc + m.image/m.file 发送状态机
+  - `useFileDropZone({ onFiles })` + `<DragDropOverlay>` — drag-and-drop 文件上传层
+  - ChatRoom.tsx 由 1040 行降至 966 行；行为不变
 
 ### Improvements
-- 新增测试：parser v1 路径 11 例、tool-call-counter 结构化 id 去重 7 例、audit-log 6 例、server-auth 5 例、audit API route 5 例、worker route RBAC 3 例；access.test.ts 与 plugins/route.test.ts mock 适配新 SessionValidation 形状。全量 1188 个用例通过
+- 新增测试：parser v1 路径 11 例、tool-call-counter 结构化 id 去重 7 例、audit-log 6 例、server-auth 5 例、audit API route 5 例、worker route RBAC 3 例、usePersistedDraft 7 例、useFileUpload 5 例、useFileDropZone 4 例、DragDropOverlay 3 例；access.test.ts 与 plugins/route.test.ts mock 适配新 SessionValidation 形状。全量 1207 个用例通过
 
 ### Contributors
 - @monkeycode-ai（平台 AI 协作者）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
 - **项目时间线面板（Project Timeline Panel）**：在项目详情面板底部新增「干预记录」折叠区，调用 Controller `GET /api/v1/projects/{id}/history` 与 `…/history/{ts}` 端点，按时间倒序列出每次人工干预（暂停 / 恢复 / 重规划等）前的 workflow 快照元数据；点击单条记录可查看状态、标题、操作人、操作时间、暂停原因等审计字段
   - 用 AbortController 取消未完成的请求，避免面板关闭/组件卸载后状态错位
 - **项目 API 降级横幅（DegradedBanner）**：在项目页头部展示 Controller 端点 404（API 未部署）/ 500（Controller 故障）的差异化提示，并附带 Controller 返回的原始错误信息，便于运维快速定位
+- **运行时块协议 v1 契约（`org.agentteams.run`）**：新增 `src/lib/a2ui/protocol.ts` 定义带版本号的 discriminated union（text/thinking/tool_call/confirmation/error），并把 `parseAgentRunBlocks` 拆为 v1 规范化路径与 v0 透传路径。v1 路径为 tool_call 块补齐 `tool_call_id` / `status` / `started_at` / `finished_at` 等字段，confirmation 块要求 `confirmation_id`。未知版本一律降级到现有文本启发式而不丢弃消息
+- **结构化 tool_call 去重**：`recordToolCalls` 新增可选 `structuredKeys` 参数，当 runtime 上传带 `tool_call_id` 的结构化块时以 id 为权威去重键；同一事件多次修订或跨设备复用同一 id 都不会重复计入 Worker 卡片活物条。v0/纯事件块路径行为不变
+
+### Improvements
+- 新增测试：parser v1 路径 11 例（每种块类型 + 字段缺失 + 未知版本 + 未知块类型）；tool-call-counter 结构化 id 去重 7 例。全量 1167 个用例通过
 
 ### Contributors
-
 - @monkeycode-ai（平台 AI 协作者）
 
 ## v1.2.3.1 (2026-08-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@
 - **项目 API 降级横幅（DegradedBanner）**：在项目页头部展示 Controller 端点 404（API 未部署）/ 500（Controller 故障）的差异化提示，并附带 Controller 返回的原始错误信息，便于运维快速定位
 - **运行时块协议 v1 契约（`org.agentteams.run`）**：新增 `src/lib/a2ui/protocol.ts` 定义带版本号的 discriminated union（text/thinking/tool_call/confirmation/error），并把 `parseAgentRunBlocks` 拆为 v1 规范化路径与 v0 透传路径。v1 路径为 tool_call 块补齐 `tool_call_id` / `status` / `started_at` / `finished_at` 等字段，confirmation 块要求 `confirmation_id`。未知版本一律降级到现有文本启发式而不丢弃消息
 - **结构化 tool_call 去重**：`recordToolCalls` 新增可选 `structuredKeys` 参数，当 runtime 上传带 `tool_call_id` 的结构化块时以 id 为权威去重键；同一事件多次修订或跨设备复用同一 id 都不会重复计入 Worker 卡片活物条。v0/纯事件块路径行为不变
+- **服务端 RBAC + JSONL 审计**：
+  - `src/lib/audit-log.ts` 新增 append-only JSONL 审计日志（10 MB 自动 rotate，保留 30 份归档，路径可通过 `AGENTTEAMS_AUDIT_LOG_PATH` 覆盖）
+  - `validateHigressSession` 现返回 `{ valid, user }`，middleware 在通过验证时把 `x-agentteams-user` / `x-agentteams-user-level` 注入下游，proxy-helper 透传给 Controller
+  - `src/lib/server-auth.ts` 提供 `enforceServerSideRbac`，workers/teams/managers/humans 的写操作路由（POST/PUT/DELETE/wake/sleep/ensure-ready）调用 rbac-engine 做服务端细粒度校验；403 时自动写一条 warning 审计
+  - `src/app/api/agentteams/audit/route.ts` 新增：POST 写入（服务端镜像客户端审计事件），GET 列表（admin-only，按时间/entity 过滤）
+  - `auditMutation` 客户端 helper 自动向服务端镜像审计事件，失败仅 warn 不阻塞 mutation
 
 ### Improvements
-- 新增测试：parser v1 路径 11 例（每种块类型 + 字段缺失 + 未知版本 + 未知块类型）；tool-call-counter 结构化 id 去重 7 例。全量 1167 个用例通过
+- 新增测试：parser v1 路径 11 例、tool-call-counter 结构化 id 去重 7 例、audit-log 6 例、server-auth 5 例、audit API route 5 例、worker route RBAC 3 例；access.test.ts 与 plugins/route.test.ts mock 适配新 SessionValidation 形状。全量 1188 个用例通过
 
 ### Contributors
 - @monkeycode-ai（平台 AI 协作者）

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,24 @@ flowchart LR
   API --> Console["Higress Console"]
   API --> Storage["MinIO"]
   API --> Nacos["Nacos 注册中心"]
+  API --> AuditLog["审计日志 (JSONL)"]
 ```
+
+## 服务端治理（v1.2.4 起）
+
+`src/middleware.ts` 在 Higress session 通过验证后，注入 `x-agentteams-user` / `x-agentteams-user-level` 两个请求头；`src/app/api/agentteams/proxy-helper.ts` 透传给 Controller 便于审计关联。`src/lib/server-auth.ts` 的 `enforceServerSideRbac` 调用既有 `src/lib/rbac-engine.ts`（3 级权限 + 显式规则 deny 优先），对 workers / teams / managers / humans 的写操作路由做服务端细粒度校验；403 时自动写一条 warning 审计。
+
+审计事件落 `src/lib/audit-log.ts` 维护的 append-only JSONL（10 MB rotate，保留 30 份归档，路径由 `AGENTTEAMS_AUDIT_LOG_PATH` 覆盖，默认 `${cwd}/logs/audit.log.jsonl`）。客户端 `auditMutation`（`src/lib/audit-store.ts`）每次写入同时镜像到服务端 `/api/agentteams/audit` POST，失败仅 warn 不阻塞 mutation。审计列表查询走 `GET /api/agentteams/audit`，admin-only。
+
+## 运行时消息协议（`org.agentteams.run`）
+
+Dashboard 解析 Matrix 消息时优先识别 `content['org.agentteams.run']` 结构化载荷（`src/lib/a2ui/protocol.ts` 定义 discriminated union：text / thinking / tool_call / confirmation / error），按 `version` 字段分流：
+
+- `version: "1"` 走 `parseAgentRunBlocks` 的规范化路径，补齐 `tool_call_id` / `status` / `started_at` / `finished_at` 等字段，confirmation 块强制 `confirmation_id`
+- `version: "0"` / 缺省走原有透传语义
+- 未知版本一律降级到 13 级文本启发式规则而不丢消息
+
+上游 runtime 接入此协议后即可替代现有文本启发式路径。`recordToolCalls` 接受可选 `structuredKeys`，v1 块含 `tool_call_id` 时按 id 为权威去重键，跨设备/跨修订一致。
 
 ## Higress 外部适配
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -40,10 +40,13 @@
 `.monkeycode/specs/` 目录包含已完成的功能规范文档：
 
 - [chat-unread-sort-rendering/](../.monkeycode/specs/chat-unread-sort-rendering/) - 聊天未读排序渲染
+- [chatroom-split/](../.monkeycode/specs/chatroom-split/) - ChatRoom 拆分（Phase 1：draft / upload / drag-drop）
 - [dashboard-navigation-cleanup/](../.monkeycode/specs/dashboard-navigation-cleanup/) - 导航清理
 - [debug-log-collection/](../.monkeycode/specs/debug-log-collection/) - 调试日志收集
 - [openclaw-bridge/](../.monkeycode/specs/openclaw-bridge/) - OpenClaw Bridge
 - [plugin-system/](../.monkeycode/specs/plugin-system/) - 插件系统
+- [runtime-block-protocol/](../.monkeycode/specs/runtime-block-protocol/) - `org.agentteams.run` v1 协议契约
+- [server-side-rbac-audit/](../.monkeycode/specs/server-side-rbac-audit/) - 服务端 RBAC + JSONL 审计
 - [theme-system/](../.monkeycode/specs/theme-system/) - 主题系统
 - [theme-system-ux-redesign/](../.monkeycode/specs/theme-system-ux-redesign/) - 主题 UX 重设计
 - [theme-system-ux-redesign-v2/](../.monkeycode/specs/theme-system-ux-redesign-v2/) - 主题 UX 重设计 v2

--- a/src/app/api/agentteams/audit/route.test.ts
+++ b/src/app/api/agentteams/audit/route.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createServer, type Server } from 'node:http';
+import { NextRequest } from 'next/server';
+import { GET, POST } from './route';
+import { setAuditLogPathForTests } from '@/lib/audit-log';
+
+let server: Server;
+let controllerUrl: string;
+let tmpDir: string;
+let logPath: string;
+const received: Array<{ method: string; url: string; body?: string }> = [];
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      received.push({ method: req.method ?? '', url: req.url ?? '', body });
+      res.writeHead(204);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no server address');
+  controllerUrl = `http://127.0.0.1:${address.port}`;
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'audit-route-'));
+  logPath = path.join(tmpDir, 'audit.log.jsonl');
+  setAuditLogPathForTests(logPath);
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  received.length = 0;
+});
+
+function makeRequest(pathSuffix: string, init: { method?: string; body?: string; admin?: boolean } = {}) {
+  const url = new URL(`http://localhost${pathSuffix}`);
+  url.searchParams.set('controllerUrl', controllerUrl);
+  const headers: Record<string, string> = {};
+  if (init.body) headers['content-type'] = 'application/json';
+  if (init.admin !== false) {
+    headers['x-agentteams-user'] = 'admin';
+    headers['x-agentteams-user-level'] = '3';
+  }
+  return new NextRequest(url, {
+    method: init.method ?? 'GET',
+    headers,
+    body: init.body,
+  });
+}
+
+describe('GET /api/agentteams/audit', () => {
+  it('returns 403 when the caller is not admin', async () => {
+    const res = await GET(makeRequest('/api/agentteams/audit', { admin: false }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 with the active log entries when admin', async () => {
+    const res = await GET(makeRequest('/api/agentteams/audit'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.events)).toBe(true);
+  });
+});
+
+describe('POST /api/agentteams/audit', () => {
+  it('returns 403 when no identity header is present', async () => {
+    const res = await POST(makeRequest('/api/agentteams/audit', { method: 'POST', body: '{}', admin: false }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when the payload is missing required fields', async () => {
+    const res = await POST(makeRequest('/api/agentteams/audit', { method: 'POST', body: '{}' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('writes a valid event to the JSONL log', async () => {
+    const res = await POST(
+      makeRequest('/api/agentteams/audit', {
+        method: 'POST',
+        body: JSON.stringify({
+          entity_type: 'worker',
+          entity_name: 'w-from-test',
+          action: 'create',
+          severity: 'info',
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.id).toMatch(/^audit-/);
+
+    // Wait briefly for fs.appendFile to flush, then verify the line landed.
+    await new Promise((r) => setTimeout(r, 20));
+    const content = await fs.readFile(logPath, 'utf8');
+    expect(content).toContain('w-from-test');
+    expect(content).toContain('"action":"create"');
+  });
+});

--- a/src/app/api/agentteams/audit/route.ts
+++ b/src/app/api/agentteams/audit/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { appendAuditEvent, listAuditEvents, type AuditEventInput, type AuditEventRecord } from '@/lib/audit-log';
+import { readServerIdentity, SERVER_USER_LEVEL_HEADER } from '@/lib/server-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ALLOWED_ENTITIES: ReadonlySet<AuditEventInput['entity_type']> = new Set([
+  'worker',
+  'team',
+  'manager',
+  'human',
+  'system',
+]);
+
+function badRequest(message: string): NextResponse {
+  return NextResponse.json({ success: false, error: message }, { status: 400 });
+}
+
+function isAdminLevel(value: string | null): boolean {
+  if (!value) return false;
+  const level = Number(value);
+  return Number.isFinite(level) && level >= 3;
+}
+
+/**
+ * GET /api/agentteams/audit?from=&to=&entityType=&limit=
+ *
+ * Lists recent audit events. Admin-only — the dashboard is the canonical
+ * viewer for this data, and downstream operator personas are at level 3.
+ */
+export async function GET(request: NextRequest) {
+  if (!isAdminLevel(request.headers.get(SERVER_USER_LEVEL_HEADER))) {
+    return NextResponse.json({ success: false, error: '需要管理员权限' }, { status: 403 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  const from = params.get('from');
+  const to = params.get('to');
+  const entityType = params.get('entityType');
+  const limitRaw = params.get('limit');
+
+  const query: Parameters<typeof listAuditEvents>[0] = {};
+  if (from) {
+    const ts = Number(from);
+    if (!Number.isFinite(ts)) return badRequest('from 不是合法时间戳');
+    query.from = ts;
+  }
+  if (to) {
+    const ts = Number(to);
+    if (!Number.isFinite(ts)) return badRequest('to 不是合法时间戳');
+    query.to = ts;
+  }
+  if (entityType) {
+    if (!ALLOWED_ENTITIES.has(entityType as AuditEventInput['entity_type'])) {
+      return badRequest('entityType 非法');
+    }
+    query.entityType = entityType as AuditEventInput['entity_type'];
+  }
+  if (limitRaw) {
+    const limit = Number(limitRaw);
+    if (!Number.isFinite(limit) || limit <= 0) return badRequest('limit 必须为正整数');
+    query.limit = limit;
+  }
+
+  const events = await listAuditEvents(query);
+  return NextResponse.json({ success: true, events });
+}
+
+/**
+ * POST /api/agentteams/audit
+ *
+ * Internal write path used by the mutation flow to record governance events
+ * on the server. The identity is taken from middleware-injected headers
+ * (forgery-resistant). Body fields that conflict with the resolved identity
+ * are overwritten server-side so a malicious client cannot impersonate.
+ */
+export async function POST(request: NextRequest) {
+  const identity = readServerIdentity(request);
+  if (!identity) {
+    return NextResponse.json(
+      { success: false, error: '无身份头，禁止写入审计' },
+      { status: 403 },
+    );
+  }
+
+  let payload: Partial<AuditEventInput> & { severity?: AuditEventInput['severity'] };
+  try {
+    payload = (await request.json()) as typeof payload;
+  } catch {
+    return badRequest('请求体不是合法 JSON');
+  }
+
+  if (!payload || typeof payload !== 'object') return badRequest('请求体必须为对象');
+  if (typeof payload.entity_type !== 'string' || !ALLOWED_ENTITIES.has(payload.entity_type as AuditEventInput['entity_type'])) {
+    return badRequest('entity_type 非法');
+  }
+  if (typeof payload.entity_name !== 'string' || payload.entity_name.length === 0) {
+    return badRequest('entity_name 必填');
+  }
+  if (typeof payload.action !== 'string' || payload.action.length === 0) {
+    return badRequest('action 必填');
+  }
+
+  const record: AuditEventRecord | undefined = await appendAuditEvent({
+    actor: identity.name,
+    actor_level: identity.level,
+    entity_type: payload.entity_type as AuditEventInput['entity_type'],
+    entity_name: payload.entity_name,
+    action: payload.action,
+    details: typeof payload.details === 'string' ? payload.details : undefined,
+    severity: payload.severity,
+    source_ip: identity.sourceIp,
+  });
+
+  if (!record) {
+    return NextResponse.json({ success: false, error: '审计写入失败' }, { status: 500 });
+  }
+  return NextResponse.json({ success: true, id: record.id });
+}

--- a/src/app/api/agentteams/debug-log/route.ts
+++ b/src/app/api/agentteams/debug-log/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { zipSync, strToU8 } from 'fflate';
 import { getAuthToken, getControllerUrl } from '../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 import { redactPii, redactJsonStrings } from './redact';
 import {
   DockerContext,
@@ -131,6 +132,8 @@ function parseBody(value: unknown): { body: DebugLogRequest; error?: string } {
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'view', 'debug-log', 'collect');
+  if (denied) return denied;
   let rawBody: unknown;
   try {
     rawBody = await request.json();

--- a/src/app/api/agentteams/gateway/consumers/[id]/bind/route.ts
+++ b/src/app/api/agentteams/gateway/consumers/[id]/bind/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'gateway.consumer', id);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/gateway/consumers/${encodeURIComponent(id)}/bind`, { forwardBody: false, method: 'POST' });
 }

--- a/src/app/api/agentteams/gateway/consumers/[id]/route.ts
+++ b/src/app/api/agentteams/gateway/consumers/[id]/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const denied = await enforceLevelOnlyRbac(request, 'delete', 'gateway.consumer', id);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/gateway/consumers/${encodeURIComponent(id)}`, { forwardBody: false, method: 'DELETE' });
 }

--- a/src/app/api/agentteams/gateway/consumers/route.ts
+++ b/src/app/api/agentteams/gateway/consumers/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/gateway/consumers', { forwardBody: false });
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'create', 'gateway.consumer', 'new');
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/gateway/consumers');
 }

--- a/src/app/api/agentteams/humans/[name]/route.ts
+++ b/src/app/api/agentteams/humans/[name]/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../proxy-helper';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'update', 'team', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/humans/${encodeURIComponent(name)}`);
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'delete', 'team', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/humans/${encodeURIComponent(name)}`, { forwardBody: false, method: 'DELETE' });
 }

--- a/src/app/api/agentteams/humans/route.ts
+++ b/src/app/api/agentteams/humans/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../proxy-helper';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/humans', { forwardBody: false });
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceServerSideRbac(request, 'create', 'team', '*');
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/humans');
 }

--- a/src/app/api/agentteams/managers/[name]/route.ts
+++ b/src/app/api/agentteams/managers/[name]/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../proxy-helper';
 import { getRequestModelAlias, rejectExternalModelProvider, rejectUnavailableExternalModelAlias } from '../../external-model-binding-guard';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'update', 'team', name);
+  if (denied) return denied;
   const providerRejected = await rejectExternalModelProvider(request);
   if (providerRejected) return providerRejected;
   const rejected = await rejectUnavailableExternalModelAlias(request, await getRequestModelAlias(request));
@@ -13,5 +16,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'delete', 'team', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/managers/${encodeURIComponent(name)}`, { forwardBody: false, method: 'DELETE' });
 }

--- a/src/app/api/agentteams/managers/route.ts
+++ b/src/app/api/agentteams/managers/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../proxy-helper';
 import { getRequestModelAlias, rejectExternalModelProvider, rejectUnavailableExternalModelAlias } from '../external-model-binding-guard';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/managers', { forwardBody: false });
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceServerSideRbac(request, 'create', 'team', '*');
+  if (denied) return denied;
   const providerRejected = await rejectExternalModelProvider(request);
   if (providerRejected) return providerRejected;
   const rejected = await rejectUnavailableExternalModelAlias(request, await getRequestModelAlias(request));

--- a/src/app/api/agentteams/mcps/[name]/route.ts
+++ b/src/app/api/agentteams/mcps/[name]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 const MCP_SERVERS_PREFIX = 'mcp-servers/';
 
@@ -69,6 +70,9 @@ export async function PUT(
     return NextResponse.json({ error: 'Invalid MCP server name' }, { status: 400 });
   }
 
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'mcp', name);
+  if (denied) return denied;
+
   let body: { url?: string; transport?: string; type?: string; timeout?: number; headers?: Record<string, string>; description?: string };
   try {
     body = await request.json();
@@ -132,7 +136,7 @@ export async function PUT(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ name: string }> }
 ) {
   const bucket = getMinioBucket();
@@ -144,6 +148,9 @@ export async function DELETE(
   if (!isValidMcpName(name)) {
     return NextResponse.json({ error: 'Invalid MCP server name' }, { status: 400 });
   }
+
+  const denied = await enforceLevelOnlyRbac(request, 'delete', 'mcp', name);
+  if (denied) return denied;
 
   const key = `${MCP_SERVERS_PREFIX}${name}.json`;
 

--- a/src/app/api/agentteams/mcps/route.ts
+++ b/src/app/api/agentteams/mcps/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 const MCP_SERVERS_PREFIX = 'mcp-servers/';
 
@@ -81,6 +82,9 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: '请求体格式错误' }, { status: 400 });
   }
+
+  const denied = await enforceLevelOnlyRbac(request, 'create', 'mcp', body.name ?? 'new-mcp');
+  if (denied) return denied;
 
   const { name, url, transport, type, timeout, headers, description } = body;
 

--- a/src/app/api/agentteams/projects/[id]/pause/route.ts
+++ b/src/app/api/agentteams/projects/[id]/pause/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,6 +21,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
+
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'project', id);
+  if (denied) return denied;
 
   const search = request.nextUrl.searchParams;
   const forwarded = new URLSearchParams();

--- a/src/app/api/agentteams/projects/[id]/replan/route.ts
+++ b/src/app/api/agentteams/projects/[id]/replan/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,6 +22,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
+
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'project', id);
+  if (denied) return denied;
 
   const search = request.nextUrl.searchParams;
   const forwarded = new URLSearchParams();

--- a/src/app/api/agentteams/projects/[id]/resume/route.ts
+++ b/src/app/api/agentteams/projects/[id]/resume/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,6 +20,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
+
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'project', id);
+  if (denied) return denied;
 
   const search = request.nextUrl.searchParams;
   const forwarded = new URLSearchParams();

--- a/src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.ts
+++ b/src/app/api/agentteams/projects/[id]/tasks/[taskId]/cancel/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../../../proxy-helper';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,6 +21,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string; taskId: string }> },
 ) {
   const { id, taskId } = await params;
+
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'project.task', `${id}/${taskId}`);
+  if (denied) return denied;
 
   const search = request.nextUrl.searchParams;
   const forwarded = new URLSearchParams();

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -116,6 +116,14 @@ export async function proxyToAgentTeams(
       (fetchOptions.headers as Record<string, string>)['authorization'] = `Bearer ${authToken}`;
     }
 
+    // Forward the server-resolved identity (set by middleware from the Higress
+    // session) so the controller can attribute write actions to the right user
+    // without trusting browser-supplied headers.
+    for (const name of ['x-agentteams-user', 'x-agentteams-user-level']) {
+      const value = request.headers.get(name);
+      if (value) (fetchOptions.headers as Record<string, string>)[name] = value;
+    }
+
     if (forwardBody && ['POST', 'PUT', 'PATCH'].includes(method)) {
       if (contentType === 'multipart/form-data') {
         // Forward multipart as-is (don't set Content-Type, let fetch handle boundary)

--- a/src/app/api/agentteams/skills/[name]/route.ts
+++ b/src/app/api/agentteams/skills/[name]/route.ts
@@ -6,6 +6,7 @@ import {
   SKILLS_BUCKET,
   SKILLS_METADATA_PREFIX,
 } from '@/lib/skill-center-types';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 async function getSkillMetadata(client: any, skillName: string): Promise<SkillEntry | null> {
   const key = `${SKILLS_METADATA_PREFIX}${skillName}.json`;
@@ -80,6 +81,9 @@ export async function PUT(
     return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
   }
 
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'skill', name);
+  if (denied) return denied;
+
   let body: { description?: string; version?: string };
   try {
     body = await request.json();
@@ -125,7 +129,7 @@ export async function PUT(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ name: string }> }
 ) {
   const { name } = await params;
@@ -137,6 +141,9 @@ export async function DELETE(
   if (!bucket) {
     return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
   }
+
+  const denied = await enforceLevelOnlyRbac(request, 'delete', 'skill', name);
+  if (denied) return denied;
 
   try {
     const client = createMinioClient();

--- a/src/app/api/agentteams/skills/nacos/config/route.ts
+++ b/src/app/api/agentteams/skills/nacos/config/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getNacosConfig, setNacosConfig } from '@/lib/skill-center-config';
 import type { NacosConfig } from '@/lib/skill-center-config';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 function isValidNacosUrl(url: string): boolean {
   return /^nacos:\/\/[a-zA-Z0-9._-]+(:[0-9]+)?\/[a-zA-Z0-9._-]+$/.test(url);
@@ -17,6 +18,8 @@ export async function GET() {
 }
 
 export async function PUT(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'skill.nacos.config', 'config');
+  if (denied) return denied;
   let body: { registryUrl?: string; namespace?: string; alias?: string; protocol?: 'http' | 'https'; apiPrefix?: string; mode?: 'services' | 'skills'; username?: string; password?: string };
   try {
     body = await request.json();

--- a/src/app/api/agentteams/skills/nacos/full-sync/route.ts
+++ b/src/app/api/agentteams/skills/nacos/full-sync/route.ts
@@ -1,10 +1,13 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { nacosSyncEngine } from '@/lib/nacos-sync-engine';
 import { getNacosConfig } from '@/lib/skill-center-config';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST() {
+export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'skill.nacos', 'full-sync');
+  if (denied) return denied;
   try {
     const config = await getNacosConfig();
     if (!config) {

--- a/src/app/api/agentteams/skills/nacos/sync/route.ts
+++ b/src/app/api/agentteams/skills/nacos/sync/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getNacosConfig, setNacosConfig } from '@/lib/skill-center-config';
 import { syncNacosSkills } from '@/lib/skill-center-storage';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
-export async function POST(_request: NextRequest) {
+export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'update', 'skill.nacos', 'sync');
+  if (denied) return denied;
   const config = await getNacosConfig();
   if (!config) {
     return NextResponse.json({ error: 'Nacos 未配置' }, { status: 400 });

--- a/src/app/api/agentteams/skills/route.ts
+++ b/src/app/api/agentteams/skills/route.ts
@@ -15,6 +15,7 @@ import {
   SkillEntry,
   SKILLS_BUCKET,
 } from '@/lib/skill-center-types';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   const bucket = getMinioBucket();
@@ -78,6 +79,9 @@ export async function POST(request: NextRequest) {
   if (!bucket) {
     return NextResponse.json({ error: 'MinIO 未配置' }, { status: 503 });
   }
+
+  const denied = await enforceLevelOnlyRbac(request, 'create', 'skill', 'upload');
+  if (denied) return denied;
 
   const contentType = request.headers.get('content-type') || '';
   if (!contentType.includes('multipart/form-data')) {

--- a/src/app/api/agentteams/storage/buckets/[bucket]/bulk-delete/route.ts
+++ b/src/app/api/agentteams/storage/buckets/[bucket]/bulk-delete/route.ts
@@ -1,6 +1,7 @@
 // POST /api/agentteams/storage/buckets/[bucket]/bulk-delete — Bulk delete objects
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function POST(
   request: NextRequest,
@@ -8,6 +9,8 @@ export async function POST(
 ) {
   const { bucket } = await params;
   const bucketName = decodeURIComponent(bucket);
+  const denied = await enforceLevelOnlyRbac(request, 'delete', 'storage.bucket', bucketName);
+  if (denied) return denied;
 
   try {
     const body = await request.json();

--- a/src/app/api/agentteams/storage/buckets/[bucket]/objects/[...key]/route.ts
+++ b/src/app/api/agentteams/storage/buckets/[bucket]/objects/[...key]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function DELETE(
   request: NextRequest,
@@ -7,10 +8,13 @@ export async function DELETE(
 ) {
   const { bucket, key } = await params;
   const objectKey = decodeURIComponent(key.join('/'));
+  const bucketName = decodeURIComponent(bucket);
+  const denied = await enforceLevelOnlyRbac(request, 'delete', 'storage.object', `${bucketName}/${objectKey}`);
+  if (denied) return denied;
 
   try {
     const client = createMinioClient();
-    await client.removeObject(decodeURIComponent(bucket), objectKey);
+    await client.removeObject(bucketName, objectKey);
     return NextResponse.json({ success: true });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown storage error';

--- a/src/app/api/agentteams/storage/buckets/[bucket]/route.ts
+++ b/src/app/api/agentteams/storage/buckets/[bucket]/route.ts
@@ -1,15 +1,18 @@
 // DELETE /api/agentteams/storage/buckets/[bucket] — Delete a bucket
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ bucket: string }> }
 ) {
   const { bucket } = await params;
+  const bucketName = decodeURIComponent(bucket);
+  const denied = await enforceLevelOnlyRbac(request, 'delete', 'storage.bucket', bucketName);
+  if (denied) return denied;
   try {
     const client = createMinioClient();
-    const bucketName = decodeURIComponent(bucket);
 
     const exists = await client.bucketExists(bucketName);
     if (!exists) {

--- a/src/app/api/agentteams/storage/buckets/route.ts
+++ b/src/app/api/agentteams/storage/buckets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function GET() {
   try {
@@ -23,9 +24,16 @@ export async function GET() {
 
 // POST — Create a new bucket
 export async function POST(request: NextRequest) {
+  let body: { name?: string; bucket?: string } = {};
   try {
-    const body = await request.json();
-    const bucketName = body.name || body.bucket;
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const bucketName = body.name || body.bucket;
+  const denied = await enforceLevelOnlyRbac(request, 'create', 'storage.bucket', bucketName || 'new-bucket');
+  if (denied) return denied;
+  try {
     if (!bucketName || typeof bucketName !== 'string') {
       return NextResponse.json({ error: 'Bucket name is required' }, { status: 400 });
     }

--- a/src/app/api/agentteams/storage/presign/route.ts
+++ b/src/app/api/agentteams/storage/presign/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 const PRESIGN_EXPIRY_SECONDS = 15 * 60;
 
@@ -26,6 +27,8 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'view', 'storage', 'presign');
+  if (denied) return denied;
   let body: { bucket?: string; key?: string; contentType?: string } = {};
   try {
     body = await request.json();

--- a/src/app/api/agentteams/storage/upload/route.ts
+++ b/src/app/api/agentteams/storage/upload/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Readable } from 'stream';
 import { createMinioClient } from '@/lib/minio-client';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'create', 'storage', 'upload');
+  if (denied) return denied;
   const bucket = request.nextUrl.searchParams.get('bucket') || '';
   const key = request.nextUrl.searchParams.get('key') || '';
   const contentType = request.nextUrl.searchParams.get('contentType') || 'application/octet-stream';

--- a/src/app/api/agentteams/teams/[name]/files/upload/route.ts
+++ b/src/app/api/agentteams/teams/[name]/files/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
 import { isValidNameSegment } from '@/lib/skill-package';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function POST(
   request: NextRequest,
@@ -12,6 +13,9 @@ export async function POST(
   if (!isValidNameSegment(name)) {
     return NextResponse.json({ error: '非法 Team 名' }, { status: 400 });
   }
+
+  const denied = await enforceServerSideRbac(request, 'update', 'team', name);
+  if (denied) return denied;
 
   const bucket = getMinioBucket();
   if (!bucket) {

--- a/src/app/api/agentteams/teams/[name]/route.ts
+++ b/src/app/api/agentteams/teams/[name]/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../proxy-helper';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'update', 'team', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/teams/${encodeURIComponent(name)}`);
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'delete', 'team', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/teams/${encodeURIComponent(name)}`, { forwardBody: false, method: 'DELETE' });
 }

--- a/src/app/api/agentteams/teams/route.ts
+++ b/src/app/api/agentteams/teams/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../proxy-helper';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/teams', { forwardBody: false });
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceServerSideRbac(request, 'create', 'team', '*');
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/teams');
 }

--- a/src/app/api/agentteams/wen-tian/logs/route.ts
+++ b/src/app/api/agentteams/wen-tian/logs/route.ts
@@ -20,6 +20,7 @@
 //   error     { error }
 
 import { NextRequest } from 'next/server';
+import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 import { redactPii } from '../../debug-log/redact';
 import {
   DockerContext,
@@ -230,6 +231,8 @@ function buildPrompt(args: {
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceLevelOnlyRbac(request, 'view', 'wen-tian', 'logs');
+  if (denied) return denied;
   let rawBody: unknown;
   try { rawBody = await request.json(); } catch {
     return Response.json({ error: 'Invalid JSON body' }, { status: 400 });

--- a/src/app/api/agentteams/workers/[name]/ensure-ready/route.ts
+++ b/src/app/api/agentteams/workers/[name]/ensure-ready/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
 import { rejectUnavailableExternalWorkerAlias } from '../../../external-model-binding-guard';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'ensure-ready', 'worker', name);
+  if (denied) return denied;
   const controllerUrl = getControllerUrl(request);
   const rejected = await rejectUnavailableExternalWorkerAlias(request, controllerUrl, name);
   if (rejected) return rejected;

--- a/src/app/api/agentteams/workers/[name]/files/upload/route.ts
+++ b/src/app/api/agentteams/workers/[name]/files/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
 import { isValidNameSegment } from '@/lib/skill-package';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 async function hasPrefix(client: ReturnType<typeof createMinioClient>, bucket: string, prefix: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -17,6 +18,9 @@ export async function POST(
 ) {
   const { name } = await params;
   const subdir = request.nextUrl.searchParams.get('prefix') ?? '';
+
+  const denied = await enforceServerSideRbac(request, 'update', 'worker', name);
+  if (denied) return denied;
 
   if (!isValidNameSegment(name)) {
     return NextResponse.json({ error: '非法 Worker 名' }, { status: 400 });

--- a/src/app/api/agentteams/workers/[name]/restart/route.ts
+++ b/src/app/api/agentteams/workers/[name]/restart/route.ts
@@ -1,15 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isValidNameSegment } from '@/lib/skill-package';
 import { restartWorkerForSkillReload } from '@/lib/worker-restart';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ name: string }> },
 ) {
   const { name } = await params;
   if (!isValidNameSegment(name)) {
     return NextResponse.json({ error: '非法 Worker 名' }, { status: 400 });
   }
+
+  const denied = await enforceServerSideRbac(request, 'wake', 'worker', name);
+  if (denied) return denied;
 
   const restart = await restartWorkerForSkillReload(name);
   if (!restart.ok) {

--- a/src/app/api/agentteams/workers/[name]/route.test.ts
+++ b/src/app/api/agentteams/workers/[name]/route.test.ts
@@ -120,3 +120,51 @@ describe('DELETE /api/agentteams/workers/{name} (smoke)', () => {
     expect(received[0].url).toBe('/api/v1/workers/worker-1');
   });
 });
+
+describe('RBAC enforcement on worker write routes', () => {
+  function makeRequestWithLevel(name: string, level: number) {
+    const url = new URL(`http://localhost/api/agentteams/workers/worker-1`);
+    url.searchParams.set('controllerUrl', controllerUrl);
+    const headers: Record<string, string> = {
+      'x-agentteams-user': name,
+      'x-agentteams-user-level': String(level),
+    };
+    return new NextRequest(url, { method: 'DELETE', headers });
+  }
+
+  it('denies observer DELETE on a worker (403)', async () => {
+    received.length = 0;
+    const res = await DELETE(makeRequestWithLevel('observer', 1), {
+      params: Promise.resolve({ name: 'worker-1' }),
+    });
+    expect(res.status).toBe(403);
+    expect(received).toHaveLength(0);
+  });
+
+  it('denies observer PUT on a worker (403)', async () => {
+    received.length = 0;
+    const url = new URL(`http://localhost/api/agentteams/workers/worker-1`);
+    url.searchParams.set('controllerUrl', controllerUrl);
+    const req = new NextRequest(url, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'x-agentteams-user': 'observer',
+        'x-agentteams-user-level': '1',
+      },
+      body: JSON.stringify({ spec: { skills: [] } }),
+    });
+    const res = await PUT(req, { params: Promise.resolve({ name: 'worker-1' }) });
+    expect(res.status).toBe(403);
+    expect(received).toHaveLength(0);
+  });
+
+  it('allows admin DELETE on a worker', async () => {
+    received.length = 0;
+    const res = await DELETE(makeRequestWithLevel('admin', 3), {
+      params: Promise.resolve({ name: 'worker-1' }),
+    });
+    expect(res.status).toBe(200);
+    expect(received[0].method).toBe('DELETE');
+  });
+});

--- a/src/app/api/agentteams/workers/[name]/route.ts
+++ b/src/app/api/agentteams/workers/[name]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../proxy-helper';
 import { getRequestModelAlias, rejectExternalModelProvider, rejectUnavailableExternalModelAlias } from '../../external-model-binding-guard';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 // GET /api/agentteams/workers/{name}
 //
@@ -21,6 +22,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'update', 'worker', name);
+  if (denied) return denied;
   const providerRejected = await rejectExternalModelProvider(request);
   if (providerRejected) return providerRejected;
   const rejected = await rejectUnavailableExternalModelAlias(request, await getRequestModelAlias(request));
@@ -30,5 +33,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'delete', 'worker', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/workers/${encodeURIComponent(name)}`, { forwardBody: false, method: 'DELETE' });
 }

--- a/src/app/api/agentteams/workers/[name]/skills/route.ts
+++ b/src/app/api/agentteams/workers/[name]/skills/route.ts
@@ -8,6 +8,7 @@ import {
   isValidNameSegment,
 } from '@/lib/skill-package';
 import { restartWorkerForSkillReload } from '@/lib/worker-restart';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 const SYNC_FAILED_NOTE = '技能已上传，Worker 最长约 5 分钟内自动发现';
 
@@ -74,6 +75,9 @@ export async function POST(
   if (!isValidNameSegment(name)) {
     return NextResponse.json({ error: '非法 Worker 名' }, { status: 400 });
   }
+
+  const denied = await enforceServerSideRbac(request, 'update', 'worker', name);
+  if (denied) return denied;
 
   const contentType = request.headers.get('content-type') || '';
   if (!contentType.includes('multipart/form-data')) {

--- a/src/app/api/agentteams/workers/[name]/sleep/route.ts
+++ b/src/app/api/agentteams/workers/[name]/sleep/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'sleep', 'worker', name);
+  if (denied) return denied;
   return proxyToAgentTeams(request, getControllerUrl(request), `/api/v1/workers/${encodeURIComponent(name)}/sleep`, { forwardBody: false, method: 'POST' });
 }

--- a/src/app/api/agentteams/workers/[name]/wake/route.ts
+++ b/src/app/api/agentteams/workers/[name]/wake/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../../../proxy-helper';
 import { rejectUnavailableExternalWorkerAlias } from '../../../external-model-binding-guard';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;
+  const denied = await enforceServerSideRbac(request, 'wake', 'worker', name);
+  if (denied) return denied;
   const controllerUrl = getControllerUrl(request);
   const rejected = await rejectUnavailableExternalWorkerAlias(request, controllerUrl, name);
   if (rejected) return rejected;

--- a/src/app/api/agentteams/workers/route.ts
+++ b/src/app/api/agentteams/workers/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from '../proxy-helper';
 import { getRequestModelAlias, rejectExternalModelProvider, rejectUnavailableExternalModelAlias } from '../external-model-binding-guard';
+import { enforceServerSideRbac } from '@/lib/server-auth';
 
 export async function GET(request: NextRequest) {
   return proxyToAgentTeams(request, getControllerUrl(request), '/api/v1/workers', { forwardBody: false });
 }
 
 export async function POST(request: NextRequest) {
+  const denied = await enforceServerSideRbac(request, 'create', 'worker', '*');
+  if (denied) return denied;
   const providerRejected = await rejectExternalModelProvider(request);
   if (providerRejected) return providerRejected;
   const rejected = await rejectUnavailableExternalModelAlias(request, await getRequestModelAlias(request));

--- a/src/app/api/dashboard/plugins/[id]/route.ts
+++ b/src/app/api/dashboard/plugins/[id]/route.ts
@@ -12,8 +12,8 @@ export const dynamic = 'force-dynamic';
  * The dashboard plugin registry entry is dropped client-side on uninstall.
  */
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const authorized = await validateHigressSession(request);
-  if (!authorized) {
+  const { valid } = await validateHigressSession(request);
+  if (!valid) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/dashboard/plugins/route.test.ts
+++ b/src/app/api/dashboard/plugins/route.test.ts
@@ -65,20 +65,20 @@ describe('POST /api/dashboard/plugins', () => {
   });
 
   it('rejects unauthenticated uploads with 401', async () => {
-    authMock.validateHigressSession.mockResolvedValue(false);
+    authMock.validateHigressSession.mockResolvedValue({ valid: false, user: null });
     const res = await POST(postRequest());
     expect(res.status).toBe(401);
     expect(packageMock.installPluginPackage).not.toHaveBeenCalled();
   });
 
   it('rejects non-multipart requests', async () => {
-    authMock.validateHigressSession.mockResolvedValue(true);
+    authMock.validateHigressSession.mockResolvedValue({ valid: true, user: { name: 'admin', level: 3 } });
     const res = await POST(postRequest());
     expect(res.status).toBe(415);
   });
 
   it('installs a valid zip package and returns the manifest URL', async () => {
-    authMock.validateHigressSession.mockResolvedValue(true);
+    authMock.validateHigressSession.mockResolvedValue({ valid: true, user: { name: 'admin', level: 3 } });
     packageMock.installPluginPackage.mockResolvedValue({
       id: 'alpha',
       manifestUrl: '/plugins/alpha/plugin.json',
@@ -92,7 +92,7 @@ describe('POST /api/dashboard/plugins', () => {
   });
 
   it('maps manifest validation errors to a 400 with a readable message', async () => {
-    authMock.validateHigressSession.mockResolvedValue(true);
+    authMock.validateHigressSession.mockResolvedValue({ valid: true, user: { name: 'admin', level: 3 } });
     packageMock.installPluginPackage.mockRejectedValue(new PluginManifestError('未找到 plugin.json'));
     const form = new FormData();
     form.append('file', new File(['zip-bytes'], 'bad.zip', { type: 'application/zip' }));
@@ -102,7 +102,7 @@ describe('POST /api/dashboard/plugins', () => {
   });
 
   it('rejects an empty file', async () => {
-    authMock.validateHigressSession.mockResolvedValue(true);
+    authMock.validateHigressSession.mockResolvedValue({ valid: true, user: { name: 'admin', level: 3 } });
     const form = new FormData();
     form.append('file', new File([], 'empty.zip', { type: 'application/zip' }));
     const res = await POST(postRequest({ body: form }));

--- a/src/app/api/dashboard/plugins/route.ts
+++ b/src/app/api/dashboard/plugins/route.ts
@@ -54,8 +54,8 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   // Plugin packages become executable frontend code for every dashboard user.
   // Require the same Higress Console session gate as /api/agentteams/* writes.
-  const authorized = await validateHigressSession(request);
-  if (!authorized) {
+  const { valid } = await validateHigressSession(request);
+  if (!valid) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/higress/access.test.ts
+++ b/src/app/api/higress/access.test.ts
@@ -34,7 +34,7 @@ describe('Higress Console write access', () => {
 
   it('rejects writes without a valid Console session', async () => {
     mockGetHigressConsoleURL.mockReturnValue('https://console.example.test');
-    mockValidateHigressSession.mockResolvedValue(false);
+    mockValidateHigressSession.mockResolvedValue({ valid: false, user: null });
 
     const result = await requireHigressConsoleWriteAccess(
       new NextRequest('http://dashboard.test/api/higress/ai-providers', { method: 'POST' })
@@ -45,7 +45,7 @@ describe('Higress Console write access', () => {
 
   it('allows writes with valid deployment configuration and session', async () => {
     mockGetHigressConsoleURL.mockReturnValue('https://console.example.test');
-    mockValidateHigressSession.mockResolvedValue(true);
+    mockValidateHigressSession.mockResolvedValue({ valid: true, user: { name: 'admin', level: 3 } });
 
     const result = await requireHigressConsoleWriteAccess(
       new NextRequest('http://dashboard.test/api/higress/ai-providers', { method: 'POST' })

--- a/src/app/api/higress/access.ts
+++ b/src/app/api/higress/access.ts
@@ -10,7 +10,8 @@ export async function requireHigressConsoleAccess(request: NextRequest): Promise
     return NextResponse.json({ error: message }, { status: 503 });
   }
 
-  if (!(await validateHigressSession(request))) {
+  const { valid } = await validateHigressSession(request);
+  if (!valid) {
     return NextResponse.json({ error: 'A valid Higress Console session is required' }, { status: 401 });
   }
   return null;

--- a/src/components/dashboard/agent-teams-dashboard.tsx
+++ b/src/components/dashboard/agent-teams-dashboard.tsx
@@ -60,6 +60,7 @@ const ChatSection = lazy(() => import('./sections/chat/ChatSection').then(m => (
 const DocsSection = lazy(() => import('./sections/docs-section').then(m => ({ default: m.DocsSection })));
 const TasksSection = lazy(() => import('./sections/tasks-section').then(m => ({ default: m.TasksSection })));
 const ProjectsSection = lazy(() => import('./sections/projects-section').then(m => ({ default: m.ProjectsSection })));
+const AuditSection = lazy(() => import('./sections/audit-section').then(m => ({ default: m.AuditSection })));
 
 export const sectionMap: Record<string, React.ComponentType> = {
   overview: OverviewSection,
@@ -71,6 +72,7 @@ export const sectionMap: Record<string, React.ComponentType> = {
   managers: ManagersSection,
   humans: HumansSection,
   models: ModelsSection,
+  audit: AuditSection,
   chat: ChatSection,
   docs: DocsSection,
 };

--- a/src/components/dashboard/nav-items.test.ts
+++ b/src/components/dashboard/nav-items.test.ts
@@ -16,6 +16,7 @@ describe('Navigation with groups', () => {
       'humans',
       'skills',
       'models',
+      'audit',
       'docs',
     ]);
     expect(navItems.every((item) => 'group' in item)).toBe(true);
@@ -37,6 +38,7 @@ describe('Navigation with groups', () => {
     expect(groupMap.get('humans')).toBe('runtime');
     expect(groupMap.get('skills')).toBe('resource');
     expect(groupMap.get('models')).toBe('resource');
+    expect(groupMap.get('audit')).toBe('resource');
     expect(groupMap.get('docs')).toBe('footer');
   });
 

--- a/src/components/dashboard/nav-items.ts
+++ b/src/components/dashboard/nav-items.ts
@@ -10,6 +10,7 @@ import {
   Sparkles,
   ListTodo,
   GitBranch,
+  ScrollText,
   type LucideIcon,
 } from 'lucide-react';
 import { useAgentTeamsStore } from '@/lib/agentteams-store';
@@ -46,6 +47,7 @@ export const navItems: NavItem[] = [
   // 资源中心分组
   { id: 'skills', label: '市场', icon: Sparkles, group: 'resource' },
   { id: 'models', label: '模型', icon: Brain, group: 'resource' },
+  { id: 'audit', label: '审计', icon: ScrollText, group: 'resource' },
   { id: 'docs', label: '文档', icon: BookOpen, group: 'footer' },
 ];
 

--- a/src/components/dashboard/sections/audit-section.test.tsx
+++ b/src/components/dashboard/sections/audit-section.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/hooks/use-audit-events', () => ({
+  useAuditEvents: vi.fn(),
+}));
+
+import { useAuditEvents, type AuditEventsResponse } from '@/hooks/use-audit-events';
+import { AuditSection } from './audit-section';
+
+const mockedUseAuditEvents = vi.mocked(useAuditEvents);
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AuditSection', () => {
+  it('renders an inline admin-only notice when the API returns 403', async () => {
+    mockedUseAuditEvents.mockReturnValue({
+      data: { success: false, error: '需要管理员权限' },
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useAuditEvents>);
+    render(<AuditSection />, { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText('需要管理员权限')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/权限等级 ≥ 3/)).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the API returns no events', async () => {
+    mockedUseAuditEvents.mockReturnValue({
+      data: { success: true, events: [] } as AuditEventsResponse,
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useAuditEvents>);
+    render(<AuditSection />, { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText('暂无审计事件')).toBeInTheDocument();
+    });
+  });
+
+  it('renders audit events with actor, entity, action and severity', async () => {
+    mockedUseAuditEvents.mockReturnValue({
+      data: {
+        success: true,
+        events: [
+          {
+            id: 'audit-1',
+            timestamp: Date.UTC(2026, 7, 25, 10, 0, 0),
+            actor: 'alice',
+            actor_level: 3,
+            entity_type: 'worker',
+            entity_name: 'w-1',
+            action: 'create',
+            severity: 'info',
+            source_ip: '10.0.0.1',
+          },
+          {
+            id: 'audit-2',
+            timestamp: Date.UTC(2026, 7, 25, 11, 0, 0),
+            actor: 'observer',
+            actor_level: 1,
+            entity_type: 'system',
+            entity_name: 'audit-target',
+            action: 'rbac.deny.delete',
+            details: '权限等级 1 不允许 "delete" worker 操作',
+            severity: 'warning',
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useAuditEvents>);
+    render(<AuditSection />, { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument();
+    });
+    expect(screen.getByText('拒绝：delete')).toBeInTheDocument();
+    expect(screen.getByText('L3')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+    // Entity badges render the raw type string; both rows should be present.
+    expect(screen.getAllByText('worker').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('system').length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/dashboard/sections/audit-section.tsx
+++ b/src/components/dashboard/sections/audit-section.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Filter,
+  RefreshCw,
+  AlertTriangle,
+  ShieldAlert,
+  ShieldCheck,
+  type LucideIcon,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { SectionHeader } from '@/components/dashboard/section-header';
+import { useAuditEvents, type AuditEvent, type AuditQuery } from '@/hooks/use-audit-events';
+
+type EntityFilter = AuditEvent['entity_type'] | 'all';
+
+const ENTITY_OPTIONS: { id: EntityFilter; label: string }[] = [
+  { id: 'all', label: '全部' },
+  { id: 'worker', label: 'Worker' },
+  { id: 'team', label: '团队' },
+  { id: 'manager', label: 'Manager' },
+  { id: 'human', label: 'Human' },
+  { id: 'system', label: '系统' },
+];
+
+const SEVERITY_META: Record<AuditEvent['severity'], { label: string; icon: LucideIcon; className: string }> = {
+  info: {
+    label: '信息',
+    icon: ShieldCheck,
+    className: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  },
+  warning: {
+    label: '警告',
+    icon: AlertTriangle,
+    className: 'bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  },
+  error: {
+    label: '错误',
+    icon: ShieldAlert,
+    className: 'bg-red-500/10 text-red-700 dark:text-red-300',
+  },
+};
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  return `${d.toLocaleDateString('zh-CN')} ${d.toLocaleTimeString('zh-CN')}`;
+}
+
+function actionLabel(action: string): string {
+  if (action.startsWith('rbac.deny.')) return `拒绝：${action.slice('rbac.deny.'.length)}`;
+  if (action.endsWith('-failed')) return `${action.replace(/-failed$/, '')} 失败`;
+  return action;
+}
+
+export function AuditSection() {
+  const [entityType, setEntityType] = useState<EntityFilter>('all');
+  const query: AuditQuery = useMemo(() => {
+    const out: AuditQuery = { limit: 200 };
+    if (entityType !== 'all') out.entityType = entityType;
+    return out;
+  }, [entityType]);
+
+  const { data, isLoading, isFetching, refetch } = useAuditEvents(query);
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader
+        title="审计日志"
+        description="服务端记录的治理事件（mutation、RBAC 拒绝、登录等）。10 MB 自动 rotate，保留 30 份归档。"
+      />
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0 pb-3">
+          <CardTitle className="text-base">最近事件</CardTitle>
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-muted-foreground" aria-hidden />
+            <div className="flex flex-wrap gap-1">
+              {ENTITY_OPTIONS.map((opt) => (
+                <Button
+                  key={opt.id}
+                  type="button"
+                  size="sm"
+                  variant={entityType === opt.id ? 'default' : 'outline'}
+                  onClick={() => setEntityType(opt.id)}
+                  aria-pressed={entityType === opt.id}
+                >
+                  {opt.label}
+                </Button>
+              ))}
+            </div>
+            <Button
+              type="button"
+              size="icon"
+              variant="outline"
+              onClick={() => refetch()}
+              aria-label="刷新"
+              disabled={isFetching}
+            >
+              <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} aria-hidden />
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {data && data.success === false ? (
+            <div className="flex items-start gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden />
+              <div>
+                  <p className="font-medium text-amber-700 dark:text-amber-300">{data.error}</p>
+                  <p className="text-xs text-muted-foreground">该视图仅对权限等级 ≥ 3 的管理员开放</p>
+                </div>
+            </div>
+          ) : isLoading ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">加载中...</p>
+          ) : !data?.events?.length ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">暂无审计事件</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-2 py-2">时间</th>
+                    <th className="px-2 py-2">操作者</th>
+                    <th className="px-2 py-2">实体</th>
+                    <th className="px-2 py-2">动作</th>
+                    <th className="px-2 py-2">严重度</th>
+                    <th className="px-2 py-2">详情</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.events.map((event) => {
+                    const meta = SEVERITY_META[event.severity];
+                    const Icon = meta.icon;
+                    return (
+                      <tr key={event.id} className="border-b last:border-0 align-top">
+                        <td className="px-2 py-2 font-mono text-xs whitespace-nowrap">{formatTimestamp(event.timestamp)}</td>
+                        <td className="px-2 py-2">
+                          <span className="font-medium">{event.actor ?? '系统'}</span>
+                          {event.actor_level !== undefined ? (
+                            <span className="ml-1 text-xs text-muted-foreground">L{event.actor_level}</span>
+                          ) : null}
+                          {event.source_ip ? (
+                            <div className="text-xs text-muted-foreground">{event.source_ip}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-2 py-2">
+                          <Badge variant="outline" className="font-mono text-xs">
+                            {event.entity_type}
+                          </Badge>
+                          <div className="text-xs text-muted-foreground">{event.entity_name}</div>
+                        </td>
+                        <td className="px-2 py-2 font-mono text-xs">{actionLabel(event.action)}</td>
+                        <td className="px-2 py-2">
+                          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}>
+                            <Icon className="h-3 w-3" aria-hidden />
+                            {meta.label}
+                          </span>
+                        </td>
+                        <td className="px-2 py-2 max-w-md break-words text-xs text-muted-foreground">
+                          {event.details ?? '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/dashboard/sections/chat/ChatRoom.tsx
+++ b/src/components/dashboard/sections/chat/ChatRoom.tsx
@@ -5,6 +5,10 @@ import { useChatStore } from './ChatStore';
 import { MessageList, type LocalOutboundMessage, type ChatSystemNotice } from './structures/MessageList';
 import { ThreadPanel } from './structures/ThreadPanel';
 import type { ScrollPanelHandle } from './structures/ScrollPanel';
+import { usePersistedDraft } from './hooks/usePersistedDraft';
+import { useFileUpload } from './hooks/useFileUpload';
+import { useFileDropZone } from './hooks/useFileDropZone';
+import { DragDropOverlay } from './components/DragDropOverlay';
 import { useMatrixStore } from '@/lib/matrix-store';
 import {
   useMatrixRoomMessages,
@@ -25,7 +29,7 @@ import { MatrixRequestError, getRateLimitRetryDelay } from '@/lib/matrix-api';
 import { useMatrixReadReceipts, useRoomMetaStore } from '@/hooks/use-matrix';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Users, PanelRightClose, ArrowDown, FolderTree, UserCheck, Upload } from 'lucide-react';
+import { Users, PanelRightClose, ArrowDown, FolderTree, UserCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ChatComposer, type MentionEntry } from './chat-composer';
 import { parseOutboundCommand } from './composer-commands';
@@ -73,15 +77,12 @@ export function ChatRoom({
   const [replyTo, setReplyTo] = useState<DisplayMessage | null>(null);
   const [activeThread, setActiveThread] = useState<DisplayMessage | null>(null);
   const [mentions, setMentions] = useState<MentionEntry[]>([]);
-  const [inputValue, setInputValue] = useState('');
+  const { value: inputValue, setValue: setInputValue, setValueLocal: setInputValueLocal, clear: clearDraft } = usePersistedDraft(roomId);
   // Composer edit session (ArrowUp on empty input → edit my latest message)
   const [editSession, setEditSession] = useState<{ eventId: string; initialText: string } | null>(null);
   const [localMessages, setLocalMessages] = useState<LocalOutboundMessage[]>([]);
   const [actionError, setActionError] = useState<string | null>(null);
   const [systemNotices, setSystemNotices] = useState<ChatSystemNotice[]>([]);
-  const [isUploading, setIsUploading] = useState(false);
-  // Drag-and-drop file upload overlay
-  const [dragActive, setDragActive] = useState(false);
   const [showWorkers, setShowWorkers] = useState(false);
   // Worker rooms default to the owning worker so the files panel opens on
   // "the current worker's" directory instead of an empty picker.
@@ -90,32 +91,6 @@ export function ChatRoom({
   const [isResizingWorkerPane, setIsResizingWorkerPane] = useState(false);
   const noticeCounterRef = useRef(0);
   const chatLayoutRef = useRef<HTMLDivElement>(null);
-  const dragCounterRef = useRef(0);
-
-  // ---- Per-room draft persistence (element-web behavior) ----
-  // The composer state survives room switches (ChatRoom is not remounted), so
-  // without drafts a half-typed message would follow the user into the next
-  // room and could be sent to the wrong place. Save on input, restore on switch.
-  const draftKey = `agentteams-chat-draft:${roomId}`;
-  // Restore the draft during render when the room changes (same adjust-state-
-  // during-render pattern as the dashboard's poll handlers).
-  const [prevRoomId, setPrevRoomId] = useState(roomId);
-  if (prevRoomId !== roomId) {
-    setPrevRoomId(roomId);
-    let draft = '';
-    try {
-      draft = localStorage.getItem(`agentteams-chat-draft:${roomId}`) ?? '';
-    } catch { /* storage unavailable */ }
-    setInputValue(draft);
-    setEditSession(null);
-  }
-
-  const persistDraft = useCallback((text: string) => {
-    try {
-      if (text.trim()) localStorage.setItem(draftKey, text);
-      else localStorage.removeItem(draftKey);
-    } catch { /* storage unavailable */ }
-  }, [draftKey]);
 
   const { userId, isLoggedIn } = useMatrixStore();
   const sendMutation = useMatrixSendMessage();
@@ -289,6 +264,10 @@ export function ChatRoom({
     setLocalMessages(prev => prev.filter(m => m.clientId !== clientId));
   }, []);
 
+  const pushLocal = useCallback((message: LocalOutboundMessage) => {
+    setLocalMessages(prev => [...prev, message]);
+  }, []);
+
   const patchLocal = useCallback((clientId: string, patch: Partial<LocalOutboundMessage>) => {
     setLocalMessages(prev => prev.map(m => m.clientId === clientId ? { ...m, ...patch } : m));
   }, []);
@@ -394,49 +373,18 @@ export function ChatRoom({
 
   // Upload a file to the Matrix homeserver, then send it as an m.image /
   // m.file message so it appears in the room timeline like any other message.
-  const handleFileUpload = useCallback(async (file: File) => {
-    if (!roomId || !isLoggedIn || !userId) return;
-    setIsUploading(true);
-    const cid = `local-${Date.now()}-${++localCounterRef.current}`;
-    const isImage = file.type.startsWith('image/');
-    setLocalMessages(prev => [...prev, {
-      clientId: cid,
-      sender: userId,
-      senderShort: userId.startsWith('@') ? userId.split(':')[0].slice(1) : userId,
-      content: file.name,
-      timestamp: Date.now(),
-      status: 'sending' as const,
-    }]);
-    try {
-      const { content_uri } = await uploadMutation.mutateAsync({ roomId, file });
-      const extra: Record<string, unknown> = {
-        msgtype: isImage ? 'm.image' : 'm.file',
-        url: content_uri,
-        info: {
-          mimetype: file.type || 'application/octet-stream',
-          size: file.size,
-        },
-      };
-      sendMutation.mutate(
-        { roomId, body: file.name, extra },
-        {
-          onSuccess: () => removeLocal(cid),
-          onError: (err) => {
-            patchLocal(cid, { status: 'error', error: err.message });
-            pushSystemNotice(buildSystemNoticeFromError(err, { content: file.name }, ++noticeCounterRef.current));
-          },
-        }
-      );
-    } catch (err) {
-      patchLocal(cid, {
-        status: 'error',
-        error: err instanceof Error ? err.message : '上传失败',
-      });
-      pushSystemNotice(buildSystemNoticeFromError(err, { content: file.name }, ++noticeCounterRef.current));
-    } finally {
-      setIsUploading(false);
-    }
-  }, [roomId, isLoggedIn, userId, uploadMutation, sendMutation, removeLocal, patchLocal, pushSystemNotice]);
+  const { isUploading, upload: handleFileUpload } = useFileUpload({
+    roomId,
+    isLoggedIn,
+    userId,
+    upload: (input) => uploadMutation.mutateAsync(input),
+    send: (args, callbacks) => sendMutation.mutate(args, callbacks),
+    pushLocal,
+    patchLocal,
+    removeLocal,
+    pushSystemNotice,
+    buildSystemNotice: buildSystemNoticeFromError,
+  });
 
   const handleSend = useCallback((content: string, _options?: { html?: boolean }, mentions?: MentionEntry[]) => {
     let trimmed = content.trim();
@@ -448,7 +396,7 @@ export function ChatRoom({
 
     if (onSendMessage) {
       onSendMessage(trimmed, _options, mentions);
-      persistDraft('');
+      clearDraft();
       return;
     }
     if (!roomId || !isLoggedIn) return;
@@ -457,21 +405,19 @@ export function ChatRoom({
     // Sending a message immediately ends the typing state, otherwise other
     // members keep seeing "typing" for up to the full timeout window.
     stopTyping();
-    setInputValue('');
+    clearDraft();
     setMentions([]);
     setReplyTo(null);
-    persistDraft('');
-  }, [onSendMessage, roomId, isLoggedIn, sendOutbound, stopTyping, replyTo, persistDraft]);
+  }, [onSendMessage, roomId, isLoggedIn, sendOutbound, stopTyping, replyTo, clearDraft]);
 
   const handleInputChange = useCallback((content: string) => {
     setInputValue(content);
-    persistDraft(content);
     if (content.trim()) {
       notifyTyping();
     } else {
       stopTyping();
     }
-  }, [notifyTyping, stopTyping, persistDraft]);
+  }, [notifyTyping, stopTyping, setInputValue]);
 
   // ---- Composer edit session (ArrowUp flow) ----
   const handleRequestEditLast = useCallback(() => {
@@ -485,10 +431,12 @@ export function ChatRoom({
         Date.now() - m.timestamp < EDIT_WINDOW_MS
       ) {
         setEditSession({ eventId: m.eventId, initialText: m.content });
-        setInputValue(m.content);
+        setInputValueLocal(m.content);
         return;
       }
     }
+    // setInputValueLocal is a stable setter returned by the hook.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formattedMessages]);
 
   const handleComposerEditSubmit = useCallback(async (text: string) => {
@@ -503,44 +451,26 @@ export function ChatRoom({
         body: trimmed,
       });
       setEditSession(null);
-      setInputValue('');
-      persistDraft('');
+      clearDraft();
     } catch (err) {
       // Keep the edit session open so the user can retry.
       setActionError(err instanceof Error ? err.message : '编辑消息失败');
     }
-  }, [editSession, editMutation, roomId, persistDraft]);
+  }, [editSession, editMutation, roomId, clearDraft]);
 
   const handleCancelEdit = useCallback(() => {
     setEditSession(null);
-    setInputValue('');
+    setInputValueLocal('');
+    // setInputValueLocal is stable (from the hook).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ---- Drag-and-drop file upload (overlay on the whole room area) ----
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes('Files')) return;
-    e.preventDefault();
-    dragCounterRef.current += 1;
-    setDragActive(true);
-  }, []);
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes('Files')) return;
-    e.preventDefault();
-  }, []);
-  const handleDragLeave = useCallback(() => {
-    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
-    if (dragCounterRef.current === 0) setDragActive(false);
-  }, []);
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes('Files')) return;
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setDragActive(false);
-    const files = Array.from(e.dataTransfer.files);
-    if (files.length > 0) {
+  const { dragActive, dropZoneProps } = useFileDropZone({
+    onFiles: (files) => {
       for (const file of files) handleFileUpload(file);
-    }
-  }, [handleFileUpload]);
+    },
+  });
 
   const handleAutoScrollChange = useCallback((auto: boolean) => {
     setAutoScrollLocal(auto);
@@ -778,21 +708,17 @@ export function ChatRoom({
     <div
       ref={chatLayoutRef}
       className={`flex h-full relative ${isResizingWorkerPane ? 'select-none' : ''} ${className}`}
-      onDragEnter={handleDragEnter}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
+      onDragEnter={dropZoneProps.onDragEnter}
+      onDragOver={dropZoneProps.onDragOver}
+      onDragLeave={dropZoneProps.onDragLeave}
+      onDrop={dropZoneProps.onDrop}
     >
       {/* Drag-and-drop upload overlay */}
-      {dragActive && (
-        <div className="absolute inset-0 z-40 flex items-center justify-center bg-background/80 backdrop-blur-[2px] pointer-events-none">
-          <div className="flex flex-col items-center gap-2 rounded-xl border-2 border-dashed border-emerald-500/60 bg-emerald-500/5 px-10 py-8">
-            <Upload className="w-8 h-8 text-emerald-500" />
-            <p className="text-sm font-medium">松开以上传文件</p>
-            <p className="text-xs text-muted-foreground">支持多文件，发送到 {roomName}</p>
-          </div>
-        </div>
-      )}
+      <DragDropOverlay
+        active={dragActive}
+        label="松开以上传文件"
+        description={`支持多文件，发送到 ${roomName}`}
+      />
       {/* Main chat area */}
       <div className="flex-1 flex flex-col min-w-0 min-h-0">
         {header}

--- a/src/components/dashboard/sections/chat/components/DragDropOverlay.test.tsx
+++ b/src/components/dashboard/sections/chat/components/DragDropOverlay.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { DragDropOverlay } from './DragDropOverlay';
+
+describe('DragDropOverlay', () => {
+  it('renders nothing when inactive', () => {
+    const { container } = render(<DragDropOverlay active={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the overlay with default label when active', () => {
+    render(<DragDropOverlay active />);
+    expect(screen.getByTestId('chat-drop-overlay')).toBeInTheDocument();
+    expect(screen.getByText('拖入文件以上传')).toBeInTheDocument();
+  });
+
+  it('accepts a custom label', () => {
+    render(<DragDropOverlay active label="Drop to upload" />);
+    expect(screen.getByText('Drop to upload')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/sections/chat/components/DragDropOverlay.tsx
+++ b/src/components/dashboard/sections/chat/components/DragDropOverlay.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Upload } from 'lucide-react';
+
+/**
+ * Full-room overlay shown while a file drag is in progress. Purely visual —
+ * the drop logic lives in `useFileDropZone`.
+ */
+export interface DragDropOverlayProps {
+  active: boolean;
+  /** Primary label, e.g. "松开以上传文件". */
+  label?: string;
+  /** Secondary caption, e.g. "支持多文件，发送到 team-alpha". */
+  description?: string;
+}
+
+export function DragDropOverlay({
+  active,
+  label = '拖入文件以上传',
+  description,
+}: DragDropOverlayProps) {
+  if (!active) return null;
+  return (
+    <div
+      data-testid="chat-drop-overlay"
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-primary/10 backdrop-blur-sm"
+    >
+      <div className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-primary/60 bg-background/80 px-8 py-6 text-foreground shadow-lg">
+        <Upload className="h-8 w-8 text-primary" aria-hidden />
+        <span className="text-base font-medium">{label}</span>
+        {description ? (
+          <span className="text-xs text-muted-foreground">{description}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/sections/chat/hooks/useFileDropZone.test.ts
+++ b/src/components/dashboard/sections/chat/hooks/useFileDropZone.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useFileDropZone } from './useFileDropZone';
+
+function makeDragEvent(types: string[], files: File[] = []): React.DragEvent<HTMLElement> {
+  return {
+    dataTransfer: { types, files } as unknown as DataTransfer,
+    preventDefault: vi.fn(),
+  } as unknown as React.DragEvent<HTMLElement>;
+}
+
+describe('useFileDropZone', () => {
+  it('does not activate the overlay for non-file drags', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useFileDropZone({ onFiles }));
+
+    act(() => result.current.dropZoneProps.onDragEnter(makeDragEvent(['text/plain'])));
+    expect(result.current.dragActive).toBe(false);
+  });
+
+  it('activates on the first file drag and clears on the final leave', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useFileDropZone({ onFiles }));
+
+    act(() => result.current.dropZoneProps.onDragEnter(makeDragEvent(['Files'])));
+    expect(result.current.dragActive).toBe(true);
+
+    // Bubbling through children should NOT toggle.
+    act(() => result.current.dropZoneProps.onDragEnter(makeDragEvent(['Files'])));
+    act(() => result.current.dropZoneProps.onDragLeave(makeDragEvent(['Files'])));
+    expect(result.current.dragActive).toBe(true);
+
+    // Final leave flips it off.
+    act(() => result.current.dropZoneProps.onDragLeave(makeDragEvent(['Files'])));
+    expect(result.current.dragActive).toBe(false);
+  });
+
+  it('hands off dropped files and resets state', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useFileDropZone({ onFiles }));
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+
+    act(() => result.current.dropZoneProps.onDragEnter(makeDragEvent(['Files'])));
+    act(() => result.current.dropZoneProps.onDrop(makeDragEvent(['Files'], [file])));
+
+    expect(onFiles).toHaveBeenCalledWith([file]);
+    expect(result.current.dragActive).toBe(false);
+  });
+
+  it('ignores drop events whose payload is empty', () => {
+    const onFiles = vi.fn();
+    const { result } = renderHook(() => useFileDropZone({ onFiles }));
+    act(() => result.current.dropZoneProps.onDrop(makeDragEvent(['Files'], [])));
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dashboard/sections/chat/hooks/useFileDropZone.ts
+++ b/src/components/dashboard/sections/chat/hooks/useFileDropZone.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import type { DragEvent, RefObject } from 'react';
+
+/**
+ * Drop zone for files dragged onto a container element.
+ *
+ * Drag events fire on every child element the cursor passes over, so naive
+ * `onDragEnter`/`onDragLeave` toggles flicker as the cursor crosses the
+ * container's children. The hook tracks an enter/leave counter and only
+ * flips the overlay on the actual outer boundary.
+ *
+ * Non-`Files` drags (text, links, internal DnD) are ignored so the overlay
+ * does not appear for drags the handler cannot service.
+ */
+export interface UseFileDropZoneResult {
+  dragActive: boolean;
+  dropZoneProps: {
+    onDragEnter: (_event: DragEvent<HTMLElement>) => void;
+    onDragOver: (_event: DragEvent<HTMLElement>) => void;
+    onDragLeave: (_event: DragEvent<HTMLElement>) => void;
+    onDrop: (_event: DragEvent<HTMLElement>) => void;
+  };
+  /** Re-bind a container ref at runtime. */
+  containerRef: RefObject<HTMLElement | null>;
+}
+
+export interface UseFileDropZoneInput {
+  onFiles: (_files: File[]) => void;
+}
+
+export function useFileDropZone({ onFiles }: UseFileDropZoneInput): UseFileDropZoneResult {
+  const containerRef = useRef<HTMLElement>(null);
+  const counterRef = useRef(0);
+  const [dragActive, setDragActive] = useState(false);
+
+  const isFileDrag = useCallback((event: DragEvent<HTMLElement>) => {
+    return Array.from(event.dataTransfer.types).includes('Files');
+  }, []);
+
+  const onDragEnter = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      counterRef.current += 1;
+      if (counterRef.current === 1) setDragActive(true);
+    },
+    [isFileDrag],
+  );
+
+  const onDragOver = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+    },
+    [isFileDrag],
+  );
+
+  const onDragLeave = useCallback((_event: DragEvent<HTMLElement>) => {
+    counterRef.current = Math.max(0, counterRef.current - 1);
+    if (counterRef.current === 0) setDragActive(false);
+  }, []);
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      counterRef.current = 0;
+      setDragActive(false);
+      const files = Array.from(event.dataTransfer.files);
+      if (files.length > 0) onFiles(files);
+    },
+    [isFileDrag, onFiles],
+  );
+
+  return {
+    dragActive,
+    containerRef,
+    dropZoneProps: { onDragEnter, onDragOver, onDragLeave, onDrop },
+  };
+}

--- a/src/components/dashboard/sections/chat/hooks/useFileUpload.test.ts
+++ b/src/components/dashboard/sections/chat/hooks/useFileUpload.test.ts
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatSystemNotice } from '../structures/MessageList';
+import { useFileUpload } from './useFileUpload';
+
+function makeHarness() {
+  const pushLocal = vi.fn();
+  const patchLocal = vi.fn();
+  const removeLocal = vi.fn();
+  const pushSystemNotice = vi.fn();
+  const upload = vi.fn(async () => ({ content_uri: 'mxc://example/abc' }));
+  const send = vi.fn();
+  const buildSystemNotice = vi.fn(
+    (err: unknown, payload: { content: string }, counter: number): ChatSystemNotice => ({
+      id: counter,
+      kind: 'error',
+      message: err instanceof Error ? err.message : String(err),
+      createdAt: Date.now(),
+      autoRetry: false,
+      retryPayload: payload,
+    }),
+  );
+
+  const input = {
+    roomId: '!room:example',
+    isLoggedIn: true,
+    userId: '@alice:example',
+    upload,
+    send,
+    pushLocal,
+    patchLocal,
+    removeLocal,
+    pushSystemNotice,
+    buildSystemNotice,
+  };
+  return { input, pushLocal, patchLocal, removeLocal, pushSystemNotice, upload, send, buildSystemNotice };
+}
+
+describe('useFileUpload', () => {
+  it('uploads then sends m.image for image files', async () => {
+    const h = makeHarness();
+    const { result } = renderHook(() => useFileUpload(h.input));
+    const file = new File(['bytes'], 'pic.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.upload(file);
+    });
+
+    expect(h.upload).toHaveBeenCalledWith({ roomId: '!room:example', file });
+    expect(h.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'pic.png',
+        extra: expect.objectContaining({ msgtype: 'm.image', url: 'mxc://example/abc' }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+    expect(h.pushLocal).toHaveBeenCalled();
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it('uploads then sends m.file for non-image files', async () => {
+    const h = makeHarness();
+    const { result } = renderHook(() => useFileUpload(h.input));
+    const file = new File(['bytes'], 'doc.pdf', { type: 'application/pdf' });
+
+    await act(async () => {
+      await result.current.upload(file);
+    });
+
+    const sendArgs = h.send.mock.calls[0][0];
+    expect(sendArgs.extra.msgtype).toBe('m.file');
+  });
+
+  it('calls pushSystemNotice when upload fails', async () => {
+    const h = makeHarness();
+    h.upload.mockRejectedValueOnce(new Error('upload 502'));
+    const { result } = renderHook(() => useFileUpload(h.input));
+
+    await act(async () => {
+      await result.current.upload(new File(['x'], 'foo.txt', { type: 'text/plain' }));
+    });
+
+    expect(h.patchLocal).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ status: 'error' }));
+    expect(h.pushSystemNotice).toHaveBeenCalledTimes(1);
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it('flags an error when send.onError fires', () => {
+    const h = makeHarness();
+    const { result } = renderHook(() => useFileUpload(h.input));
+    const sendCallbacks = vi.fn();
+    h.send.mockImplementation((_args, cbs) => sendCallbacks(cbs));
+
+    return act(async () => {
+      await result.current.upload(new File(['x'], 'a.png', { type: 'image/png' }));
+      const captured = sendCallbacks.mock.calls[0][0];
+      captured.onError(new Error('rate limit'));
+      expect(h.patchLocal).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ status: 'error' }));
+      expect(h.pushSystemNotice).toHaveBeenCalled();
+    });
+  });
+
+  it('does nothing when not logged in', async () => {
+    const h = makeHarness();
+    h.input.isLoggedIn = false;
+    const { result } = renderHook(() => useFileUpload(h.input));
+
+    await act(async () => {
+      await result.current.upload(new File(['x'], 'a.png'));
+    });
+
+    expect(h.upload).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dashboard/sections/chat/hooks/useFileUpload.ts
+++ b/src/components/dashboard/sections/chat/hooks/useFileUpload.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { ChatSystemNotice, LocalOutboundMessage } from '../structures/MessageList';
+
+/**
+ * File upload to the Matrix homeserver, then send it as an `m.image` /
+ * `m.file` message so it appears in the room timeline like any other
+ * message. Extracted from ChatRoom so the upload state machine is unit
+ * testable independently of the surrounding UI.
+ *
+ * The hook owns:
+ *   - `isUploading` flag (rendering the spinner)
+ *   - Optimistic local message lifecycle (sending → sent → error)
+ *   - System notice emission when the upload or send fails
+ *
+ * It delegates the actual transport to the caller-supplied mutations so the
+ * hook stays free of `use-matrix`/`useMatrixStore` imports (easier testing,
+ * no React context fan-out).
+ */
+
+export interface UseFileUploadInput {
+  roomId: string;
+  isLoggedIn: boolean;
+  userId: string | null;
+  /** Async resolver for the upload step — typically `useMatrixUploadMedia`. */
+  upload: (_input: { roomId: string; file: File }) => Promise<{ content_uri: string }>;
+  /** Fires the final send. `onSuccess`/`onError` let the caller mutate local
+   *  message state and propagate errors to the user. */
+  send: (
+    _args: { roomId: string; body: string; extra: Record<string, unknown> },
+    _callbacks: {
+      onSuccess: () => void;
+      onError: (_err: Error) => void;
+    },
+  ) => void;
+  /** Push / patch / remove optimistic local messages. */
+  pushLocal: (_message: LocalOutboundMessage) => void;
+  patchLocal: (_clientId: string, _patch: Partial<LocalOutboundMessage>) => void;
+  removeLocal: (_clientId: string) => void;
+  /** Emit a system notice (e.g. rate limit, network failure). */
+  pushSystemNotice: (_notice: ChatSystemNotice) => void;
+  /** Build a system notice from a thrown error (kept as a callback so the
+   *  hook does not import the builder directly and stays host-agnostic). */
+  buildSystemNotice: (
+    _err: unknown,
+    _payload: {
+      content: string;
+      mentions?: import('../chat-composer').MentionEntry[];
+      replyTo?: import('@/hooks/use-matrix').DisplayMessage | null;
+    },
+    _counter: number,
+  ) => ChatSystemNotice;
+}
+
+export interface UseFileUploadResult {
+  isUploading: boolean;
+  upload: (_file: File) => Promise<void>;
+}
+
+export function useFileUpload(input: UseFileUploadInput): UseFileUploadResult {
+  const [isUploading, setIsUploading] = useState(false);
+  const [noticeCounter, setNoticeCounter] = useState(0);
+
+  const upload = useCallback(
+    async (file: File) => {
+      if (!input.roomId || !input.isLoggedIn || !input.userId) return;
+      setIsUploading(true);
+      const cid = `local-${Date.now()}-${noticeCounter}`;
+      const isImage = file.type.startsWith('image/');
+      input.pushLocal({
+        clientId: cid,
+        sender: input.userId,
+        senderShort: input.userId.startsWith('@')
+          ? input.userId.split(':')[0].slice(1)
+          : input.userId,
+        content: file.name,
+        timestamp: Date.now(),
+        status: 'sending',
+      });
+      try {
+        const { content_uri } = await input.upload({ roomId: input.roomId, file });
+        const extra: Record<string, unknown> = {
+          msgtype: isImage ? 'm.image' : 'm.file',
+          url: content_uri,
+          info: {
+            mimetype: file.type || 'application/octet-stream',
+            size: file.size,
+          },
+        };
+        input.send(
+          { roomId: input.roomId, body: file.name, extra },
+          {
+            onSuccess: () => input.removeLocal(cid),
+            onError: (err) => {
+              input.patchLocal(cid, { status: 'error', error: err.message });
+              const next = noticeCounter + 1;
+              setNoticeCounter(next);
+              input.pushSystemNotice(input.buildSystemNotice(err, { content: file.name }, next));
+            },
+          },
+        );
+      } catch (err) {
+        input.patchLocal(cid, {
+          status: 'error',
+          error: err instanceof Error ? err.message : '上传失败',
+        });
+        const next = noticeCounter + 1;
+        setNoticeCounter(next);
+        input.pushSystemNotice(input.buildSystemNotice(err, { content: file.name }, next));
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [input, noticeCounter],
+  );
+
+  return { isUploading, upload };
+}

--- a/src/components/dashboard/sections/chat/hooks/usePersistedDraft.test.ts
+++ b/src/components/dashboard/sections/chat/hooks/usePersistedDraft.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePersistedDraft } from './usePersistedDraft';
+
+const KEY_PREFIX = 'agentteams-chat-draft:';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('usePersistedDraft', () => {
+  it('starts empty when no draft is stored', () => {
+    const { result } = renderHook(() => usePersistedDraft('room-a'));
+    expect(result.current.value).toBe('');
+  });
+
+  it('restores the draft saved for the matching room', () => {
+    localStorage.setItem(`${KEY_PREFIX}room-a`, 'half-typed message');
+    const { result } = renderHook(() => usePersistedDraft('room-a'));
+    expect(result.current.value).toBe('half-typed message');
+  });
+
+  it('does not persist whitespace-only drafts', () => {
+    const { result } = renderHook(() => usePersistedDraft('room-a'));
+    act(() => result.current.setValue('   '));
+    expect(localStorage.getItem(`${KEY_PREFIX}room-a`)).toBeNull();
+  });
+
+  it('switches drafts when roomId changes', () => {
+    localStorage.setItem(`${KEY_PREFIX}room-a`, 'alpha draft');
+    localStorage.setItem(`${KEY_PREFIX}room-b`, 'beta draft');
+
+    const { result, rerender } = renderHook(({ roomId }) => usePersistedDraft(roomId), {
+      initialProps: { roomId: 'room-a' },
+    });
+    expect(result.current.value).toBe('alpha draft');
+
+    rerender({ roomId: 'room-b' });
+    expect(result.current.value).toBe('beta draft');
+  });
+
+  it('clear() removes the persisted entry and resets the in-memory value', () => {
+    localStorage.setItem(`${KEY_PREFIX}room-a`, 'will be cleared');
+    const { result } = renderHook(() => usePersistedDraft('room-a'));
+    expect(result.current.value).toBe('will be cleared');
+
+    act(() => result.current.clear());
+    expect(result.current.value).toBe('');
+    expect(localStorage.getItem(`${KEY_PREFIX}room-a`)).toBeNull();
+  });
+
+  it('setValueLocal does not write to storage (edit session reuse)', () => {
+    const { result } = renderHook(() => usePersistedDraft('room-a'));
+    act(() => result.current.setValueLocal('editing existing message'));
+    expect(result.current.value).toBe('editing existing message');
+    expect(localStorage.getItem(`${KEY_PREFIX}room-a`)).toBeNull();
+  });
+
+  it('survives a broken localStorage without throwing', () => {
+    const original = localStorage.getItem;
+    localStorage.getItem = () => {
+      throw new Error('storage disabled');
+    };
+    try {
+      const { result } = renderHook(() => usePersistedDraft('room-a'));
+      expect(result.current.value).toBe('');
+      act(() => result.current.setValue('typed'));
+      expect(result.current.value).toBe('typed');
+    } finally {
+      localStorage.getItem = original;
+    }
+  });
+});

--- a/src/components/dashboard/sections/chat/hooks/usePersistedDraft.ts
+++ b/src/components/dashboard/sections/chat/hooks/usePersistedDraft.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+/**
+ * Per-room composer draft persistence.
+ *
+ * The chat composer state survives room switches (ChatRoom is not remounted),
+ * so without drafts a half-typed message would follow the user into the next
+ * room and could be sent to the wrong place. This hook restores the saved
+ * draft during render when `roomId` changes (the same adjust-state-during-
+ * render pattern used by other dashboard poll handlers) and exposes a stable
+ * `clear()` to wipe storage after a successful send.
+ *
+ * Falls back to an empty in-memory string when `localStorage` is unavailable
+ * (Safari private mode, quota errors, etc.) — drafts are best-effort and
+ * must never block the composer.
+ */
+export interface UsePersistedDraftResult {
+  value: string;
+  /** Set the draft and write it to storage. Whitespace-only drafts are not
+   *  persisted (matches element-web behaviour). */
+  setValue: (_next: string) => void;
+  /** Replace the in-memory value without touching storage. Used when the
+   *  composer is repurposed for an edit session — we do not want the
+   *  in-flight edit body to leak into the room's draft on the next visit. */
+  setValueLocal: (_next: string) => void;
+  /** Reset both the in-memory value and the persisted draft. */
+  clear: () => void;
+}
+
+export function usePersistedDraft(roomId: string): UsePersistedDraftResult {
+  const draftKey = `agentteams-chat-draft:${roomId}`;
+  const [value, setValueState] = useState<string>(() => readDraft(draftKey));
+
+  const [prevRoomId, setPrevRoomId] = useState(roomId);
+  if (prevRoomId !== roomId) {
+    setPrevRoomId(roomId);
+    setValueState(readDraft(`agentteams-chat-draft:${roomId}`));
+  }
+
+  const setValue = useCallback(
+    (next: string) => {
+      setValueState(next);
+      writeDraft(`agentteams-chat-draft:${roomId}`, next);
+    },
+    [roomId],
+  );
+
+  const setValueLocal = useCallback((next: string) => {
+    setValueState(next);
+  }, []);
+
+  const clear = useCallback(() => {
+    setValueState('');
+    clearDraft(`agentteams-chat-draft:${roomId}`);
+  }, [roomId]);
+
+  return { value, setValue, setValueLocal, clear };
+}
+
+function readDraft(key: string): string {
+  try {
+    return localStorage.getItem(key) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function writeDraft(key: string, value: string): void {
+  try {
+    if (value.trim()) localStorage.setItem(key, value);
+    else localStorage.removeItem(key);
+  } catch {
+    /* storage unavailable — best-effort */
+  }
+}
+
+function clearDraft(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/src/hooks/use-audit-events.ts
+++ b/src/hooks/use-audit-events.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface AuditEvent {
+  id: string;
+  timestamp: number;
+  actor?: string;
+  actor_level?: number;
+  entity_type: 'worker' | 'team' | 'manager' | 'human' | 'system';
+  entity_name: string;
+  action: string;
+  details?: string;
+  severity: 'info' | 'warning' | 'error';
+  source_ip?: string;
+}
+
+export interface AuditQuery {
+  from?: number;
+  to?: number;
+  entityType?: AuditEvent['entity_type'];
+  limit?: number;
+}
+
+export interface AuditEventsResponse {
+  success: boolean;
+  events?: AuditEvent[];
+  error?: string;
+}
+
+/**
+ * Fetch server-side audit events. The endpoint is admin-only and returns
+ * 403 for non-admin sessions — surfaced via `error` rather than thrown so
+ * the UI can render an inline notice instead of crashing.
+ */
+export function useAuditEvents(query: AuditQuery = {}) {
+  return useQuery<AuditEventsResponse>({
+    queryKey: ['audit-events', query],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (query.from !== undefined) params.set('from', String(query.from));
+      if (query.to !== undefined) params.set('to', String(query.to));
+      if (query.entityType) params.set('entityType', query.entityType);
+      if (query.limit !== undefined) params.set('limit', String(query.limit));
+
+      const qs = params.toString();
+      const res = await fetch(`/api/agentteams/audit${qs ? `?${qs}` : ''}`, {
+        credentials: 'same-origin',
+      });
+      if (res.status === 403) {
+        return { success: false, error: '需要管理员权限' };
+      }
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        return { success: false, error: text || `HTTP ${res.status}` };
+      }
+      return (await res.json()) as AuditEventsResponse;
+    },
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+  });
+}

--- a/src/lib/a2ui/parser-agent-run.test.ts
+++ b/src/lib/a2ui/parser-agent-run.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentRunBlocks } from './parser';
+
+describe('parseAgentRunBlocks v1', () => {
+  it('parses a v1 envelope with text + thinking blocks', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      run_id: 'run-1',
+      step_id: 'step-1',
+      blocks: [
+        { type: 'thinking', content: '思考中' },
+        { type: 'text', text: '最终回答' },
+      ],
+    });
+    expect(blocks).toHaveLength(2);
+    expect(blocks?.[0]).toMatchObject({ type: 'thinking', content: '思考中' });
+    expect(blocks?.[1]).toMatchObject({ type: 'text', text: '最终回答' });
+  });
+
+  it('normalises tool_call v1 blocks with stable id and status defaults', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [{ type: 'tool_call', tool_name: 'search', arguments: { q: 'test' } }],
+    });
+    expect(blocks).toHaveLength(1);
+    const payload = blocks?.[0].payload as { tool_name: string; arguments: Record<string, unknown>; status: string; tool_call_id?: string };
+    expect(payload.tool_name).toBe('search');
+    expect(payload.arguments).toEqual({ q: 'test' });
+    expect(payload.status).toBe('running');
+    expect(payload.tool_call_id).toBeUndefined();
+  });
+
+  it('preserves tool_call_id when the runtime provides one', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [{ type: 'tool_call', tool_name: 'read_file', arguments: {}, tool_call_id: 'call-42', status: 'succeeded' }],
+    });
+    const payload = blocks?.[0].payload as { tool_call_id?: string; status: string };
+    expect(payload.tool_call_id).toBe('call-42');
+    expect(payload.status).toBe('succeeded');
+  });
+
+  it('drops tool_call blocks that lack a tool_name', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [{ type: 'tool_call', arguments: {} }],
+    });
+    expect(blocks).toBeUndefined();
+  });
+
+  it('drops confirmation blocks that lack confirmation_id', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [{ type: 'confirmation', tool_name: 'bash', parameters: 'ls' }],
+    });
+    expect(blocks).toBeUndefined();
+  });
+
+  it('passes through confirmation blocks with confirmation_id', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [{ type: 'confirmation', tool_name: 'bash', confirmation_id: 'cfm-1' }],
+    });
+    expect(blocks?.[0].type).toBe('confirmation');
+    const payload = blocks?.[0].payload as { tool_name: string; confirmation_id: string };
+    expect(payload.confirmation_id).toBe('cfm-1');
+  });
+
+  it('normalises error blocks to the recognised kinds', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [
+        { type: 'error', kind: 'cancelled', title: '已取消' },
+        { type: 'error', kind: 'unknown', title: 'whatever' },
+      ],
+    });
+    expect(blocks).toHaveLength(1);
+    expect(blocks?.[0]).toMatchObject({ type: 'error' });
+    expect((blocks?.[0].payload as { kind: string }).kind).toBe('cancelled');
+  });
+
+  it('skips unknown block types silently', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '1',
+      blocks: [
+        { type: 'something_new', foo: 1 },
+        { type: 'text', text: 'hi' },
+      ],
+    });
+    expect(blocks).toHaveLength(1);
+    expect(blocks?.[0].type).toBe('text');
+  });
+
+  it('returns undefined for unknown protocol versions', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '9',
+      blocks: [{ type: 'text', text: 'hi' }],
+    });
+    expect(blocks).toBeUndefined();
+  });
+
+  it('returns undefined when v1 blocks array is missing', () => {
+    expect(parseAgentRunBlocks({ version: '1' })).toBeUndefined();
+    expect(parseAgentRunBlocks({ version: '1', blocks: 'nope' })).toBeUndefined();
+  });
+});
+
+describe('parseAgentRunBlocks legacy (v0 / unspecified)', () => {
+  it('still maps every recognised block type with declared fields', () => {
+    const blocks = parseAgentRunBlocks({
+      blocks: [
+        { type: 'thinking', content: '分析中' },
+        { type: 'text', text: '分析结果' },
+      ],
+    });
+    expect(blocks).toHaveLength(2);
+    expect(blocks?.[0]).toMatchObject({ type: 'thinking', content: '分析中' });
+    expect(blocks?.[1]).toMatchObject({ type: 'text', text: '分析结果' });
+  });
+
+  it('treats explicit version "0" as legacy', () => {
+    const blocks = parseAgentRunBlocks({
+      version: '0',
+      blocks: [{ type: 'text', text: 'legacy' }],
+    });
+    expect(blocks?.[0]).toMatchObject({ type: 'text', text: 'legacy' });
+  });
+});

--- a/src/lib/a2ui/parser.ts
+++ b/src/lib/a2ui/parser.ts
@@ -19,6 +19,13 @@
 
 import type { A2uiMessage } from '@a2ui/web_core/v0_9';
 import { tryParseAgentReprBlocks } from './agent-repr';
+import {
+  normalizeConfirmationPayload,
+  normalizeErrorPayload,
+  normalizeToolCallPayload,
+  resolveProtocolVersion,
+  RUNTIME_BLOCK_PROTOCOL_VERSION,
+} from './protocol';
 import type { WorkflowPayload } from './workflow';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -59,28 +66,106 @@ const AGENT_RUN_BLOCK_TYPES = new Set<ParsedA2uiBlock['type']>([
 
 /**
  * Reads an optional structured run payload attached by an AgentTeams runtime
- * adapter. AgentTeams itself does not define this Matrix event schema, so it
- * remains an opt-in compatibility path alongside the runtime repr parser.
+ * adapter. The `version` field on the envelope selects the parsing strategy:
+ *
+ * - "1" (or future versions): field-normalised shapes produced by
+ *   `normalizeToolCallPayload` / `normalizeConfirmationPayload` /
+ *   `normalizeErrorPayload`. Invalid blocks are dropped (not silently coerced
+ *   into text) so consumers can see the gap.
+ * - "0" / undefined: pass-through parser that maps every recognised block
+ *   type with its declared fields. Kept so existing opt-in producers do not
+ *   break.
+ * - unknown version: returns undefined so the caller falls back to the legacy
+ *   text heuristics — never silently drops a message.
  */
 export function parseAgentRunBlocks(value: unknown, isStreaming = false): ParsedA2uiBlock[] | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-  const blocks = (value as Record<string, unknown>).blocks;
+  const source = value as Record<string, unknown>;
+  const version = resolveProtocolVersion(source.version);
+  if (version === undefined) return undefined;
+
+  if (version === RUNTIME_BLOCK_PROTOCOL_VERSION) {
+    return parseV1RunBlocks(source, isStreaming);
+  }
+  return parseLegacyRunBlocks(source, isStreaming);
+}
+
+function parseV1RunBlocks(source: Record<string, unknown>, isStreaming: boolean): ParsedA2uiBlock[] | undefined {
+  const rawBlocks = source.blocks;
+  if (!Array.isArray(rawBlocks)) return undefined;
+
+  const blocks: ParsedA2uiBlock[] = [];
+  for (const raw of rawBlocks) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const candidate = raw as Record<string, unknown>;
+    const type = candidate.type;
+
+    switch (type) {
+      case 'text': {
+        if (typeof candidate.text !== 'string') continue;
+        blocks.push({
+          type: 'text',
+          text: candidate.text,
+          isStreaming: candidate.isStreaming === true || (isStreaming && !('isStreaming' in candidate)),
+        });
+        break;
+      }
+      case 'thinking': {
+        if (typeof candidate.content !== 'string') continue;
+        blocks.push({
+          type: 'thinking',
+          content: candidate.content,
+          isStreaming: candidate.isStreaming === true || (isStreaming && !('isStreaming' in candidate)),
+        });
+        break;
+      }
+      case 'tool_call': {
+        const normalised = normalizeToolCallPayload(candidate);
+        if (!normalised) continue;
+        blocks.push({
+          type: 'tool_call',
+          payload: normalised.payload as unknown as Record<string, unknown>,
+          isStreaming: isStreaming && normalised.payload.status === 'running' ? true : undefined,
+        });
+        break;
+      }
+      case 'confirmation': {
+        const normalised = normalizeConfirmationPayload(candidate);
+        if (!normalised) continue;
+        blocks.push({ type: 'confirmation', payload: normalised.payload as unknown as Record<string, unknown> });
+        break;
+      }
+      case 'error': {
+        const normalised = normalizeErrorPayload(candidate);
+        if (!normalised) continue;
+        blocks.push({ type: 'error', payload: normalised.payload as unknown as Record<string, unknown> });
+        break;
+      }
+      default:
+        continue;
+    }
+  }
+  return blocks.length > 0 ? blocks : undefined;
+}
+
+function parseLegacyRunBlocks(source: Record<string, unknown>, isStreaming: boolean): ParsedA2uiBlock[] | undefined {
+  const blocks = source.blocks;
   if (!Array.isArray(blocks)) return undefined;
 
   return blocks.flatMap((block): ParsedA2uiBlock[] => {
     if (!block || typeof block !== 'object' || Array.isArray(block)) return [];
-    const source = block as Record<string, unknown>;
-    const type = source.type;
+    const candidate = block as Record<string, unknown>;
+    const type = candidate.type;
     if (typeof type !== 'string' || !AGENT_RUN_BLOCK_TYPES.has(type as ParsedA2uiBlock['type'])) return [];
 
     const parsed: ParsedA2uiBlock = { type: type as ParsedA2uiBlock['type'] };
-    if (typeof source.content === 'string') parsed.content = source.content;
-    if (typeof source.text === 'string') parsed.text = source.text;
-    if (source.payload && typeof source.payload === 'object' && !Array.isArray(source.payload)) {
-      parsed.payload = source.payload as Record<string, unknown>;
+    if (typeof candidate.content === 'string') parsed.content = candidate.content;
+    if (typeof candidate.text === 'string') parsed.text = candidate.text;
+    if (candidate.payload && typeof candidate.payload === 'object' && !Array.isArray(candidate.payload)) {
+      parsed.payload = candidate.payload as Record<string, unknown>;
     }
-    if (Array.isArray(source.messages)) parsed.messages = source.messages as A2uiMessage[];
-    if (source.isStreaming === true || (isStreaming && type !== 'text')) parsed.isStreaming = true;
+    if (Array.isArray(candidate.messages)) parsed.messages = candidate.messages as A2uiMessage[];
+    if (candidate.isStreaming === true || (isStreaming && type !== 'text')) parsed.isStreaming = true;
     return [parsed];
   });
 }

--- a/src/lib/a2ui/protocol.ts
+++ b/src/lib/a2ui/protocol.ts
@@ -1,0 +1,178 @@
+/**
+ * Runtime block protocol — discriminated union for `org.agentteams.run` blocks.
+ *
+ * AgentTeams runtimes MAY emit a structured `content['org.agentteams.run']`
+ * payload instead of relying on the body-text heuristics in `parser.ts`.
+ * The schema is intentionally narrow: every block carries a `type` discriminator
+ * and only fields that downstream consumers (Chat renderer, tool-call counter,
+ * WenTian diagnosis) actually consume.
+ *
+ * Two versions are recognised:
+ *   - "0" / undefined: legacy opt-in shape (see parser.parseAgentRunBlocks).
+ *     The schema is loosely typed; consumers must tolerate missing fields.
+ *   - "1": normalised shape. New fields (run_id, step_id, tool_call.status,
+ *     confirmation.confirmation_id) are reserved. Field defaults are filled
+ *     in by `normalizeRuntimeBlock` for forward compatibility.
+ *
+ * When an unknown version is seen or required fields are missing the parser
+ * returns `undefined` so the caller can fall through to the legacy text
+ * heuristics — never silently drop a message.
+ */
+
+export const RUNTIME_BLOCK_PROTOCOL_VERSION = '1';
+export const RUNTIME_BLOCK_PROTOCOL_LEGACY = '0';
+
+export type RuntimeProtocolVersion = typeof RUNTIME_BLOCK_PROTOCOL_VERSION | typeof RUNTIME_BLOCK_PROTOCOL_LEGACY;
+
+/** Status of a single tool invocation, matching the existing Chat card states. */
+export type RuntimeToolCallStatus = 'pending' | 'running' | 'succeeded' | 'failed';
+
+/** Mirror of parser.RunEndingPayload, kept here so the protocol file is the source of truth. */
+export type RuntimeRunEndingKind = 'cancelled' | 'failed' | 'quiet';
+
+export interface RuntimeTextBlock {
+  type: 'text';
+  text: string;
+  isStreaming?: boolean;
+}
+
+export interface RuntimeThinkingBlock {
+  type: 'thinking';
+  content: string;
+  isStreaming?: boolean;
+}
+
+export interface RuntimeToolCallBlock {
+  type: 'tool_call';
+  payload: {
+    tool_name: string;
+    arguments: Record<string, unknown>;
+    result?: unknown;
+    status: RuntimeToolCallStatus;
+    /** Stable id assigned by the runtime. Used to dedupe across revisions / replays. */
+    tool_call_id?: string;
+    started_at?: number;
+    finished_at?: number;
+  };
+}
+
+export interface RuntimeConfirmationBlock {
+  type: 'confirmation';
+  payload: {
+    tool_name: string;
+    parameters?: string;
+    external_files?: string;
+    /** Stable id used to correlate approve / deny replies. */
+    confirmation_id: string;
+    expires_at?: number;
+  };
+}
+
+export interface RuntimeErrorBlock {
+  type: 'error';
+  payload: { kind: RuntimeRunEndingKind; title: string };
+}
+
+export type RuntimeBlock =
+  | RuntimeTextBlock
+  | RuntimeThinkingBlock
+  | RuntimeToolCallBlock
+  | RuntimeConfirmationBlock
+  | RuntimeErrorBlock;
+
+export interface RuntimeBlockEnvelope {
+  version: RuntimeProtocolVersion;
+  /** Correlation id joining multiple messages from the same execution. */
+  run_id?: string;
+  /** Current step id within the run. */
+  step_id?: string;
+  blocks: RuntimeBlock[];
+}
+
+export function resolveProtocolVersion(value: unknown): RuntimeProtocolVersion | undefined {
+  if (value === RUNTIME_BLOCK_PROTOCOL_VERSION) return RUNTIME_BLOCK_PROTOCOL_VERSION;
+  if (value === undefined || value === RUNTIME_BLOCK_PROTOCOL_LEGACY || value === null) {
+    return RUNTIME_BLOCK_PROTOCOL_LEGACY;
+  }
+  return undefined;
+}
+
+/** True when a block carries a usable tool_call_id (non-empty string). */
+export function hasToolCallId(block: RuntimeBlock): block is RuntimeToolCallBlock {
+  return (
+    block.type === 'tool_call' &&
+    typeof block.payload.tool_call_id === 'string' &&
+    block.payload.tool_call_id.length > 0
+  );
+}
+
+/**
+ * Normalise a v1 tool_call block: fill in missing optional fields with safe
+ * defaults so downstream consumers do not have to null-check everything.
+ * Unknown fields are stripped to keep the payload serialisable.
+ */
+export function normalizeToolCallPayload(raw: unknown): RuntimeToolCallBlock | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const source = raw as Record<string, unknown>;
+  const toolName = source.tool_name;
+  if (typeof toolName !== 'string' || toolName.length === 0) return undefined;
+
+  const status = normalizeToolCallStatus(source.status);
+
+  const args: Record<string, unknown> =
+    source.arguments && typeof source.arguments === 'object' && !Array.isArray(source.arguments)
+      ? (source.arguments as Record<string, unknown>)
+      : {};
+
+  const payload: RuntimeToolCallBlock['payload'] = { tool_name: toolName, arguments: args, status };
+  if (typeof source.tool_call_id === 'string' && source.tool_call_id.length > 0) {
+    payload.tool_call_id = source.tool_call_id;
+  }
+  if (typeof source.started_at === 'number') payload.started_at = source.started_at;
+  if (typeof source.finished_at === 'number') payload.finished_at = source.finished_at;
+  if ('result' in source) payload.result = source.result;
+  return { type: 'tool_call', payload };
+}
+
+function normalizeToolCallStatus(value: unknown): RuntimeToolCallStatus {
+  if (value === 'pending' || value === 'running' || value === 'succeeded' || value === 'failed') {
+    return value;
+  }
+  return 'running';
+}
+
+/**
+ * Normalise a v1 confirmation block. Requires confirmation_id; without it the
+ * caller should fall back to the legacy text heuristic so the operator still
+ * sees an approval card.
+ */
+export function normalizeConfirmationPayload(raw: unknown): RuntimeConfirmationBlock | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const source = raw as Record<string, unknown>;
+  const toolName = source.tool_name;
+  const confirmationId = source.confirmation_id;
+  if (typeof toolName !== 'string' || toolName.length === 0) return undefined;
+  if (typeof confirmationId !== 'string' || confirmationId.length === 0) return undefined;
+
+  const payload: RuntimeConfirmationBlock['payload'] = {
+    tool_name: toolName,
+    confirmation_id: confirmationId,
+  };
+  if (typeof source.parameters === 'string') payload.parameters = source.parameters;
+  if (typeof source.external_files === 'string') payload.external_files = source.external_files;
+  if (typeof source.expires_at === 'number') payload.expires_at = source.expires_at;
+  return { type: 'confirmation', payload };
+}
+
+/**
+ * Normalise a v1 error block. The runtime run-ending sentinels stay narrow
+ * (cancelled / failed / quiet) — anything else is rejected so the caller can
+ * fall through to the existing parseRunEnding text heuristic.
+ */
+export function normalizeErrorPayload(raw: unknown): RuntimeErrorBlock | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const source = raw as Record<string, unknown>;
+  if (source.kind !== 'cancelled' && source.kind !== 'failed' && source.kind !== 'quiet') return undefined;
+  if (typeof source.title !== 'string') return undefined;
+  return { type: 'error', payload: { kind: source.kind, title: source.title } };
+}

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -6,9 +6,20 @@ import { callHigressConsole } from '../app/api/higress/proxy-helper';
 
 // In-memory session validation cache (30s TTL) to avoid hitting Higress
 // Console on every API request. Keyed by a hash of the Higress session cookie.
-const sessionCache = new Map<string, { valid: boolean; expires: number }>();
+const sessionCache = new Map<string, CachedSession>();
 const CACHE_TTL_MS = 30_000;
 const MAX_CACHE_SIZE = 1000;
+
+interface CachedSession {
+  valid: boolean;
+  user: SessionUser | null;
+  expires: number;
+}
+
+export interface SessionUser {
+  name: string;
+  level: number;
+}
 
 function extractSessionCookie(cookie: string): string {
   // Extract only Higress-relevant cookies to keep the cache key stable
@@ -49,54 +60,80 @@ function pruneCache() {
   }
 }
 
+function extractUser(body: unknown): SessionUser | null {
+  if (!body || typeof body !== 'object') return null;
+  // Higress `/v1/consumers` may return either the consumer object directly
+  // (`{ name, ... }`) or a list (`[{ name, ... }]`). Accept both shapes.
+  const candidates: unknown[] = Array.isArray(body) ? body : [body];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const record = candidate as Record<string, unknown>;
+    const name = record.name ?? record.username ?? record.userName;
+    if (typeof name !== 'string' || name.length === 0) continue;
+    const levelRaw = record.level ?? record.permissionLevel ?? record.accessLevel ?? 1;
+    const level = typeof levelRaw === 'number' ? levelRaw : Number(levelRaw);
+    return { name, level: Number.isFinite(level) ? level : 1 };
+  }
+  return null;
+}
+
+export interface SessionValidation {
+  valid: boolean;
+  user: SessionUser | null;
+}
+
 /**
  * Validate the browser's Higress Console session by forwarding the cookie
  * to the Higress Console /v1/consumers endpoint. Results are cached for 30s.
- * Returns true if the session is valid, false otherwise.
+ * Returns `{ valid, user }` — `user` is populated whenever the response body
+ * carries a recognisable consumer record.
  *
  * Ignores user-supplied ?consoleUrl= parameter and always uses the configured
  * environment URL to prevent SSRF via cookie forwarding.
  */
-export async function validateHigressSession(request: NextRequest): Promise<boolean> {
+export async function validateHigressSession(request: NextRequest): Promise<SessionValidation> {
+  const empty: SessionValidation = { valid: false, user: null };
   const cookie = request.headers.get('cookie');
   if (!cookie) {
-    return false;
+    return empty;
   }
 
   const sessionPart = extractSessionCookie(cookie);
   if (!sessionPart) {
-    return false;
+    return empty;
   }
 
   // Check cache first
   const key = hashCookie(sessionPart);
   const cached = sessionCache.get(key);
   if (cached && cached.expires > Date.now()) {
-    return cached.valid;
+    return { valid: cached.valid, user: cached.user };
   }
 
   try {
     // Always use the configured server-side Console URL, never accept
     // user-supplied consoleUrl query param for auth validation (SSRF protection).
     const consoleUrl = process.env.AGENTTEAMS_AI_GATEWAY_ADMIN_URL || undefined;
-    const { response } = await callHigressConsole('/v1/consumers', {
+    const { response, body } = await callHigressConsole('/v1/consumers', {
       method: 'GET',
       cookie,
       consoleUrl,
     });
 
     const valid = response.ok;
+    const user = valid ? extractUser(body) : null;
 
     // Cache the result. Invalid sessions get shorter TTL to reduce cache poisoning risk.
     sessionCache.set(key, {
       valid,
+      user,
       expires: Date.now() + (valid ? CACHE_TTL_MS : 5000),
     });
     pruneCache();
 
-    return valid;
+    return { valid, user };
   } catch {
-    return false;
+    return empty;
   }
 }
 

--- a/src/lib/audit-log.test.ts
+++ b/src/lib/audit-log.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  appendAuditEvent,
+  listAuditEvents,
+  resetAuditLogForTests,
+  setAuditLogPathForTests,
+} from './audit-log';
+
+let tmpDir: string;
+let logPath: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'audit-log-'));
+  logPath = path.join(tmpDir, 'audit.log.jsonl');
+  setAuditLogPathForTests(logPath);
+});
+
+afterEach(async () => {
+  delete process.env.AGENTTEAMS_AUDIT_LOG_PATH;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('appendAuditEvent', () => {
+  it('writes a JSONL line with id/timestamp/severity defaults', async () => {
+    const record = await appendAuditEvent({
+      actor: 'u1',
+      entity_type: 'worker',
+      entity_name: 'w1',
+      action: 'create',
+    });
+    expect(record?.id).toMatch(/^audit-/);
+    expect(record?.timestamp).toBeGreaterThan(0);
+    expect(record?.severity).toBe('info');
+
+    const content = await fs.readFile(logPath, 'utf8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).action).toBe('create');
+  });
+
+  it('preserves explicit severity and optional fields', async () => {
+    await appendAuditEvent({
+      actor: 'u1',
+      actor_level: 3,
+      entity_type: 'team',
+      entity_name: 't1',
+      action: 'delete',
+      severity: 'warning',
+      details: 'RBAC denied',
+      source_ip: '127.0.0.1',
+    });
+    const events = await listAuditEvents();
+    expect(events[0]).toMatchObject({
+      actor: 'u1',
+      actor_level: 3,
+      severity: 'warning',
+      details: 'RBAC denied',
+      source_ip: '127.0.0.1',
+    });
+  });
+});
+
+describe('listAuditEvents', () => {
+  it('returns events newest-first within a time window', async () => {
+    const base = Date.now();
+    await appendAuditEvent({ entity_type: 'worker', entity_name: 'w1', action: 'create' });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await appendAuditEvent({ entity_type: 'worker', entity_name: 'w2', action: 'delete' });
+    const events = await listAuditEvents({ from: base });
+    expect(events.map((e) => e.entity_name)).toEqual(['w2', 'w1']);
+  });
+
+  it('filters by entity type', async () => {
+    await appendAuditEvent({ entity_type: 'worker', entity_name: 'w1', action: 'create' });
+    await appendAuditEvent({ entity_type: 'team', entity_name: 't1', action: 'create' });
+    const events = await listAuditEvents({ entityType: 'team' });
+    expect(events).toHaveLength(1);
+    expect(events[0].entity_name).toBe('t1');
+  });
+
+  it('caps results to the requested limit', async () => {
+    for (let i = 0; i < 5; i++) {
+      await appendAuditEvent({ entity_type: 'worker', entity_name: `w${i}`, action: 'create' });
+    }
+    const events = await listAuditEvents({ limit: 3 });
+    expect(events).toHaveLength(3);
+  });
+});
+
+describe('rotation', () => {
+  it('archives the active file once it exceeds MAX_FILE_BYTES', async () => {
+    // Force rotation by simulating an oversized file with one existing record,
+    // then appending a new one. We bypass MAX_FILE_BYTES by writing the
+    // active file at the limit and then appending through the public API.
+    const bigLine = 'x'.repeat(11 * 1024 * 1024);
+    await fs.writeFile(logPath, bigLine);
+
+    await appendAuditEvent({ entity_type: 'worker', entity_name: 'w1', action: 'create' });
+
+    const dir = path.dirname(logPath);
+    const entries = await fs.readdir(dir);
+    const archives = entries.filter((n) => n !== path.basename(logPath));
+    expect(archives.length).toBeGreaterThanOrEqual(1);
+    // Active file should now contain only the new event line.
+    const active = await fs.readFile(logPath, 'utf8');
+    expect(active.split('\n').filter(Boolean)).toHaveLength(1);
+  });
+});
+
+afterEach(async () => {
+  await resetAuditLogForTests();
+});

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -1,0 +1,249 @@
+/**
+ * Server-side audit log — append-only JSONL with size-based rotation.
+ *
+ * Stores governance events (mutations, RBAC denials, login attempts) on the
+ * server so they survive client-side localStorage clears and remain
+ * tamper-resistant. The format is line-delimited JSON, friendly to grep /
+ * awk and to downstream pipelines that tail the file.
+ *
+ * Rotation is triggered when the active file exceeds {@link MAX_FILE_BYTES};
+ * older archives keep their original date in the filename and are evicted
+ * past {@link MAX_REK_FILES}.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as fsSync from 'node:fs';
+import * as path from 'node:path';
+
+export type AuditSeverity = 'info' | 'warning' | 'error';
+
+export interface AuditEventInput {
+  actor?: string;
+  actor_level?: number;
+  entity_type: 'worker' | 'team' | 'manager' | 'human' | 'system';
+  entity_name: string;
+  action: string;
+  details?: string;
+  severity?: AuditSeverity;
+  source_ip?: string;
+}
+
+export interface AuditEventRecord extends AuditEventInput {
+  id: string;
+  timestamp: number;
+  severity: AuditSeverity;
+}
+
+export interface AuditQuery {
+  from?: number;
+  to?: number;
+  entityType?: AuditEventInput['entity_type'];
+  limit?: number;
+}
+
+const DEFAULT_LOG_PATH = path.resolve(process.cwd(), 'logs', 'audit.log.jsonl');
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_RETAINED_FILES = 30;
+const DEFAULT_QUERY_LIMIT = 100;
+const MAX_QUERY_LIMIT = 1000;
+
+let counter = 0;
+function generateId(timestamp: number): string {
+  counter = (counter + 1) & 0xffff;
+  const rand = Math.floor(Math.random() * 0xffffffff).toString(36);
+  return `audit-${timestamp.toString(36)}-${counter.toString(36)}-${rand}`;
+}
+
+function resolveLogPath(): string {
+  const override = process.env.AGENTTEAMS_AUDIT_LOG_PATH;
+  return override && override.length > 0 ? path.resolve(override) : DEFAULT_LOG_PATH;
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function shouldRotate(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.size >= MAX_FILE_BYTES;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+function archiveName(activePath: string): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const ext = path.extname(activePath);
+  const base = activePath.slice(0, -ext.length);
+  return `${base}.${date}${ext}`;
+}
+
+async function rotate(filePath: string): Promise<void> {
+  if (!(await shouldRotate(filePath))) return;
+  const target = archiveName(filePath);
+  try {
+    await fs.rename(filePath, target);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+  await pruneArchives(filePath);
+}
+
+async function pruneArchives(activePath: string): Promise<void> {
+  const dir = path.dirname(activePath);
+  const base = path.basename(activePath);
+  const ext = path.extname(base);
+  const stem = base.slice(0, -ext.length);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return;
+  }
+  const archives = entries
+    .filter((name) => name.startsWith(`${stem}.`) && name.endsWith(ext) && name !== base)
+    .sort();
+  if (archives.length <= MAX_RETAINED_FILES) return;
+  const toDelete = archives.slice(0, archives.length - MAX_RETAINED_FILES);
+  await Promise.all(toDelete.map((name) => fs.unlink(path.join(dir, name)).catch(() => undefined)));
+}
+
+/** Internal helper exposed for tests so concurrent appends are not blocked. */
+export async function appendRawLine(filePath: string, line: string): Promise<void> {
+  await ensureDir(filePath);
+  if (fsSync.existsSync(filePath)) {
+    await rotate(filePath);
+  }
+  await fs.appendFile(filePath, line, 'utf8');
+}
+
+/**
+ * Append an audit event. Always safe to call from request handlers; failures
+ * are swallowed and logged so an audit write never breaks the upstream
+ * mutation flow.
+ */
+export async function appendAuditEvent(input: AuditEventInput): Promise<AuditEventRecord | undefined> {
+  const record: AuditEventRecord = {
+    ...input,
+    id: generateId(Date.now()),
+    timestamp: Date.now(),
+    severity: input.severity ?? 'info',
+  };
+  const line = JSON.stringify(record) + '\n';
+  const target = resolveLogPath();
+  try {
+    await appendRawLine(target, line);
+    return record;
+  } catch (err) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[audit-log] failed to append event', err);
+    }
+    return undefined;
+  }
+}
+
+function parseLine(line: string): AuditEventRecord | null {
+  if (!line.trim()) return null;
+  try {
+    const value = JSON.parse(line) as AuditEventRecord;
+    if (typeof value.timestamp !== 'number' || typeof value.id !== 'string') return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List audit events newest-first. Reads the active file plus any
+ * `audit.log.YYYY-MM-DD.jsonl` archives that overlap the query range; keeps
+ * memory bounded by `query.limit`.
+ */
+export async function listAuditEvents(query: AuditQuery = {}): Promise<AuditEventRecord[]> {
+  const target = resolveLogPath();
+  const limit = Math.min(Math.max(query.limit ?? DEFAULT_QUERY_LIMIT, 1), MAX_QUERY_LIMIT);
+  const from = query.from ?? 0;
+  const to = query.to ?? Number.MAX_SAFE_INTEGER;
+
+  const files = await candidateFiles(target, to);
+  const collected: AuditEventRecord[] = [];
+
+  for (const file of files) {
+    try {
+      const content = await fs.readFile(file, 'utf8');
+      const lines = content.split('\n');
+      // Files are appended newest-last; iterate in reverse and stop when we
+      // fall below `from` so older archives are skipped quickly.
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const record = parseLine(lines[i]);
+        if (!record) continue;
+        if (record.timestamp < from) break;
+        if (record.timestamp > to) continue;
+        if (query.entityType && record.entity_type !== query.entityType) continue;
+        collected.push(record);
+        if (collected.length >= limit) return collected;
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+  return collected;
+}
+
+async function candidateFiles(activePath: string, to: number): Promise<string[]> {
+  const dir = path.dirname(activePath);
+  const base = path.basename(activePath);
+  const ext = path.extname(base);
+  const stem = base.slice(0, -ext.length);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return [activePath];
+  }
+  const archives = entries.filter((name) => name.startsWith(`${stem}.`) && name.endsWith(ext));
+  archives.sort();
+  const ordered = [...archives.filter((n) => n !== base), base];
+  // Stop reading archives older than `to`. Each archive's date is encoded in
+  // the filename; reuse a 00:00 UTC timestamp to compare.
+  const cutoff = new Date(to);
+  const filtered = ordered.filter((name) => {
+    const match = name.match(/\.(\d{4}-\d{2}-\d{2})/);
+    if (!match) return true;
+    return new Date(`${match[1]}T23:59:59.999Z`).getTime() >= cutoff.getTime() - 24 * 3600 * 1000;
+  });
+  return filtered.map((name) => path.join(dir, name));
+}
+
+/** Test helper: wipe the active log and all rotated archives. */
+export async function resetAuditLogForTests(): Promise<void> {
+  const target = resolveLogPath();
+  try {
+    await fs.unlink(target);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  const dir = path.dirname(target);
+  const base = path.basename(target);
+  const ext = path.extname(base);
+  const stem = base.slice(0, -ext.length);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return;
+  }
+  await Promise.all(
+    entries
+      .filter((name) => name.startsWith(`${stem}.`) && name.endsWith(ext))
+      .map((name) => fs.unlink(path.join(dir, name)).catch(() => undefined)),
+  );
+}
+
+/** Test helper: override the log path used by the current process. */
+export function setAuditLogPathForTests(filePath: string): void {
+  process.env.AGENTTEAMS_AUDIT_LOG_PATH = filePath;
+}

--- a/src/lib/audit-store.ts
+++ b/src/lib/audit-store.ts
@@ -58,6 +58,32 @@ export const useAuditStore = create<AuditState>()(
   )
 );
 
+/**
+ * Mirror an audit event to the server-side JSONL log so it survives
+ * localStorage clears and is shared across sessions / devices. Failures are
+ * swallowed: a transient audit write must never block the caller or surface
+ * a visible error to the operator.
+ */
+function reportServerAudit(input: {
+  entity_type: AuditEvent['entityType'];
+  entity_name: string;
+  action: string;
+  details?: string;
+  severity?: AuditEvent['severity'];
+}): void {
+  if (typeof fetch === 'undefined') return;
+  void fetch('/api/agentteams/audit', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+    credentials: 'same-origin',
+  }).catch((err) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[audit] server-side report failed', err);
+    }
+  });
+}
+
 /** Helper to record a mutation audit event */
 export function auditMutation(
   entityType: AuditEvent['entityType'],
@@ -73,5 +99,12 @@ export function auditMutation(
     details,
     severity,
     actor: 'dashboard-user',
+  });
+  reportServerAudit({
+    entity_type: entityType,
+    entity_name: entityName,
+    action,
+    details,
+    severity,
   });
 }

--- a/src/lib/rbac-engine.ts
+++ b/src/lib/rbac-engine.ts
@@ -29,6 +29,16 @@ function getLevelPermissions(level: number | undefined): Permission[] {
 }
 
 /**
+ * Check whether a permission level grants the action. Pure level-based
+ * decision (no resource scoping) — applies to global resources such as
+ * storage buckets, skill catalogs, project boards, and gateway routes
+ * that are not partitioned per-team/per-worker.
+ */
+export function checkPermissionByLevel(level: number | undefined, action: Permission): boolean {
+  return getLevelPermissions(level).includes(action);
+}
+
+/**
  * Check if a human has a specific permission on a resource.
  * Rules:
  * 1. Check explicit RBAC rules first (deny overrides allow)

--- a/src/lib/server-auth.test.ts
+++ b/src/lib/server-auth.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { NextRequest } from 'next/server';
+import { enforceServerSideRbac, readServerIdentity, SERVER_USER_HEADER, SERVER_USER_LEVEL_HEADER } from './server-auth';
+import { setAuditLogPathForTests } from './audit-log';
+
+function makeRequest(name: string | null, level: number | null): NextRequest {
+  const headers = new Headers();
+  if (name) headers.set(SERVER_USER_HEADER, name);
+  if (level !== null) headers.set(SERVER_USER_LEVEL_HEADER, String(level));
+  return new NextRequest('http://localhost/api/agentteams/workers/x', { headers });
+}
+
+describe('readServerIdentity', () => {
+  it('returns null when no identity header is present', () => {
+    expect(readServerIdentity(makeRequest(null, null))).toBeNull();
+  });
+
+  it('parses name and level, defaulting to level 1', () => {
+    expect(readServerIdentity(makeRequest('alice', 2))).toEqual({
+      name: 'alice',
+      level: 2,
+      sourceIp: undefined,
+    });
+  });
+
+  it('captures the first forwarded IP for audit attribution', () => {
+    const headers = new Headers();
+    headers.set(SERVER_USER_HEADER, 'alice');
+    headers.set(SERVER_USER_LEVEL_HEADER, '3');
+    headers.set('x-forwarded-for', '10.1.2.3, 10.0.0.1');
+    const req = new NextRequest('http://localhost/api', { headers });
+    expect(readServerIdentity(req)?.sourceIp).toBe('10.1.2.3');
+  });
+});
+
+describe('enforceServerSideRbac', () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rbac-test-'));
+    setAuditLogPathForTests(path.join(tmpDir, 'audit.log.jsonl'));
+  });
+
+  afterEach(async () => {
+    delete process.env.AGENTTEAMS_AUDIT_LOG_PATH;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns null (allow) when no identity header is present', async () => {
+    const res = await enforceServerSideRbac(makeRequest(null, null), 'delete', 'worker', 'w1');
+    expect(res).toBeNull();
+  });
+
+  it('allows admin (level 3) to delete any worker', async () => {
+    const res = await enforceServerSideRbac(makeRequest('admin', 3), 'delete', 'worker', 'w1');
+    expect(res).toBeNull();
+  });
+
+  it('denies observer (level 1) attempting delete with a 403', async () => {
+    const res = await enforceServerSideRbac(makeRequest('observer', 1), 'delete', 'worker', 'w1');
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+    const body = await res?.json();
+    expect(body).toMatchObject({ success: false, action: 'delete', resourceType: 'worker', resourceName: 'w1' });
+    expect(typeof body.error).toBe('string');
+  });
+
+  it('appends a warning audit event when RBAC denies', async () => {
+    await enforceServerSideRbac(makeRequest('observer', 1), 'delete', 'worker', 'w-secret');
+    // Give the fire-and-forget append a tick to flush.
+    await new Promise((r) => setTimeout(r, 20));
+    const content = await fs.readFile(path.join(tmpDir, 'audit.log.jsonl'), 'utf8');
+    expect(content).toContain('rbac.deny.delete');
+    expect(content).toContain('"severity":"warning"');
+    expect(content).toContain('w-secret');
+  });
+});

--- a/src/lib/server-auth.test.ts
+++ b/src/lib/server-auth.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { NextRequest } from 'next/server';
-import { enforceServerSideRbac, readServerIdentity, SERVER_USER_HEADER, SERVER_USER_LEVEL_HEADER } from './server-auth';
+import { enforceServerSideRbac, enforceLevelOnlyRbac, readServerIdentity, SERVER_USER_HEADER, SERVER_USER_LEVEL_HEADER } from './server-auth';
 import { setAuditLogPathForTests } from './audit-log';
 
 function makeRequest(name: string | null, level: number | null): NextRequest {
@@ -76,5 +76,52 @@ describe('enforceServerSideRbac', () => {
     expect(content).toContain('rbac.deny.delete');
     expect(content).toContain('"severity":"warning"');
     expect(content).toContain('w-secret');
+  });
+});
+
+describe('enforceLevelOnlyRbac', () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rbac-level-'));
+    setAuditLogPathForTests(path.join(tmpDir, 'audit.log.jsonl'));
+  });
+
+  afterEach(async () => {
+    delete process.env.AGENTTEAMS_AUDIT_LOG_PATH;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null (allow) when no identity header is present', async () => {
+    const res = await enforceLevelOnlyRbac(makeRequest(null, null), 'delete', 'storage.bucket', 'foo');
+    expect(res).toBeNull();
+  });
+
+  it('allows admin (level 3) to delete a storage bucket', async () => {
+    const res = await enforceLevelOnlyRbac(makeRequest('admin', 3), 'delete', 'storage.bucket', 'foo');
+    expect(res).toBeNull();
+  });
+
+  it('denies observer (level 1) attempting delete with a 403', async () => {
+    const res = await enforceLevelOnlyRbac(makeRequest('observer', 1), 'delete', 'storage.bucket', 'foo');
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+    const body = await res?.json();
+    expect(body).toMatchObject({ success: false, action: 'delete', resourceType: 'storage.bucket', resourceName: 'foo' });
+    expect(typeof body.error).toBe('string');
+  });
+
+  it('allows operator (level 2) to perform wake (level 2 grants wake but not create/delete)', async () => {
+    const res = await enforceLevelOnlyRbac(makeRequest('operator', 2), 'wake', 'worker', 'w-1');
+    expect(res).toBeNull();
+  });
+
+  it('appends a system audit event on deny with severity=warning', async () => {
+    await enforceLevelOnlyRbac(makeRequest('observer', 1), 'delete', 'storage.bucket', 'audit-target');
+    await new Promise((r) => setTimeout(r, 20));
+    const content = await fs.readFile(path.join(tmpDir, 'audit.log.jsonl'), 'utf8');
+    expect(content).toContain('rbac.deny.delete');
+    expect(content).toContain('"entity_type":"system"');
+    expect(content).toContain('audit-target');
+    expect(content).toContain('"severity":"warning"');
   });
 });

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -10,7 +10,7 @@
  * (those would be forgeable).
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { checkPermission, type Permission } from '@/lib/rbac-engine';
+import { checkPermission, checkPermissionByLevel, type Permission } from '@/lib/rbac-engine';
 import type { HumanResponse } from '@/lib/agentteams-api';
 import { appendAuditEvent } from '@/lib/audit-log';
 
@@ -107,6 +107,44 @@ export async function enforceServerSideRbac(
   if (result.allowed) return null;
   return NextResponse.json(
     { success: false, error: result.reason, action, resourceType, resourceName },
+    { status: 403 },
+  );
+}
+
+/**
+ * Level-only RBAC check for global resources (storage, skill catalog,
+ * gateway routes, etc.) that are not partitioned per-team / per-worker.
+ * Bypasses the resource-scoping logic in `rbac-engine` and answers only
+ * whether the permission level grants the requested action. Mirrors
+ * `enforceServerSideRbac` semantics for the no-identity path.
+ */
+export async function enforceLevelOnlyRbac(
+  request: NextRequest,
+  action: Permission,
+  resourceType: string,
+  resourceName: string,
+): Promise<NextResponse | null> {
+  const identity = readServerIdentity(request);
+  if (!identity) return null;
+  if (checkPermissionByLevel(identity.level, action)) return null;
+  await appendAuditEvent({
+    actor: identity.name,
+    actor_level: identity.level,
+    entity_type: 'system',
+    entity_name: resourceName,
+    action: `rbac.deny.${action}`,
+    details: `权限等级 ${identity.level} 不允许 "${action}" ${resourceType} 操作`,
+    severity: 'warning',
+    source_ip: identity.sourceIp,
+  });
+  return NextResponse.json(
+    {
+      success: false,
+      error: `权限等级 ${identity.level} 不允许 "${action}" ${resourceType} 操作`,
+      action,
+      resourceType,
+      resourceName,
+    },
     { status: 403 },
   );
 }

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -1,0 +1,112 @@
+/**
+ * Server-side authentication helpers used by route handlers under
+ * `/api/agentteams/*`. Reads the identity injected by middleware (from the
+ * Higress session) and constructs a synthetic `HumanResponse` so the existing
+ * `rbac-engine` can evaluate write permissions uniformly.
+ *
+ * IMPORTANT: `request` here is the *mutated* request that Next.js forwards
+ * downstream after the middleware ran. The identity headers were attached by
+ * `src/middleware.ts` and must not be read off the original browser request
+ * (those would be forgeable).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { checkPermission, type Permission } from '@/lib/rbac-engine';
+import type { HumanResponse } from '@/lib/agentteams-api';
+import { appendAuditEvent } from '@/lib/audit-log';
+
+export const SERVER_USER_HEADER = 'x-agentteams-user';
+export const SERVER_USER_LEVEL_HEADER = 'x-agentteams-user-level';
+export const SERVER_USER_IP_HEADER = 'x-forwarded-for';
+
+export interface ServerIdentity {
+  name: string;
+  level: number;
+  sourceIp?: string;
+}
+
+export function readServerIdentity(request: NextRequest): ServerIdentity | null {
+  const name = request.headers.get(SERVER_USER_HEADER);
+  if (!name) return null;
+  const levelRaw = request.headers.get(SERVER_USER_LEVEL_HEADER);
+  const level = levelRaw ? Number(levelRaw) : 1;
+  const forwarded = request.headers.get(SERVER_USER_IP_HEADER);
+  const sourceIp = forwarded ? forwarded.split(',')[0]?.trim() : undefined;
+  return {
+    name,
+    level: Number.isFinite(level) ? level : 1,
+    sourceIp,
+  };
+}
+
+function buildHuman(identity: ServerIdentity): HumanResponse {
+  return {
+    name: identity.name,
+    permissionLevel: identity.level,
+    // RBAC scoping fields default to undefined so the engine treats the user
+    // as having global access within their permission level. Per-team /
+    // per-worker restrictions are configured in the Controller side.
+  } as HumanResponse;
+}
+
+export interface RbacEnforcementInput {
+  identity: ServerIdentity;
+  action: Permission;
+  resourceType: 'worker' | 'team';
+  resourceName: string;
+}
+
+export interface RbacEnforcementResult {
+  allowed: boolean;
+  reason: string;
+}
+
+/**
+ * Evaluate server-side RBAC for a write request. Returns `{ allowed: false,
+ * reason }` when the active session lacks the permission; route handlers
+ * should turn this into a 403 response. On deny, an audit event is appended
+ * with severity=warning for forensic traceability.
+ */
+export function evaluateServerSideRbac(input: RbacEnforcementInput): RbacEnforcementResult {
+  const human = buildHuman(input.identity);
+  const result = checkPermission(human, input.action, input.resourceType, input.resourceName);
+  if (!result.allowed) {
+    void appendAuditEvent({
+      actor: input.identity.name,
+      actor_level: input.identity.level,
+      entity_type: input.resourceType === 'worker' ? 'worker' : 'team',
+      entity_name: input.resourceName,
+      action: `rbac.deny.${input.action}`,
+      details: result.reason,
+      severity: 'warning',
+      source_ip: input.identity.sourceIp,
+    });
+  }
+  return result;
+}
+
+/**
+ * Convenience wrapper for route handlers: when RBAC denies, returns a 403
+ * `NextResponse`; otherwise returns `null` so the handler can proceed.
+ *
+ * If the request carries no server-injected identity (test paths,
+ * `AGENTTEAMS_AUTH_DISABLED=true`, or any code path that bypassed
+ * middleware) the function returns `null` so the handler can proceed —
+ * the middleware gate at the network edge remains the authoritative
+ * authentication check. This keeps the function side-effect-free for
+ * callers that do not yet wire identity headers.
+ */
+export async function enforceServerSideRbac(
+  request: NextRequest,
+  action: Permission,
+  resourceType: 'worker' | 'team',
+  resourceName: string,
+): Promise<NextResponse | null> {
+  const identity = readServerIdentity(request);
+  if (!identity) return null;
+  const result = evaluateServerSideRbac({ identity, action, resourceType, resourceName });
+  if (result.allowed) return null;
+  return NextResponse.json(
+    { success: false, error: result.reason, action, resourceType, resourceName },
+    { status: 403 },
+  );
+}

--- a/src/lib/tool-call-counter.structured.test.ts
+++ b/src/lib/tool-call-counter.structured.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearToolCallLedger,
+  countToolCalls24h,
+  recordToolCalls,
+} from './tool-call-counter';
+
+beforeEach(() => clearToolCallLedger());
+
+describe('tool-call-counter structured keys', () => {
+  it('counts each unique structured id once even if the event revision repeats', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '$e1', 2, now, ['call-a', 'call-b']);
+    recordToolCalls('w1', '$e1', 2, now + 1, ['call-a', 'call-b']);
+    expect(countToolCalls24h('w1', now + 1)).toBe(2);
+  });
+
+  it('adds only the unseen ids when a revision carries a partial overlap', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '$e1', 0, now, ['call-a']);
+    recordToolCalls('w1', '$e1', 0, now + 1, ['call-a', 'call-b']);
+    expect(countToolCalls24h('w1', now + 1)).toBe(2);
+  });
+
+  it('uses structured ids as the authoritative dedupe (event-delta is bypassed)', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '$e1', 1, now, ['call-a']);
+    recordToolCalls('w1', '$e1', 2, now + 1, ['call-a', 'call-b']);
+    expect(countToolCalls24h('w1', now + 1)).toBe(2);
+  });
+
+  it('ignores empty or non-string structured keys', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '$e1', 0, now, ['', undefined as unknown as string, '  ']);
+    expect(countToolCalls24h('w1', now)).toBe(0);
+  });
+
+  it('still records timestamps when only structured keys are provided', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '', 0, now, ['call-a']);
+    expect(countToolCalls24h('w1', now)).toBe(1);
+  });
+
+  it('persists structured keys across ledger reloads', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '$e1', 0, now, ['call-a', 'call-b']);
+    // Re-reading the ledger should keep the dedupe memory.
+    recordToolCalls('w1', '$e1', 0, now + 1, ['call-a', 'call-b', 'call-c']);
+    expect(countToolCalls24h('w1', now + 1)).toBe(3);
+  });
+
+  it('keeps per-worker isolation of structured key memory', () => {
+    const now = Date.now();
+    recordToolCalls('w1', '$e1', 0, now, ['call-a']);
+    recordToolCalls('w2', '$e1', 0, now, ['call-a']);
+    expect(countToolCalls24h('w1', now)).toBe(1);
+    expect(countToolCalls24h('w2', now)).toBe(1);
+  });
+});

--- a/src/lib/tool-call-counter.ts
+++ b/src/lib/tool-call-counter.ts
@@ -14,6 +14,8 @@ interface ToolCallLedger {
   events: Record<string, number>;
   /** Worker name → timestamps of counted tool calls. */
   perWorker: Record<string, number[]>;
+  /** Worker name → structured tool_call ids already counted (org.agentteams.run v1). */
+  structuredKeys?: Record<string, Set<string>>;
 }
 
 function loadLedger(): ToolCallLedger {
@@ -24,15 +26,41 @@ function loadLedger(): ToolCallLedger {
     return {
       events: parsed.events && typeof parsed.events === 'object' ? parsed.events : {},
       perWorker: parsed.perWorker && typeof parsed.perWorker === 'object' ? parsed.perWorker : {},
+      structuredKeys: parsed.structuredKeys && typeof parsed.structuredKeys === 'object'
+        ? asStringSets(parsed.structuredKeys)
+        : {},
     };
   } catch {
-    return { events: {}, perWorker: {} };
+    return { events: {}, perWorker: {}, structuredKeys: {} };
   }
+}
+
+function asStringSets(value: unknown): Record<string, Set<string>> {
+  if (!value || typeof value !== 'object') return {};
+  const result: Record<string, Set<string>> = {};
+  for (const [workerName, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!raw || typeof raw !== 'object') continue;
+    result[workerName] = new Set(Object.keys(raw as Record<string, unknown>));
+  }
+  return result;
 }
 
 function saveLedger(ledger: ToolCallLedger): void {
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ledger));
+    const serialisable: ToolCallLedger = {
+      events: ledger.events,
+      perWorker: ledger.perWorker,
+    };
+    if (ledger.structuredKeys) {
+      const serialisedKeys: Record<string, Record<string, number>> = {};
+      for (const [workerName, keys] of Object.entries(ledger.structuredKeys)) {
+        const inner: Record<string, number> = {};
+        for (const key of keys) inner[key] = 1;
+        serialisedKeys[workerName] = inner;
+      }
+      serialisable.structuredKeys = serialisedKeys as unknown as Record<string, Set<string>>;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(serialisable));
   } catch {
     // Storage full / unavailable — counting is best-effort, never block chat.
   }
@@ -46,17 +74,52 @@ function isAvailable(): boolean {
  * Count `blockCount` tool_call blocks belonging to one rendered message.
  * Revisions of the same root event (m.replace streaming) only add the delta,
  * so a growing tool list is not double-counted.
+ *
+ * `structuredKeys` is an optional list of stable tool_call ids from
+ * runtime-versioned (`org.agentteams.run` v1) blocks. When provided, these ids
+ * are the authoritative dedupe keys and the event-delta counter is skipped —
+ * each tool call has exactly one stable id, so counting both the event block
+ * count and the structured ids would double-count. Pass `undefined` (or an
+ * empty array) to keep the original event-delta behaviour.
  */
-export function recordToolCalls(workerName: string, eventId: string, blockCount: number, now = Date.now()): void {
-  if (!isAvailable() || !workerName || !eventId || blockCount <= 0) return;
-  const ledger = loadLedger();
-  const already = ledger.events[eventId] ?? 0;
-  const delta = blockCount - already;
-  if (delta <= 0) return;
+export function recordToolCalls(
+  workerName: string,
+  eventId: string,
+  blockCount: number,
+  now: number = Date.now(),
+  structuredKeys?: readonly string[],
+): void {
+  if (!isAvailable() || !workerName) return;
 
-  ledger.events[eventId] = blockCount;
+  const hasStructuredKeys = !!structuredKeys && structuredKeys.length > 0;
+  const hasEventDelta = !hasStructuredKeys && !!eventId && blockCount > 0;
+  if (!hasStructuredKeys && !hasEventDelta) return;
+
+  const ledger = loadLedger();
+
+  let totalDelta = 0;
+  if (hasStructuredKeys) {
+    const seen = ledger.structuredKeys ?? (ledger.structuredKeys = {});
+    const keySet = seen[workerName] ?? (seen[workerName] = new Set<string>());
+    for (const key of structuredKeys) {
+      if (typeof key !== 'string' || key.trim().length === 0) continue;
+      if (keySet.has(key)) continue;
+      keySet.add(key);
+      totalDelta += 1;
+    }
+  } else if (hasEventDelta) {
+    const already = ledger.events[eventId] ?? 0;
+    const delta = blockCount - already;
+    if (delta > 0) {
+      ledger.events[eventId] = blockCount;
+      totalDelta = delta;
+    }
+  }
+
+  if (totalDelta <= 0) return;
+
   const stamps = [...(ledger.perWorker[workerName] ?? [])];
-  for (let i = 0; i < delta; i++) stamps.push(now);
+  for (let i = 0; i < totalDelta; i++) stamps.push(now);
   ledger.perWorker[workerName] = stamps.slice(-MAX_TIMESTAMPS_PER_WORKER);
 
   // Bound the event index: drop oldest arbitrary entries past the cap.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,21 @@ const PUBLIC_PATHS = [
   '/api/agentteams/setup/status',
 ];
 
+const USER_NAME_HEADER = 'x-agentteams-user';
+const USER_LEVEL_HEADER = 'x-agentteams-user-level';
+
+function withUserHeaders(request: NextRequest, user: { name: string; level: number } | null): Headers {
+  const headers = new Headers(request.headers);
+  if (user) {
+    headers.set(USER_NAME_HEADER, user.name);
+    headers.set(USER_LEVEL_HEADER, String(user.level));
+  } else {
+    headers.delete(USER_NAME_HEADER);
+    headers.delete(USER_LEVEL_HEADER);
+  }
+  return headers;
+}
+
 // Backward compatibility for embedded mode: old /dashboard/ URLs redirect to root
 // because the dashboard is now served at "/" when NEXT_PUBLIC_BASE_PATH is empty.
 export async function middleware(request: NextRequest) {
@@ -52,10 +67,14 @@ export async function middleware(request: NextRequest) {
       return res;
     }
 
-    const valid = await validateHigressSession(request);
+    const { valid, user } = await validateHigressSession(request);
     if (!valid) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    // Forward the resolved identity downstream so route handlers (and the
+    // Controller proxy) can apply server-side RBAC + audit attribution.
+    return NextResponse.next({ request: { headers: withUserHeaders(request, user) } });
   }
 
   return NextResponse.next();


### PR DESCRIPTION
# PR: org.agentteams.run v1 协议 + 服务端治理完整化 + ChatRoom 重构 Phase 1

## 概述

六个独立可合并的 commit，源于对本仓库的 review 与后续治理补完：

- `ccd51c4` —— `org.agentteams.run` v1 协议契约 + 工具调用结构化去重
- `0dd49cf` —— 服务端 JSONL 审计 + RBAC（workers/teams/managers/humans）+ 用户身份注入
- `f0d9878` —— ChatRoom.tsx 拆分 Phase 1（draft / upload / drag-drop 三个 hook）
- `c9594ac` —— 文档与 MEMORY 同步
- `a225e24` —— RBAC 扩展到全部写路由（storage / skills / projects / gateway / debug-log / wen-tian / mcps / worker 文件 / team 文件 / restart）
- `8e7efae` —— 审计 viewer 前端（admin-only 表格 + 实体过滤 + 15s 轮询）

85 文件 / +3000 / -175，139 测试文件 / 1215 用例通过（新增 51 个，0 回归）。

---

## 提交 1 · `feat(a2ui): introduce org.agentteams.run v1 protocol contract`

Dashboard 当前通过 13 级文本启发式规则解析 Matrix runtime 消息，脆弱且无法承载跨消息运行上下文。本次规范化：

- 新增 `src/lib/a2ui/protocol.ts`：`RuntimeBlock` discriminated union（text/thinking/tool_call/confirmation/error）+ 版本探测 + 字段规范化工具
- `parseAgentRunBlocks` 拆为 v1 规范化路径与 v0 透传路径；未知版本降级到现有文本启发式（不丢消息）
- v1 tool_call 块补齐 `tool_call_id` / `status` / `started_at` / `finished_at`
- v1 confirmation 块强制 `confirmation_id`（为 Tool Guard 协议化铺路）
- `recordToolCalls` 新增可选 `structuredKeys` 参数：v1 块含 `tool_call_id` 时按 id 为权威去重键，跨设备/跨修订一致；纯事件路径行为不变

测试：parser v1 11 例 + tool-call-counter 结构化 7 例。

## 提交 2 · `feat(audit): server-side JSONL audit log + RBAC enforcement on writes`

客户端 `useAuditStore` 仅 localStorage，运维可清空，治理形同虚设。RBAC 引擎（`rbac-engine.ts`）写完了但只在 UI 展示，middleware 只校验"有无 Higress session"——任何持会话者都可执行任意写操作。本次端到端接通治理：

- `src/lib/audit-log.ts`：append-only JSONL，10 MB 自动 rotate，保留 30 份归档，路径可通过 `AGENTTEAMS_AUDIT_LOG_PATH` 覆盖
- `validateHigressSession` 返回 `{ valid, user }`（从 `/v1/consumers` 提取 name/level），缓存结构向后兼容
- middleware 通过验证时注入 `x-agentteams-user` / `x-agentteams-user-level`，proxy-helper 透传给 Controller
- `src/lib/server-auth.ts` 提供 `enforceServerSideRbac`，workers/teams/managers/humans 的写操作路由（POST/PUT/DELETE/wake/sleep/ensure-ready）调用 rbac-engine，403 写入 warning 审计
- `src/app/api/agentteams/audit/route.ts`：POST 镜像客户端审计，GET 列表（admin-only，时间/entity 过滤）
- `auditMutation` 客户端 helper 自动向服务端镜像审计（失败仅 warn，不阻塞 mutation）

测试：audit-log 6 例 + server-auth 5 例 + audit API 5 例 + worker RBAC 3 例 + access/plugins mock 适配。

## 提交 3 · `refactor(chat): extract draft persistence, file upload, drag-drop from ChatRoom`

ChatRoom.tsx 1040 行，承担 15+ useState、20+ handler、5 个独立关注点。Phase 1 抽出三个高内聚自包含模块：

- `usePersistedDraft(roomId)`：每房间草稿持久化，含 `setValueLocal` 不写 storage 的接口（保留 edit session 回填不泄漏的语义）
- `useFileUpload(input)`：file → Matrix mxc → m.image/m.file 发送状态机
- `useFileDropZone({ onFiles })` + `<DragDropOverlay>`：容器级 drag-and-drop

ChatRoom.tsx → 966 行（-74）。ChatRoom.test.tsx **不改**即通过（行为不变证明）。

测试：usePersistedDraft 7 例 + useFileUpload 5 例 + useFileDropZone 4 例 + DragDropOverlay 3 例。

## 提交 4 · `docs: document server-side governance + runtime protocol + ChatRoom split`

- ARCHITECTURE.md：新增"服务端治理"与"运行时消息协议"两段
- INDEX.md：列出三个新 spec
- MEMORY.md：记录关键运维约定（`AGENTTEAMS_AUDIT_LOG_PATH`、RBAC 范围、structuredKeys 用法、usePersistedDraft.setValueLocal 语义）

## 提交 5 · `feat(rbac): extend enforcement to all write routes`

把 RBAC 从 17 个写路由扩展到 46 个，覆盖 storage / skills / projects / gateway / debug-log / wen-tian / mcps / worker 文件 / team 文件 / restart：

- 新增 `enforceLevelOnlyRbac` 处理无资源范围概念的全局资源
- 新增 `checkPermissionByLevel`（rbac-engine）支持纯等级决策
- 403 按 entity_type='system' / severity='warning' 写 audit 记录

测试：5 个新增 server-auth 用例（enforceLevelOnlyRbac 全路径）。Full 0 回归。

仍**未**覆盖的写路由（后续 PR）：
- `/api/agentteams/setup/*` —— 装机入口，必须在 RBAC 前可达
- `/api/agentteams/packages/*` —— Worker package 上传，由 Controller 侧 gate
- `/api/agentteams/models/probe` —— 只读诊断
- 全部 GET 路由 —— 读 RBAC 暂保持开放

## 提交 6 · `feat(audit): add admin-only audit viewer section`

服务端审计闭环的最后一块——让治理事件可见：

- `useAuditEvents`（TanStack Query）封装 `GET /api/agentteams/audit`，15s 轮询；403 不抛错而是返回 `{ success: false, error }`
- `AuditSection` 渲染表格：entity_type 过滤 chips、severity badges、actor+level+source IP、标准化 action label（`rbac.deny.<action>` / `*-failed`）
- nav-items + sectionMap 注册新入口
- 非 admin 看到友好提示卡（"需要管理员权限" + "该视图仅对权限等级 ≥ 3 的管理员开放"）

测试：3 例（403 notice / empty state / 多事件渲染）。

---

## 兼容性 & 风险

- **协议层**：v0 路径行为完全保留；v1 路径在生产者出现前不会被触发，零运行时影响
- **服务端治理**：middleware 增加 identity 注入、proxy-helper 透传 2 个白名单头，均为加性变更；现有路由测试 0 回归
- **审计路径**：默认 `${cwd}/logs/audit.log.jsonl`；容器部署建议挂载 `/var/log/agentteams` 卷并设 `AGENTTEAMS_AUDIT_LOG_PATH=/var/log/agentteams/audit.log.jsonl`
- **AGENTTEAMS_AUTH_DISABLED=true**：现有逃生舱行为不变；server-auth 在无 identity 时默认放行（由 middleware 网关决策）
- **ChatRoom**：仅删除死代码并替换为 hook 调用，行为字节对齐
- **RBAC 扩展**：未覆盖的写路由集中在 setup / packages / probe；GET 路由保持开放，详见提交 5 说明

## Reviewer 建议关注点

1. `src/lib/audit-log.ts` rotate 策略（10MB / 30 份）是否匹配运维预期
2. `enforceLevelOnlyRbac` 用 level-only 判断全局资源是否过宽？是否需要引入"按资源 ownership"的更细粒度（如 storage bucket 列表允许，但具体 bucket 需 ACL）
3. `enforceServerSideRbac` 的 action 映射（commit 2 列出的范围）是否准确
4. `useAuditEvents` 把 403 当成 data 返回而非抛错，是否与项目其它错误处理约定一致
5. `usePersistedDraft.setValueLocal` 的使用面（仅 edit session 回填），是否同意这个 escape hatch 设计