### PR TITLE
feat(auth): multi-user login with server-side session store (dual track)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,6 @@ AGENTTEAMS_AUTH_TOKEN_FILE=/var/run/agentteams/cli-token
 # If missing/short, login fails closed (no session can be created).
 DASHBOARD_SESSION_SECRET=
 
-# The Human CR name that maps to dashboard level 3 (Admin) when the Higress
-# Console login succeeds (deployment assumption: Console admin == L1 human).
-DASHBOARD_L1_HUMAN=luo
-
 # Set to 1 when the dashboard is served over HTTPS (adds the Secure cookie
 # flag). Leave unset for LAN HTTP deployments.
 # DASHBOARD_COOKIE_SECURE=1

--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,30 @@ NEXT_PUBLIC_AGENTTEAMS_CONTROLLER_URL=http://127.0.0.1:8090
 # AGENTTEAMS_AUTH_TOKEN=
 AGENTTEAMS_AUTH_TOKEN_FILE=/var/run/agentteams/cli-token
 
-# Escape hatch: disable the Higress browser-session gate on /api/agentteams/*.
+# Escape hatch: disable the browser-session gate on /api/agentteams/*.
 # Only for environments without a Higress Console in front of the dashboard
 # (local dev / hosted previews); production must keep it unset so the gate stays on.
 # While disabled, middleware injects the synthetic identity below so server-side
 # RBAC evaluation and audit read/write attribution keep working.
+# (M19: the gate is now the dashboard session, not the Higress Console probe.)
 # AGENTTEAMS_AUTH_DISABLED=true
 # AGENTTEAMS_LOCAL_USER=local-admin
 # AGENTTEAMS_LOCAL_USER_LEVEL=3
+
+# --- Multi-user login (M19) ---
+# REQUIRED for login: the HMAC secret for the dashboard session cookie.
+# Generate once and keep it stable across container rebuilds:
+#   openssl rand -hex 32
+# If missing/short, login fails closed (no session can be created).
+DASHBOARD_SESSION_SECRET=
+
+# The Human CR name that maps to dashboard level 3 (Admin) when the Higress
+# Console login succeeds (deployment assumption: Console admin == L1 human).
+DASHBOARD_L1_HUMAN=luo
+
+# Set to 1 when the dashboard is served over HTTPS (adds the Secure cookie
+# flag). Leave unset for LAN HTTP deployments.
+# DASHBOARD_COOKIE_SECURE=1
 
 # Matrix homeserver URL default (can be overridden in UI).
 # In the embedded topology the dashboard container reaches Tuwunel at

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ server.log
 # Agent configurations
 .claude/
 .agents/
+dist/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,7 @@ const eslintConfig = [...nextCoreWebVitals, ...nextTypescript, {
     "@typescript-eslint/no-unused-vars": "off",
   },
 }, {
-  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts", "examples/**", "skills", "tools/**"]
+  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts", "examples/**", "skills", "tools/**", "dist/**"]
 }];
 
 export default eslintConfig;

--- a/install/agentteams-dashboard.sh
+++ b/install/agentteams-dashboard.sh
@@ -72,7 +72,6 @@ AGENTTEAMS_AUTH_TOKEN=${AGENTTEAMS_AUTH_TOKEN:-}
 AGENTTEAMS_ADMIN_USER=${AGENTTEAMS_ADMIN_USER:-}
 AGENTTEAMS_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD:-}
 DASHBOARD_SESSION_SECRET=${DASHBOARD_SESSION_SECRET:-}
-DASHBOARD_L1_HUMAN=${DASHBOARD_L1_HUMAN:-luo}
 EOF
   chmod 600 "${_tmp}"
   mv -f "${_tmp}" "${ENV_FILE}"
@@ -222,7 +221,6 @@ wizard() {
     DASHBOARD_SESSION_SECRET="$(openssl rand -hex 32)"
   fi
   info "DASHBOARD_SESSION_SECRET ready (persisted in ${ENV_FILE}, mode 600)."
-  prompt_value DASHBOARD_L1_HUMAN "L1 human (Console admin) name" "luo"
 
   # Detect Higress Console URL from running container (for shared auth with Higress)
   # Use internal Docker network URL (container:port) — works for dashboard on the same network.
@@ -420,7 +418,6 @@ recreate_container() {
   env_args+=(-e MATRIX_HOMESERVER_ALLOWLIST="agentteams-controller,matrix-local.agentteams.io,matrix.org")
   [ -n "${AGENTTEAMS_AUTH_TOKEN:-}" ] && env_args+=(-e AGENTTEAMS_AUTH_TOKEN="${AGENTTEAMS_AUTH_TOKEN}")
   env_args+=(-e DASHBOARD_SESSION_SECRET="${DASHBOARD_SESSION_SECRET:-}")
-  env_args+=(-e DASHBOARD_L1_HUMAN="${DASHBOARD_L1_HUMAN:-luo}")
   [ -n "${AGENTTEAMS_ADMIN_USER:-}" ] && env_args+=(-e AGENTTEAMS_ADMIN_USER="${AGENTTEAMS_ADMIN_USER}")
   [ -n "${AGENTTEAMS_ADMIN_PASSWORD:-}" ] && env_args+=(-e AGENTTEAMS_ADMIN_PASSWORD="${AGENTTEAMS_ADMIN_PASSWORD}")
   [ -n "${AGENTTEAMS_FS_ENDPOINT:-}" ] && env_args+=(-e AGENTTEAMS_FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT}")

--- a/install/agentteams-dashboard.sh
+++ b/install/agentteams-dashboard.sh
@@ -71,6 +71,8 @@ AGENTTEAMS_DEFAULT_MODEL=${AGENTTEAMS_DEFAULT_MODEL:-}
 AGENTTEAMS_AUTH_TOKEN=${AGENTTEAMS_AUTH_TOKEN:-}
 AGENTTEAMS_ADMIN_USER=${AGENTTEAMS_ADMIN_USER:-}
 AGENTTEAMS_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD:-}
+DASHBOARD_SESSION_SECRET=${DASHBOARD_SESSION_SECRET:-}
+DASHBOARD_L1_HUMAN=${DASHBOARD_L1_HUMAN:-luo}
 EOF
   chmod 600 "${_tmp}"
   mv -f "${_tmp}" "${ENV_FILE}"
@@ -213,6 +215,14 @@ wizard() {
   prompt_value AGENTTEAMS_CONTROLLER_URL "AgentTeams Controller URL" "${ctrl_url}"
 
   prompt_value NEXT_PUBLIC_MATRIX_API_URL "Matrix Homeserver URL" "http://agentteams-controller:6167"
+
+  # Multi-user session secret (M19): generated once and persisted so container
+  # rebuilds keep the same secret (a changed secret invalidates all sessions).
+  if [ -z "${DASHBOARD_SESSION_SECRET:-}" ]; then
+    DASHBOARD_SESSION_SECRET="$(openssl rand -hex 32)"
+  fi
+  info "DASHBOARD_SESSION_SECRET ready (persisted in ${ENV_FILE}, mode 600)."
+  prompt_value DASHBOARD_L1_HUMAN "L1 human (Console admin) name" "luo"
 
   # Detect Higress Console URL from running container (for shared auth with Higress)
   # Use internal Docker network URL (container:port) — works for dashboard on the same network.
@@ -409,6 +419,8 @@ recreate_container() {
   env_args+=(-e AGENTTEAMS_AI_GATEWAY_ADMIN_ALLOWED_HOSTS="${AGENTTEAMS_AI_GATEWAY_ADMIN_ALLOWED_HOSTS:-}")
   env_args+=(-e MATRIX_HOMESERVER_ALLOWLIST="agentteams-controller,matrix-local.agentteams.io,matrix.org")
   [ -n "${AGENTTEAMS_AUTH_TOKEN:-}" ] && env_args+=(-e AGENTTEAMS_AUTH_TOKEN="${AGENTTEAMS_AUTH_TOKEN}")
+  env_args+=(-e DASHBOARD_SESSION_SECRET="${DASHBOARD_SESSION_SECRET:-}")
+  env_args+=(-e DASHBOARD_L1_HUMAN="${DASHBOARD_L1_HUMAN:-luo}")
   [ -n "${AGENTTEAMS_ADMIN_USER:-}" ] && env_args+=(-e AGENTTEAMS_ADMIN_USER="${AGENTTEAMS_ADMIN_USER}")
   [ -n "${AGENTTEAMS_ADMIN_PASSWORD:-}" ] && env_args+=(-e AGENTTEAMS_ADMIN_PASSWORD="${AGENTTEAMS_ADMIN_PASSWORD}")
   [ -n "${AGENTTEAMS_FS_ENDPOINT:-}" ] && env_args+=(-e AGENTTEAMS_FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT}")

--- a/src/app/api/agentteams/proxy-helper.test.ts
+++ b/src/app/api/agentteams/proxy-helper.test.ts
@@ -1,8 +1,14 @@
 // @vitest-environment node
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { NextRequest } from 'next/server';
 import { proxyToAgentTeams } from './proxy-helper';
+import {
+  SESSION_COOKIE_NAME,
+  __resetSessionStoreForTests,
+  createSession,
+  destroySession,
+} from '@/lib/dashboard-session';
 
 let server: Server;
 let controllerUrl: string;
@@ -123,5 +129,102 @@ describe('proxyToAgentTeams passthroughHeaders', () => {
     expect(res.headers.get('content-disposition')).toBe(
       "attachment; filename*=UTF-8''%E6%96%B9%E6%A1%88.pdf",
     );
+  });
+});
+
+describe('proxyToAgentTeams per-session credential (M19 dual track)', () => {
+  let authServer: Server;
+  let authUrl: string;
+  const captured: Array<{ authorization: string | null; user: string | null; level: string | null }> = [];
+
+  beforeAll(async () => {
+    authServer = createServer((req, res) => {
+      captured.push({
+        authorization: (req.headers['authorization'] as string) ?? null,
+        user: (req.headers['x-agentteams-user'] as string) ?? null,
+        level: (req.headers['x-agentteams-user-level'] as string) ?? null,
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{}');
+    });
+    await new Promise<void>((resolve) => authServer.listen(0, '127.0.0.1', resolve));
+    const address = authServer.address();
+    if (!address || typeof address === 'string') throw new Error('no server address');
+    authUrl = `http://127.0.0.1:${address.port}`;
+    process.env.DASHBOARD_SESSION_SECRET = 'e'.repeat(64);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => authServer.close(() => resolve()));
+    delete process.env.DASHBOARD_SESSION_SECRET;
+  });
+
+  afterEach(() => {
+    captured.length = 0;
+    __resetSessionStoreForTests();
+    delete process.env.AGENTTEAMS_AUTH_TOKEN;
+    delete process.env.AGENTTEAMS_AUTH_TOKEN_FILE;
+  });
+
+  function requestWith(cookie: string | null, extra?: Record<string, string>) {
+    const headers = new Headers();
+    if (cookie) headers.set('cookie', cookie);
+    for (const [k, v] of Object.entries(extra ?? {})) headers.set(k, v);
+    return new NextRequest('http://localhost/api/agentteams/teams', { headers });
+  }
+
+  async function proxy(request: NextRequest) {
+    return proxyToAgentTeams(request, authUrl, '/api/v1/teams', { forwardBody: false, method: 'GET' });
+  }
+
+  it('L2 session → forwards the session Matrix token; browser Authorization is ignored', async () => {
+    process.env.AGENTTEAMS_AUTH_TOKEN = 'sa-admin-token';
+    const { cookieValue } = createSession({
+      user: 'sunzong',
+      crLevel: 2,
+      credential: { kind: 'matrix', token: 'syt_l2_token' },
+    });
+    await proxy(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`, { authorization: 'Bearer browser-forged' }));
+    expect(captured[0].authorization).toBe('Bearer syt_l2_token');
+  });
+
+  it('L1 session (SA credential) → forwards the SA env token; browser Authorization is ignored', async () => {
+    process.env.AGENTTEAMS_AUTH_TOKEN = 'sa-admin-token';
+    const { cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    await proxy(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`, { authorization: 'Bearer browser-forged' }));
+    expect(captured[0].authorization).toBe('Bearer sa-admin-token');
+  });
+
+  it('no session (AUTH_DISABLED path) → falls back to the SA env token', async () => {
+    process.env.AGENTTEAMS_AUTH_TOKEN = 'sa-admin-token';
+    await proxy(requestWith(null));
+    expect(captured[0].authorization).toBe('Bearer sa-admin-token');
+  });
+
+  it('no server-side credential at all → legacy browser header fallback', async () => {
+    await proxy(requestWith(null, { authorization: 'Bearer legacy-header-token' }));
+    expect(captured[0].authorization).toBe('Bearer legacy-header-token');
+  });
+
+  it('forwards the server-resolved x-agentteams identity headers', async () => {
+    const { cookieValue } = createSession({ user: 'sunzong', crLevel: 2, credential: { kind: 'matrix', token: 't' } });
+    await proxy(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`, {
+      'x-agentteams-user': 'sunzong',
+      'x-agentteams-user-level': '2',
+    }));
+    expect(captured[0].user).toBe('sunzong');
+    expect(captured[0].level).toBe('2');
+  });
+
+  it('a forged cookie for a destroyed session sends no session token (SA fallback only)', async () => {
+    process.env.AGENTTEAMS_AUTH_TOKEN = 'sa-admin-token';
+    const { sessionId, cookieValue } = createSession({
+      user: 'sunzong',
+      crLevel: 2,
+      credential: { kind: 'matrix', token: 'syt_l2_token' },
+    });
+    destroySession(sessionId);
+    await proxy(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`, { authorization: 'Bearer browser-forged' }));
+    expect(captured[0].authorization).toBe('Bearer sa-admin-token');
   });
 });

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -115,7 +115,10 @@ export async function proxyToAgentTeams(
     // browser header is only a fallback when no server-side credential exists
     // at all (legacy dev setups).
     const session = getSessionFromRequest(request);
-    const sessionToken = session?.credential.kind === 'matrix' ? session.credential.token : undefined;
+    const sessionToken =
+      session?.credential.kind === 'matrix' || session?.credential.kind === 'controller-token'
+        ? session.credential.token
+        : undefined;
     const saToken = await getAuthToken();
     const authToken = sessionToken || saToken || (
       request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') || undefined

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -115,10 +115,7 @@ export async function proxyToAgentTeams(
     // browser header is only a fallback when no server-side credential exists
     // at all (legacy dev setups).
     const session = getSessionFromRequest(request);
-    const sessionToken =
-      session?.credential.kind === 'matrix' || session?.credential.kind === 'controller-token'
-        ? session.credential.token
-        : undefined;
+    const sessionToken = session?.credential.kind === 'matrix' ? session.credential.token : undefined;
     const saToken = await getAuthToken();
     const authToken = sessionToken || saToken || (
       request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') || undefined

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -1,5 +1,6 @@
 // Shared proxy helper for AgentTeams API routes
 import { NextRequest, NextResponse } from 'next/server';
+import { getSessionFromRequest } from '@/lib/dashboard-session';
 
 const TIMEOUT_MS = 10000;
 
@@ -104,21 +105,28 @@ export async function proxyToAgentTeams(
       headers: {},
     };
 
-    // In cluster mode the dashboard must authenticate to the controller using its
-    // own service-account token. When SA token is configured, NEVER trust the
-    // browser-supplied Authorization header to prevent token injection attacks.
-    // Only fall back to the incoming header when no server-side token exists at all.
+    // Per-session Controller credential (M19 dual-track):
+    // - L2 session → the user's own Matrix access token, held in the
+    //   server-side session store (A2 chain scopes the request to the user's
+    //   teams; token never touches the browser).
+    // - L1 session / AUTH_DISABLED → the admin SA token.
+    // When a server-side credential exists, NEVER trust the browser-supplied
+    // Authorization header (token-injection protection, upstream #89). The
+    // browser header is only a fallback when no server-side credential exists
+    // at all (legacy dev setups).
+    const session = getSessionFromRequest(request);
+    const sessionToken = session?.credential.kind === 'matrix' ? session.credential.token : undefined;
     const saToken = await getAuthToken();
-    const authToken = saToken || (
+    const authToken = sessionToken || saToken || (
       request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') || undefined
     );
     if (authToken) {
       (fetchOptions.headers as Record<string, string>)['authorization'] = `Bearer ${authToken}`;
     }
 
-    // Forward the server-resolved identity (set by middleware from the Higress
-    // session) so the controller can attribute write actions to the right user
-    // without trusting browser-supplied headers.
+    // Forward the server-resolved identity (set by middleware from the
+    // dashboard session) so the controller can attribute write actions to the
+    // right user without trusting browser-supplied headers.
     for (const name of ['x-agentteams-user', 'x-agentteams-user-level']) {
       const value = request.headers.get(name);
       if (value) (fetchOptions.headers as Record<string, string>)[name] = value;

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -45,6 +45,13 @@ function successfulConsoleLogin() {
   };
 }
 
+function failedConsoleLogin() {
+  return {
+    response: new Response(null, { status: 401 }),
+    body: { error: 'bad' },
+  };
+}
+
 /** fetch mock router: SA human lookup + Matrix login, default 401. */
 function installFetchMock(opts: {
   humans?: Record<string, { status?: number; body?: Record<string, unknown> }>;
@@ -83,7 +90,6 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     __resetSessionStoreForTests();
     vi.stubEnv('DASHBOARD_SESSION_SECRET', SECRET);
     vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'direct');
-    vi.stubEnv('DASHBOARD_L1_HUMAN', '');
     vi.stubEnv('DASHBOARD_COOKIE_SECURE', '');
     mockCallHigressConsole.mockReset();
     mockForwardCookies.mockReset();
@@ -98,79 +104,39 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     vi.unstubAllGlobals();
   });
 
-  it('L1: Console login + Human CR level 1 → level-3 session, SA credential, both cookies', async () => {
+  it('L1: Console login → level-3 session, identity = the Console username (admin ≠ luo), SA credential, both cookies', async () => {
     mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-    installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 1, accessibleTeams: ['a', 'b'] } } },
-      matrixLogin: { status: 401 },
-    });
+    const fetchMock = installFetchMock({ matrixLogin: { status: 401 } });
 
     const response = await POST(request({ username: 'admin', password: 'password' }));
     expect(response.status).toBe(200);
     const data = await responseJson(response);
     expect(data.success).toBe(true);
-    expect(data.user).toEqual({ username: 'luo', level: 3 });
+    // Identity is the Console account itself — NOT remapped to a Human CR.
+    expect(data.user).toEqual({ username: 'admin', level: 3 });
     expect(data.mode).toBe('higress');
     expect(data.matrix).toBeNull();
+
+    // No Human CR lookup on the Console track.
+    expect(fetchMock.mock.calls.every(([url]) => !String(url).includes('/api/v1/humans/'))).toBe(true);
 
     const cookies = response.headers.getSetCookie();
     expect(cookies.some((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`))).toBe(true);
     expect(cookies.some((c) => c.startsWith('_hi_sess='))).toBe(true);
   });
 
-  it('L1: honors DASHBOARD_L1_HUMAN for the CR lookup', async () => {
-    vi.stubEnv('DASHBOARD_L1_HUMAN', 'luo');
-    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-    const fetchMock = installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
-      matrixLogin: { status: 401 },
-    });
-
-    const response = await POST(request({ username: 'admin', password: 'password' }));
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://controller.test:8090/api/v1/humans/luo',
-      expect.objectContaining({ headers: { Authorization: 'Bearer sa-token' } }),
-    );
-  });
-
-  it('L1: Console ok but CR missing → 503 misconfigured (fail loudly)', async () => {
-    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-    installFetchMock({ humans: {}, matrixLogin: { status: 401 } });
-
-    const response = await POST(request({ username: 'admin', password: 'password' }));
-    expect(response.status).toBe(503);
-  });
-
-  it('L1: Console ok but CR is level 2 → 503 (not silently demoted)', async () => {
-    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-    installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 2 } } },
-      matrixLogin: { status: 401 },
-    });
-
-    const response = await POST(request({ username: 'admin', password: 'password' }));
-    expect(response.status).toBe(503);
-  });
-
   it('L1: session secret missing → fail closed (503, no cookie)', async () => {
     vi.stubEnv('DASHBOARD_SESSION_SECRET', '');
     mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-    installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
-      matrixLogin: { status: 401 },
-    });
+    installFetchMock({ matrixLogin: { status: 401 } });
 
     const response = await POST(request({ username: 'admin', password: 'password' }));
     expect(response.status).toBe(503);
     expect(response.headers.getSetCookie()).toEqual([]);
   });
 
-  it('L2: Console 401 + Matrix login + CR level 2 → level-2 session, matrix mode, no Console cookie', async () => {
-    mockCallHigressConsole.mockResolvedValue({
-      response: new Response(null, { status: 401 }),
-      body: { error: 'bad' },
-    });
+  it('Matrix: Console 401 + Matrix login + CR level 2 (sunzong) → level-2 session, scoped, matrix mode, no Console cookie', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
     installFetchMock({
       humans: { sunzong: { body: { name: 'sunzong', permissionLevel: 2, accessibleTeams: ['biz-team'] } } },
       matrixLogin: {
@@ -193,25 +159,61 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(cookies.every((c) => !c.includes('syt_l2_token'))).toBe(true);
   });
 
-  it('L2: CR level 1 (admin human) via Matrix → 401 (L1 must use the Console track)', async () => {
-    mockCallHigressConsole.mockResolvedValue({
-      response: new Response(null, { status: 401 }),
-      body: { error: 'bad' },
-    });
+  it('Matrix: CR level 1 (luo) → level-3 session, full access, NO team restriction', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
     installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
-      matrixLogin: { body: { access_token: 't', user_id: '@luo:sat.example', device_id: 'D' } },
+      humans: {
+        luo: {
+          body: { name: 'luo', permissionLevel: 1, accessibleTeams: ['sysdev-team', 'embedded-team'] },
+        },
+      },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
+      },
     });
 
-    const response = await POST(request({ username: 'luo', password: 'x' }));
+    const response = await POST(request({ username: 'luo', password: 'matrix-password' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.success).toBe(true);
+    expect(data.user).toEqual({ username: 'luo', level: 3 });
+    expect(data.mode).toBe('matrix');
+    expect((data.matrix as { accessToken?: string }).accessToken).toBe('syt_l1_token');
+  });
+
+  it('Matrix: CR level 3 (observer) → level-1 session', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
+    installFetchMock({
+      humans: { watcher: { body: { name: 'watcher', permissionLevel: 3 } } },
+      matrixLogin: {
+        body: { access_token: 't3', user_id: '@watcher:sat.example', device_id: 'D3' },
+      },
+    });
+
+    const response = await POST(request({ username: 'watcher', password: 'x' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.user).toEqual({ username: 'watcher', level: 1 });
+    expect(data.mode).toBe('matrix');
+  });
+
+  it('Matrix: login ok but no Human CR (non-human account) → 401 (no level leak)', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
+    installFetchMock({
+      humans: {},
+      matrixLogin: {
+        body: { access_token: 't', user_id: '@randomuser:sat.example', device_id: 'D' },
+      },
+    });
+
+    const response = await POST(request({ username: 'randomuser', password: 'x' }));
     expect(response.status).toBe(401);
+    const data = await responseJson(response);
+    expect(data.success).toBe(false);
   });
 
   it('both tracks fail → 401', async () => {
-    mockCallHigressConsole.mockResolvedValue({
-      response: new Response(null, { status: 401 }),
-      body: { error: 'bad' },
-    });
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
     installFetchMock({ humans: {}, matrixLogin: { status: 401 } });
 
     const response = await POST(request({ username: 'nobody', password: 'x' }));
@@ -222,25 +224,18 @@ describe('POST /api/auth/login (dual track, M19)', () => {
 
   it('never calls /system/init (auto-registration removed — fresh-Console privilege escalation)', async () => {
     mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-    installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
-      matrixLogin: { status: 401 },
-    });
+    installFetchMock({ matrixLogin: { status: 401 } });
 
     await POST(request({ username: 'admin', password: 'password' }));
     expect(mockCallHigressConsole).toHaveBeenCalledTimes(1);
-    expect(mockCallHigressConsole).not.toHaveBeenCalledWith(
-      '/system/init',
-      expect.anything(),
-    );
+    expect(mockCallHigressConsole).not.toHaveBeenCalledWith('/system/init', expect.anything());
   });
 
   it('external mode: no init, no Matrix token returned, session still created for L1', async () => {
     vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'external');
     mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
     installFetchMock({
-      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
-      matrixLogin: { body: { access_token: 'secret-matrix', user_id: '@luo:sat.example', device_id: 'D' } },
+      matrixLogin: { body: { access_token: 'secret-matrix', user_id: '@admin:sat.example', device_id: 'D' } },
     });
 
     const response = await POST(request({ username: 'admin', password: 'password' }));

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -56,7 +56,6 @@ function failedConsoleLogin() {
 function installFetchMock(opts: {
   humans?: Record<string, { status?: number; body?: Record<string, unknown> }>;
   matrixLogin?: { status?: number; body?: Record<string, unknown> };
-  teamsCheck?: { status?: number };
 }) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -68,10 +67,6 @@ function installFetchMock(opts: {
         status: spec.status ?? 200,
         headers: { 'content-type': 'application/json' },
       });
-    }
-    if (url.includes('/api/v1/teams')) {
-      const status = opts.teamsCheck?.status ?? 200;
-      return new Response(null, { status, headers: { 'content-type': 'application/json' } });
     }
     if (url.includes('/_matrix/client/v3/login')) {
       const spec = opts.matrixLogin ?? { status: 401 };
@@ -149,10 +144,15 @@ describe('POST /api/auth/login (dual track, M19)', () => {
       },
     });
 
-    // L2 users ignore a pasted controller token (their Matrix token is the
-    // data-plane credential) — passing one must not break the login.
+    // L2 users ignore admin credentials (their own Matrix token is the
+    // data-plane credential) — passing them must not break the login.
     const response = await POST(
-      request({ username: 'sunzong', password: 'matrix-password', controllerToken: 'should-be-ignored' }),
+      request({
+        username: 'sunzong',
+        password: 'matrix-password',
+        adminUsername: 'should-be-ignored',
+        adminPassword: 'x',
+      }),
     );
     expect(response.status).toBe(200);
     const data = await responseJson(response);
@@ -168,9 +168,13 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(cookies.every((c) => !c.includes('syt_l2_token'))).toBe(true);
   });
 
-  it('Matrix: CR level 1 (luo) + valid controller token → level-3 session, matrix chat token kept', async () => {
-    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
-    const fetchMock = installFetchMock({
+  it('Matrix: CR level 1 + valid admin account credentials → level-3 session, SA data credential, matrix chat token kept', async () => {
+    // First Console call = the user's own (fails → fall through to Matrix);
+    // second = the admin account verification (succeeds).
+    mockCallHigressConsole
+      .mockResolvedValueOnce(failedConsoleLogin())
+      .mockResolvedValueOnce(successfulConsoleLogin());
+    installFetchMock({
       humans: {
         luo: {
           body: { name: 'luo', permissionLevel: 1, accessibleTeams: ['sysdev-team', 'embedded-team'] },
@@ -179,11 +183,15 @@ describe('POST /api/auth/login (dual track, M19)', () => {
       matrixLogin: {
         body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
       },
-      teamsCheck: { status: 200 },
     });
 
     const response = await POST(
-      request({ username: 'luo', password: 'matrix-password', controllerToken: 'cli-admin-token' }),
+      request({
+        username: 'luo',
+        password: 'matrix-password',
+        adminUsername: 'admin',
+        adminPassword: 'admin-password',
+      }),
     );
     expect(response.status).toBe(200);
     const data = await responseJson(response);
@@ -192,13 +200,17 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(data.mode).toBe('matrix');
     // The Matrix token is still returned for the chat tab.
     expect((data.matrix as { accessToken?: string }).accessToken).toBe('syt_l1_token');
-    // The pasted token was verified against the Controller.
-    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/api/v1/teams'))).toBe(true);
-    // The pasted admin token must never leak into a cookie.
-    expect(response.headers.getSetCookie().every((c) => !c.includes('cli-admin-token'))).toBe(true);
+    // Console was hit twice: user login attempt + admin verification.
+    expect(mockCallHigressConsole).toHaveBeenCalledTimes(2);
+    expect(mockCallHigressConsole).toHaveBeenLastCalledWith(
+      '/session/login',
+      expect.objectContaining({ body: { username: 'admin', password: 'admin-password' } }),
+    );
+    // The admin verification's Console cookie must NOT be forwarded.
+    expect(response.headers.getSetCookie().every((c) => !c.startsWith('_hi_sess='))).toBe(true);
   });
 
-  it('Matrix: CR level 1 (luo) WITHOUT controller token → 400 with a clear hint', async () => {
+  it('Matrix: CR level 1 WITHOUT admin credentials → 400 with a clear hint', async () => {
     mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
     installFetchMock({
       humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
@@ -211,23 +223,25 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(response.status).toBe(400);
     const data = await responseJson(response);
     expect(data.success).toBe(false);
-    expect(String(data.error)).toContain('Controller');
+    expect(String(data.error)).toContain('管理员账号');
   });
 
-  it('Matrix: CR level 1 (luo) + INVALID controller token → 401', async () => {
+  it('Matrix: CR level 1 + WRONG admin credentials → 401 管理员账号验证失败', async () => {
+    // Both Console attempts fail (user + admin).
     mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
     installFetchMock({
       humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
       matrixLogin: {
         body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
       },
-      teamsCheck: { status: 401 },
     });
 
     const response = await POST(
-      request({ username: 'luo', password: 'matrix-password', controllerToken: 'wrong-token' }),
+      request({ username: 'luo', password: 'matrix-password', adminUsername: 'admin', adminPassword: 'wrong' }),
     );
     expect(response.status).toBe(401);
+    const data = await responseJson(response);
+    expect(String(data.error)).toContain('管理员账号验证失败');
   });
 
   it('Matrix: CR level 3 (observer) → level-1 session', async () => {

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,17 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST } from './route';
-import {
-  callHigressConsole,
-  forwardCookies,
-  getHigressConsoleURL,
-} from '../../higress/proxy-helper';
+import { callHigressConsole, forwardCookies } from '../../higress/proxy-helper';
+import { getAuthToken, getControllerUrl } from '../../agentteams/proxy-helper';
+import { __resetSessionStoreForTests, SESSION_COOKIE_NAME } from '@/lib/dashboard-session';
 
 vi.mock('../../higress/proxy-helper', () => ({
   callHigressConsole: vi.fn(),
-  forwardCookies: vi.fn(),
+  forwardCookies: vi.fn((from: Headers, to: Headers) => {
+    for (const cookie of from.getSetCookie()) {
+      to.append('set-cookie', cookie);
+    }
+  }),
   getHigressConsoleURL: vi.fn(() => 'http://higress-console:8080'),
-  higressErrorResponse: vi.fn(),
+}));
+
+vi.mock('../../agentteams/proxy-helper', () => ({
+  getAuthToken: vi.fn(async () => 'sa-token'),
+  getControllerUrl: vi.fn(() => 'http://controller.test:8090'),
 }));
 
 vi.mock('@/lib/homeserver-allowlist', () => ({
@@ -20,29 +26,71 @@ vi.mock('@/lib/homeserver-allowlist', () => ({
 
 const mockCallHigressConsole = vi.mocked(callHigressConsole);
 const mockForwardCookies = vi.mocked(forwardCookies);
-const mockGetHigressConsoleURL = vi.mocked(getHigressConsoleURL);
+const mockGetAuthToken = vi.mocked(getAuthToken);
+const mockGetControllerUrl = vi.mocked(getControllerUrl);
 
-function request() {
+const SECRET = 'c'.repeat(64);
+
+function request(body: Record<string, unknown>) {
   return new NextRequest('http://dashboard.test/api/auth/login', {
     method: 'POST',
-    body: JSON.stringify({ username: 'admin', password: 'password' }),
+    body: JSON.stringify(body),
   });
 }
 
 function successfulConsoleLogin() {
   return {
-    response: new Response(null, { status: 200 }),
+    response: new Response(null, { status: 200, headers: { 'set-cookie': '_hi_sess=abc; Path=/; HttpOnly' } }),
     body: { success: true },
   };
 }
 
-describe('POST /api/auth/login', () => {
+/** fetch mock router: SA human lookup + Matrix login, default 401. */
+function installFetchMock(opts: {
+  humans?: Record<string, { status?: number; body?: Record<string, unknown> }>;
+  matrixLogin?: { status?: number; body?: Record<string, unknown> };
+}) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    void init;
+    const humanMatch = url.match(/\/api\/v1\/humans\/([^/]+)$/);
+    if (humanMatch) {
+      const spec = opts.humans?.[decodeURIComponent(humanMatch[1])] ?? { status: 404 };
+      return new Response(spec.status ? null : JSON.stringify(spec.body ?? {}), {
+        status: spec.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.includes('/_matrix/client/v3/login')) {
+      const spec = opts.matrixLogin ?? { status: 401 };
+      return new Response(spec.status ? null : JSON.stringify(spec.body ?? {}), {
+        status: spec.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(null, { status: 401 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function responseJson(response: Response): Promise<Record<string, unknown>> {
+  return response.json();
+}
+
+describe('POST /api/auth/login (dual track, M19)', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+    __resetSessionStoreForTests();
+    vi.stubEnv('DASHBOARD_SESSION_SECRET', SECRET);
+    vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'direct');
+    vi.stubEnv('DASHBOARD_L1_HUMAN', '');
+    vi.stubEnv('DASHBOARD_COOKIE_SECURE', '');
     mockCallHigressConsole.mockReset();
     mockForwardCookies.mockReset();
-    mockGetHigressConsoleURL.mockReset();
-    mockGetHigressConsoleURL.mockReturnValue('http://higress-console:8080');
+    mockGetAuthToken.mockReset();
+    mockGetAuthToken.mockResolvedValue('sa-token');
+    mockGetControllerUrl.mockReset();
+    mockGetControllerUrl.mockReturnValue('http://controller.test:8090');
   });
 
   afterEach(() => {
@@ -50,44 +98,144 @@ describe('POST /api/auth/login', () => {
     vi.unstubAllGlobals();
   });
 
-  it('skips Console initialization in external Higress mode', async () => {
-    vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'external');
+  it('L1: Console login + Human CR level 1 → level-3 session, SA credential, both cookies', async () => {
     mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-
-    const response = await POST(request());
-
-    expect(response.status).toBe(200);
-    expect(mockCallHigressConsole).toHaveBeenCalledTimes(1);
-    expect(mockCallHigressConsole).toHaveBeenCalledWith('/session/login', {
-      method: 'POST',
-      body: { username: 'admin', password: 'password' },
-      consoleUrl: 'http://higress-console:8080',
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1, accessibleTeams: ['a', 'b'] } } },
+      matrixLogin: { status: 401 },
     });
-    expect(mockCallHigressConsole).not.toHaveBeenCalledWith(
-      '/system/init',
-      expect.anything(),
-    );
-    expect(fetch).not.toHaveBeenCalled();
+
+    const response = await POST(request({ username: 'admin', password: 'password' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.success).toBe(true);
+    expect(data.user).toEqual({ username: 'luo', level: 3 });
+    expect(data.mode).toBe('higress');
+    expect(data.matrix).toBeNull();
+
+    const cookies = response.headers.getSetCookie();
+    expect(cookies.some((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`))).toBe(true);
+    expect(cookies.some((c) => c.startsWith('_hi_sess='))).toBe(true);
   });
 
-  it('retains Console initialization for direct Higress mode', async () => {
-    vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'direct');
+  it('L1: honors DASHBOARD_L1_HUMAN for the CR lookup', async () => {
+    vi.stubEnv('DASHBOARD_L1_HUMAN', 'luo');
     mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
-
-    const response = await POST(request());
-
-    expect(response.status).toBe(200);
-    expect(mockCallHigressConsole).toHaveBeenCalledTimes(2);
-    expect(mockCallHigressConsole).toHaveBeenNthCalledWith(1, '/system/init', {
-      method: 'POST',
-      body: {
-        adminUser: {
-          name: 'admin',
-          password: 'password',
-          displayName: 'admin',
-        },
-      },
-      consoleUrl: 'http://higress-console:8080',
+    const fetchMock = installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: { status: 401 },
     });
+
+    const response = await POST(request({ username: 'admin', password: 'password' }));
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://controller.test:8090/api/v1/humans/luo',
+      expect.objectContaining({ headers: { Authorization: 'Bearer sa-token' } }),
+    );
+  });
+
+  it('L1: Console ok but CR missing → 503 misconfigured (fail loudly)', async () => {
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+    installFetchMock({ humans: {}, matrixLogin: { status: 401 } });
+
+    const response = await POST(request({ username: 'admin', password: 'password' }));
+    expect(response.status).toBe(503);
+  });
+
+  it('L1: Console ok but CR is level 2 → 503 (not silently demoted)', async () => {
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 2 } } },
+      matrixLogin: { status: 401 },
+    });
+
+    const response = await POST(request({ username: 'admin', password: 'password' }));
+    expect(response.status).toBe(503);
+  });
+
+  it('L1: session secret missing → fail closed (503, no cookie)', async () => {
+    vi.stubEnv('DASHBOARD_SESSION_SECRET', '');
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: { status: 401 },
+    });
+
+    const response = await POST(request({ username: 'admin', password: 'password' }));
+    expect(response.status).toBe(503);
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it('L2: Console 401 + Matrix login + CR level 2 → level-2 session, matrix mode, no Console cookie', async () => {
+    mockCallHigressConsole.mockImplementation(async (path: string) =>
+      path === '/system/init'
+        ? { response: new Response(null, { status: 200 }), body: {} }
+        : { response: new Response(null, { status: 401 }), body: { error: 'bad' } },
+    );
+    installFetchMock({
+      humans: { sunzong: { body: { name: 'sunzong', permissionLevel: 2, accessibleTeams: ['biz-team'] } } },
+      matrixLogin: {
+        body: { access_token: 'syt_l2_token', user_id: '@sunzong:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'sunzong', password: 'matrix-password' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.success).toBe(true);
+    expect(data.user).toEqual({ username: 'sunzong', level: 2 });
+    expect(data.mode).toBe('matrix');
+    expect((data.matrix as { accessToken?: string }).accessToken).toBe('syt_l2_token');
+
+    const cookies = response.headers.getSetCookie();
+    expect(cookies.some((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`))).toBe(true);
+    expect(cookies.some((c) => c.startsWith('_hi_sess='))).toBe(false);
+    // The Matrix token must never appear in a cookie value.
+    expect(cookies.every((c) => !c.includes('syt_l2_token'))).toBe(true);
+  });
+
+  it('L2: CR level 1 (admin human) via Matrix → 401 (L1 must use the Console track)', async () => {
+    mockCallHigressConsole.mockResolvedValue({
+      response: new Response(null, { status: 401 }),
+      body: { error: 'bad' },
+    });
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: { body: { access_token: 't', user_id: '@luo:sat.example', device_id: 'D' } },
+    });
+
+    const response = await POST(request({ username: 'luo', password: 'x' }));
+    expect(response.status).toBe(401);
+  });
+
+  it('both tracks fail → 401', async () => {
+    mockCallHigressConsole.mockResolvedValue({
+      response: new Response(null, { status: 401 }),
+      body: { error: 'bad' },
+    });
+    installFetchMock({ humans: {}, matrixLogin: { status: 401 } });
+
+    const response = await POST(request({ username: 'nobody', password: 'x' }));
+    expect(response.status).toBe(401);
+    const data = await responseJson(response);
+    expect(data.success).toBe(false);
+  });
+
+  it('external mode: no init, no Matrix token returned, session still created for L1', async () => {
+    vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'external');
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: { body: { access_token: 'secret-matrix', user_id: '@luo:sat.example', device_id: 'D' } },
+    });
+
+    const response = await POST(request({ username: 'admin', password: 'password' }));
+    expect(response.status).toBe(200);
+    expect(mockCallHigressConsole).toHaveBeenCalledTimes(1);
+    expect(mockCallHigressConsole).toHaveBeenCalledWith('/session/login', expect.anything());
+    const data = await responseJson(response);
+    expect(data.matrix).toBeNull();
+    expect(JSON.stringify(data)).not.toContain('secret-matrix');
+    expect(response.headers.getSetCookie().some((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`))).toBe(true);
   });
 });

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -167,11 +167,10 @@ describe('POST /api/auth/login (dual track, M19)', () => {
   });
 
   it('L2: Console 401 + Matrix login + CR level 2 → level-2 session, matrix mode, no Console cookie', async () => {
-    mockCallHigressConsole.mockImplementation(async (path: string) =>
-      path === '/system/init'
-        ? { response: new Response(null, { status: 200 }), body: {} }
-        : { response: new Response(null, { status: 401 }), body: { error: 'bad' } },
-    );
+    mockCallHigressConsole.mockResolvedValue({
+      response: new Response(null, { status: 401 }),
+      body: { error: 'bad' },
+    });
     installFetchMock({
       humans: { sunzong: { body: { name: 'sunzong', permissionLevel: 2, accessibleTeams: ['biz-team'] } } },
       matrixLogin: {
@@ -219,6 +218,21 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(response.status).toBe(401);
     const data = await responseJson(response);
     expect(data.success).toBe(false);
+  });
+
+  it('never calls /system/init (auto-registration removed — fresh-Console privilege escalation)', async () => {
+    mockCallHigressConsole.mockResolvedValue(successfulConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: { status: 401 },
+    });
+
+    await POST(request({ username: 'admin', password: 'password' }));
+    expect(mockCallHigressConsole).toHaveBeenCalledTimes(1);
+    expect(mockCallHigressConsole).not.toHaveBeenCalledWith(
+      '/system/init',
+      expect.anything(),
+    );
   });
 
   it('external mode: no init, no Matrix token returned, session still created for L1', async () => {

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -56,6 +56,7 @@ function failedConsoleLogin() {
 function installFetchMock(opts: {
   humans?: Record<string, { status?: number; body?: Record<string, unknown> }>;
   matrixLogin?: { status?: number; body?: Record<string, unknown> };
+  teamsCheck?: { status?: number };
 }) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -67,6 +68,10 @@ function installFetchMock(opts: {
         status: spec.status ?? 200,
         headers: { 'content-type': 'application/json' },
       });
+    }
+    if (url.includes('/api/v1/teams')) {
+      const status = opts.teamsCheck?.status ?? 200;
+      return new Response(null, { status, headers: { 'content-type': 'application/json' } });
     }
     if (url.includes('/_matrix/client/v3/login')) {
       const spec = opts.matrixLogin ?? { status: 401 };
@@ -144,7 +149,11 @@ describe('POST /api/auth/login (dual track, M19)', () => {
       },
     });
 
-    const response = await POST(request({ username: 'sunzong', password: 'matrix-password' }));
+    // L2 users ignore a pasted controller token (their Matrix token is the
+    // data-plane credential) — passing one must not break the login.
+    const response = await POST(
+      request({ username: 'sunzong', password: 'matrix-password', controllerToken: 'should-be-ignored' }),
+    );
     expect(response.status).toBe(200);
     const data = await responseJson(response);
     expect(data.success).toBe(true);
@@ -159,9 +168,9 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(cookies.every((c) => !c.includes('syt_l2_token'))).toBe(true);
   });
 
-  it('Matrix: CR level 1 (luo) → level-3 session, full access, NO team restriction', async () => {
+  it('Matrix: CR level 1 (luo) + valid controller token → level-3 session, matrix chat token kept', async () => {
     mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
-    installFetchMock({
+    const fetchMock = installFetchMock({
       humans: {
         luo: {
           body: { name: 'luo', permissionLevel: 1, accessibleTeams: ['sysdev-team', 'embedded-team'] },
@@ -170,15 +179,55 @@ describe('POST /api/auth/login (dual track, M19)', () => {
       matrixLogin: {
         body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
       },
+      teamsCheck: { status: 200 },
     });
 
-    const response = await POST(request({ username: 'luo', password: 'matrix-password' }));
+    const response = await POST(
+      request({ username: 'luo', password: 'matrix-password', controllerToken: 'cli-admin-token' }),
+    );
     expect(response.status).toBe(200);
     const data = await responseJson(response);
     expect(data.success).toBe(true);
     expect(data.user).toEqual({ username: 'luo', level: 3 });
     expect(data.mode).toBe('matrix');
+    // The Matrix token is still returned for the chat tab.
     expect((data.matrix as { accessToken?: string }).accessToken).toBe('syt_l1_token');
+    // The pasted token was verified against the Controller.
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/api/v1/teams'))).toBe(true);
+    // The pasted admin token must never leak into a cookie.
+    expect(response.headers.getSetCookie().every((c) => !c.includes('cli-admin-token'))).toBe(true);
+  });
+
+  it('Matrix: CR level 1 (luo) WITHOUT controller token → 400 with a clear hint', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
+      },
+    });
+
+    const response = await POST(request({ username: 'luo', password: 'matrix-password' }));
+    expect(response.status).toBe(400);
+    const data = await responseJson(response);
+    expect(data.success).toBe(false);
+    expect(String(data.error)).toContain('Controller');
+  });
+
+  it('Matrix: CR level 1 (luo) + INVALID controller token → 401', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
+      },
+      teamsCheck: { status: 401 },
+    });
+
+    const response = await POST(
+      request({ username: 'luo', password: 'matrix-password', controllerToken: 'wrong-token' }),
+    );
+    expect(response.status).toBe(401);
   });
 
   it('Matrix: CR level 3 (observer) → level-1 session', async () => {

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -226,6 +226,54 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(String(data.error)).toContain('管理员账号');
   });
 
+  it('Matrix: CR level 1 + valid pasted Controller token → level-3 session (plugin admin-token mode), token never in a cookie', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
+      },
+    });
+    // The token verification hits /api/v1/teams via fetch → answer 200.
+    const routerFetch = vi.mocked(fetch);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes('/api/v1/teams')) return new Response('{}', { status: 200 });
+        return routerFetch(input as RequestInfo);
+      }),
+    );
+
+    const response = await POST(
+      request({ username: 'luo', password: 'matrix-password', controllerToken: 'cli-admin-token' }),
+    );
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.user).toEqual({ username: 'luo', level: 3 });
+    expect(data.mode).toBe('matrix');
+    expect((data.matrix as { accessToken?: string }).accessToken).toBe('syt_l1_token');
+    expect(response.headers.getSetCookie().every((c) => !c.includes('cli-admin-token'))).toBe(true);
+  });
+
+  it('Matrix: CR level 1 + INVALID pasted token → 401', async () => {
+    mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());
+    // The fetch router's default 401 also answers the /api/v1/teams check →
+    // token verification fails.
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1 } } },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D2' },
+      },
+    });
+
+    const response = await POST(
+      request({ username: 'luo', password: 'matrix-password', controllerToken: 'wrong-token' }),
+    );
+    expect(response.status).toBe(401);
+    const data = await responseJson(response);
+    expect(String(data.error)).toContain('token');
+  });
+
   it('Matrix: CR level 1 + WRONG admin credentials → 401 管理员账号验证失败', async () => {
     // Both Console attempts fail (user + admin).
     mockCallHigressConsole.mockResolvedValue(failedConsoleLogin());

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,18 +1,21 @@
 // POST /api/auth/login - Dual-track multi-user authentication (M19 / batch M).
 //
 // Track L1 (Higress Console admin):
-//   Console /session/login with the admin account (deployment assumption:
-//   Console admin = the L1 human, env DASHBOARD_L1_HUMAN, default "luo").
-//   Identity is resolved server-side via the admin SA: GET /humans/{L1} must
-//   exist with permissionLevel 1. The session carries the SA credential —
-//   the browser never receives it. The Higress Console session cookie is
-//   still forwarded so the gateway tab (/api/higress/*) keeps working.
+//   Console /session/login. The Console is single-operator: whoever holds the
+//   admin password IS the deployment admin. Identity = the logged-in username
+//   itself (NO Human CR lookup — the Console "admin" account and the Human CR
+//   "luo" are different accounts, and luo logs in via the Matrix track below).
+//   The session carries the admin SA credential (server-side only, level 3).
+//   The Higress Console session cookie is still forwarded so the gateway tab
+//   (/api/higress/*) keeps working.
 //
-// Track L2 (Matrix login):
-//   Server-side Matrix password login → own access token → whoami localpart →
-//   SA GET /humans/{localpart} must exist with permissionLevel 2. The session
-//   carries the user's Matrix token (server-side only) as the Controller
-//   credential — A2 chain scopes reads to accessibleTeams (T4 field-tested).
+// Track Matrix (any Human account — luo/sunzong/maizong, …):
+//   Server-side Matrix password login → own access token → localpart →
+//   SA GET /humans/{localpart}; permissionLevel maps 1→3 (full, e.g. luo),
+//   2→2 (scoped to accessibleTeams, e.g. sunzong/maizong), 3→1 (observer).
+//   The session carries the user's Matrix token (server-side only) as the
+//   Controller credential — A2 chain scopes reads to accessibleTeams.
+//   Non-Human Matrix accounts (no CR) → generic 401.
 //
 // Both tracks fail → 401. Session secret missing → login fails closed
 // (dashboard-session throws, logged once).
@@ -170,28 +173,14 @@ async function attemptConsoleLogin(
     return { kind: 'failed' };
   }
 
-  // Resolve the L1 identity from the Human CRD via the admin SA.
-  const l1Name = process.env.DASHBOARD_L1_HUMAN || 'luo';
-  const human = await fetchHumanViaSa(request, l1Name);
-  if (!human || human.permissionLevel !== 1) {
-    return {
-      kind: 'misconfigured',
-      response: NextResponse.json(
-        {
-          success: false,
-          error: `Console login ok, but L1 identity "${l1Name}" could not be resolved from the Controller (missing SA token or Human CR / wrong permissionLevel). Check DASHBOARD_L1_HUMAN and AGENTTEAMS_AUTH_TOKEN.`,
-        },
-        { status: 503 },
-      ),
-    };
-  }
-
+  // Identity = the Console username itself. The Console admin account and the
+  // Human CRs are different accounts (admin ≠ luo): no CR lookup here.
   let cookieValue: string;
   try {
     ({ cookieValue } = createSession({
-      user: human.name || l1Name,
+      user: username,
       crLevel: 1,
-      teams: human.accessibleTeams ?? [],
+      teams: [],
       credential: { kind: 'sa' },
     }));
   } catch (err) {
@@ -221,7 +210,7 @@ async function attemptConsoleLogin(
     response: new NextResponse(
       JSON.stringify({
         success: true,
-        user: { username: human.name || l1Name, level: 3 },
+        user: { username, level: 3 },
         mode: 'higress',
         matrix,
       }),
@@ -230,9 +219,14 @@ async function attemptConsoleLogin(
   };
 }
 
+/** Human CRD permissionLevel → dashboard level (E5 inversion). */
+const MATRIX_CR_LEVEL_TO_DASH_LEVEL: Record<number, 1 | 2 | 3> = { 1: 3, 2: 2, 3: 1 };
+
 /**
- * L2 track: Matrix password login → own access token → Human CR must be
- * permissionLevel 2 → session carrying the user's Matrix token (server-side).
+ * Matrix track: password login for ANY Human account (luo L1 / sunzong,
+ * maizong L2 / observers L3) → session carrying the user's Matrix token
+ * (server-side). Level 3 (e.g. luo) gets full access, no team restriction;
+ * level 2 is scoped to accessibleTeams; level 1 is observer.
  */
 async function attemptMatrixLogin(request: NextRequest, username: string, password: string): Promise<NextResponse> {
   const matrix = await tryMatrixLogin(username, password);
@@ -243,7 +237,10 @@ async function attemptMatrixLogin(request: NextRequest, username: string, passwo
   const userId = typeof matrix.userId === 'string' ? matrix.userId : '';
   const localpart = userId.startsWith('@') ? userId.slice(1).split(':')[0] : username;
   const human = await fetchHumanViaSa(request, localpart);
-  if (!human || human.permissionLevel !== 2) {
+  const crLevel = human && typeof human.permissionLevel === 'number' ? human.permissionLevel : -1;
+  const dashLevel = MATRIX_CR_LEVEL_TO_DASH_LEVEL[crLevel];
+  if (!human || !dashLevel) {
+    // No Human CR (or unknown level) for this Matrix account → generic 401.
     return NextResponse.json({ success: false, error: 'Invalid username or password' }, { status: 401 });
   }
 
@@ -251,8 +248,9 @@ async function attemptMatrixLogin(request: NextRequest, username: string, passwo
   try {
     ({ cookieValue } = createSession({
       user: human.name || localpart,
-      crLevel: 2,
-      teams: human.accessibleTeams ?? [],
+      crLevel,
+      // Level 3 (full admin) is not team-restricted; L2/L3 users are scoped.
+      teams: dashLevel === 3 ? [] : (human.accessibleTeams ?? []),
       credential: { kind: 'matrix', token: String(matrix.accessToken) },
     }));
   } catch (err) {
@@ -270,7 +268,7 @@ async function attemptMatrixLogin(request: NextRequest, username: string, passwo
   return new NextResponse(
     JSON.stringify({
       success: true,
-      user: { username: human.name || localpart, level: 2 },
+      user: { username: human.name || localpart, level: dashLevel },
       mode: 'matrix',
       matrix,
     }),

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -106,10 +106,13 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { username, password } = body;
-    // Optional admin account verification — only consumed by the Matrix track
-    // for top-permission (CR level 1) accounts; see attemptMatrixLogin.
+    // Optional admin verification (two alternatives) — only consumed by the
+    // Matrix track for top-permission (CR level 1) accounts; see
+    // attemptMatrixLogin. adminUsername+adminPassword (Console check) OR
+    // controllerToken (Bearer check against the Controller).
     const adminUsername = typeof body.adminUsername === 'string' ? body.adminUsername.trim() : '';
     const adminPassword = typeof body.adminPassword === 'string' ? body.adminPassword : '';
+    const controllerToken = typeof body.controllerToken === 'string' ? body.controllerToken.trim() : '';
 
     if (!username || !password) {
       return NextResponse.json({ success: false, error: 'Username and password are required' }, { status: 400 });
@@ -127,7 +130,7 @@ export async function POST(request: NextRequest) {
       return l1.response;
     }
 
-    return await attemptMatrixLogin(request, username, password, adminUsername, adminPassword);
+    return await attemptMatrixLogin(request, username, password, adminUsername, adminPassword, controllerToken);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     // Fail-closed: a missing session secret surfaces here (dashboard-session throws).
@@ -245,6 +248,22 @@ async function verifyAdminConsoleCredentials(username: string, password: string)
 }
 
 /**
+ * Verify a user-supplied Controller admin token by calling an admin endpoint.
+ * Returns true only when the Controller accepts it.
+ */
+async function verifyControllerToken(request: NextRequest, token: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams/`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Matrix track: password login for ANY Human account (top-permission level
  * 1 / operators level 2 / observers level 3) → session carrying server-side
  * credentials. The level is derived from the Human CR's permissionLevel —
@@ -253,13 +272,15 @@ async function verifyAdminConsoleCredentials(username: string, password: string)
  * Credential selection:
  * - Dashboard level 3 via Matrix (CR level 1): the Controller's Matrix auth
  *   only accepts level-2 tokens, so the user's own Matrix token would 401 on
- *   every data-plane call. Admin-level data access is gated on VERIFYING THE
- *   ADMIN ACCOUNT'S CONSOLE PASSWORD (adminUsername/adminPassword). On
- *   success the session uses the server's SA token (kind 'sa') — it never
- *   leaves the server and is never pasted by the user. The Matrix token is
+ *   every data-plane call. Admin-level data access is gated on EITHER
+ *   verifying the admin account's CONSOLE PASSWORD (adminUsername/
+ *   adminPassword → session uses the server's SA token, kind 'sa', which
+ *   never leaves the server) OR a pasted Controller admin TOKEN (verified
+ *   against the Controller → kind 'controller-token', held server-side only;
+ *   same as the workbench plugin's admin-token mode). The Matrix token is
  *   still returned for the chat tab.
  * - Dashboard level 2/3 (CR level 2/3): the user's own Matrix token; A2
- *   scopes level-2 reads to accessibleTeams.
+ *   scopes level-2 reads to accessibleTeams. Admin verification is ignored.
  */
 async function attemptMatrixLogin(
   request: NextRequest,
@@ -267,6 +288,7 @@ async function attemptMatrixLogin(
   password: string,
   adminUsername: string,
   adminPassword: string,
+  controllerToken: string,
 ): Promise<NextResponse> {
   const matrix = await tryMatrixLogin(username, password);
   if (!matrix || !matrix.accessToken) {
@@ -284,24 +306,31 @@ async function attemptMatrixLogin(
   }
 
   // Level 3 via Matrix (CR level 1): the data plane needs admin-grade access
-  // (the Controller's Matrix auth rejects level-1 tokens). Gate it on the
-  // admin account's Console password, then use the server-side SA token.
-  let credential: { kind: 'sa' } | { kind: 'matrix'; token: string };
+  // (the Controller's Matrix auth rejects level-1 tokens). Gate it on EITHER
+  // the admin account's Console password OR a pasted Controller admin token.
+  let credential: { kind: 'sa' } | { kind: 'matrix'; token: string } | { kind: 'controller-token'; token: string };
   if (dashLevel === 3) {
-    if (!adminUsername || !adminPassword) {
+    if (adminUsername && adminPassword) {
+      const adminOk = await verifyAdminConsoleCredentials(adminUsername, adminPassword);
+      if (!adminOk) {
+        return NextResponse.json({ success: false, error: '管理员账号验证失败（账号或密码不正确）' }, { status: 401 });
+      }
+      credential = { kind: 'sa' };
+    } else if (controllerToken) {
+      const tokenOk = await verifyControllerToken(request, controllerToken);
+      if (!tokenOk) {
+        return NextResponse.json({ success: false, error: 'Controller 管理员 token 无效' }, { status: 401 });
+      }
+      credential = { kind: 'controller-token', token: controllerToken };
+    } else {
       return NextResponse.json(
         {
           success: false,
-          error: '该账号需要管理员账号验证：请在「管理员账号验证」中填写管理员账号与密码（由部署管理员告知）',
+          error: 'L1 账号需要管理员验证：请展开「管理员账号验证」填写管理员账号与密码，或 Controller 管理员 token（二选一，由部署管理员提供）',
         },
         { status: 400 },
       );
     }
-    const adminOk = await verifyAdminConsoleCredentials(adminUsername, adminPassword);
-    if (!adminOk) {
-      return NextResponse.json({ success: false, error: '管理员账号验证失败（账号或密码不正确）' }, { status: 401 });
-    }
-    credential = { kind: 'sa' };
   } else {
     credential = { kind: 'matrix', token: String(matrix.accessToken) };
   }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -147,25 +147,14 @@ async function attemptConsoleLogin(
 ): Promise<ConsoleAttempt> {
   const consoleUrl = getHigressConsoleURL();
 
-  // Embedded/direct deployments retain the upstream idempotent initializer.
-  if (opts.allowMatrix) {
-    try {
-    await callHigressConsole('/system/init', {
-      method: 'POST',
-      body: {
-        adminUser: {
-          name: username,
-          password,
-          displayName: username,
-        },
-      },
-      consoleUrl,
-    });
-    } catch {
-      // Continue to the login attempt; initialization is best-effort only.
-    }
-  }
-
+  // NOTE: the upstream auto-initializer (/system/init, "first login auto-
+  // registers a Console admin") was intentionally REMOVED. It is a privilege
+  // escalation path in a multi-user deployment: a fresh Console would be
+  // initialized with whoever logs in first — and in the dual-track flow a
+  // failed L2 (Matrix) attempt with mistyped credentials would create a
+  // Console admin that the L1 track then accepts as the L1 human. The Console
+  // admin account must be provisioned out-of-band (installer / first-time
+  // setup only).
   let consoleRes: Response;
   try {
     const result = await callHigressConsole('/session/login', {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,21 +1,23 @@
 // POST /api/auth/login - Dual-track multi-user authentication (M19 / batch M).
 //
-// Track L1 (Higress Console admin):
+// Track Console (deployment admin account):
 //   Console /session/login. The Console is single-operator: whoever holds the
 //   admin password IS the deployment admin. Identity = the logged-in username
-//   itself (NO Human CR lookup — the Console "admin" account and the Human CR
-//   "luo" are different accounts, and luo logs in via the Matrix track below).
-//   The session carries the admin SA credential (server-side only, level 3).
-//   The Higress Console session cookie is still forwarded so the gateway tab
-//   (/api/higress/*) keeps working.
+//   itself (NO Human CR lookup — the Console admin account is not required to
+//   have a Human CR). The session carries the admin SA credential
+//   (server-side only, level 3). The Higress Console session cookie is still
+//   forwarded so the gateway tab (/api/higress/*) keeps working.
 //
-// Track Matrix (any Human account — luo/sunzong/maizong, …):
+// Track Matrix (any Human account):
 //   Server-side Matrix password login → own access token → localpart →
-//   SA GET /humans/{localpart}; permissionLevel maps 1→3 (full, e.g. luo),
-//   2→2 (scoped to accessibleTeams, e.g. sunzong/maizong), 3→1 (observer).
+//   SA GET /humans/{localpart}; permissionLevel maps 1→3 (full),
+//   2→2 (scoped to accessibleTeams), 3→1 (observer). Level 3 via this track
+//   additionally requires admin verification (admin account password OR a
+//   pasted Controller admin token) before the session may use admin-grade
+//   data-plane credentials.
 //   The session carries the user's Matrix token (server-side only) as the
-//   Controller credential — A2 chain scopes reads to accessibleTeams.
-//   Non-Human Matrix accounts (no CR) → generic 401.
+//   Controller credential for level 2/3 — A2 chain scopes reads to
+//   accessibleTeams. Non-Human Matrix accounts (no CR) → generic 401.
 //
 // Both tracks fail → 401. Session secret missing → login fails closed
 // (dashboard-session throws, logged once).
@@ -179,7 +181,8 @@ async function attemptConsoleLogin(
   }
 
   // Identity = the Console username itself. The Console admin account and the
-  // Human CRs are different accounts (admin ≠ luo): no CR lookup here.
+  // Human CRs are different accounts (the Console admin may have no CR):
+  // no CR lookup here.
   let cookieValue: string;
   try {
     ({ cookieValue } = createSession({

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -106,16 +106,16 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { username, password } = body;
+    const controllerToken = typeof body.controllerToken === 'string' ? body.controllerToken.trim() : '';
 
     if (!username || !password) {
       return NextResponse.json({ success: false, error: 'Username and password are required' }, { status: 400 });
     }
 
     // Dual track: try the Console (L1) first; on failure fall through to
-    // Matrix (L2). A Console success with an unresolvable L1 identity is a
-    // deployment misconfiguration — fail loudly instead of guessing.
+    // Matrix (any Human level).
     // External mode (upstream #76): no init, no Matrix token/URL to the
-    // remote client; the server-side L1 CR lookup still applies.
+    // remote client.
     const l1 = await attemptConsoleLogin(request, username, password, { allowMatrix: !isExternal });
     if (l1.kind === 'session') {
       return l1.response;
@@ -124,7 +124,7 @@ export async function POST(request: NextRequest) {
       return l1.response;
     }
 
-    return await attemptMatrixLogin(request, username, password);
+    return await attemptMatrixLogin(request, username, password, controllerToken);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     // Fail-closed: a missing session secret surfaces here (dashboard-session throws).
@@ -138,9 +138,8 @@ type ConsoleAttempt =
   | { kind: 'failed' };
 
 /**
- * L1 track: Console admin login → SA human lookup (must be permissionLevel 1)
- * → session with the SA credential. Forwards the Console session cookie so
- * the gateway tab keeps working for L1.
+ * Console track: admin login → level-3 session with the SA credential.
+ * Forwards the Console session cookie so the gateway tab keeps working.
  */
 async function attemptConsoleLogin(
   request: NextRequest,
@@ -223,12 +222,41 @@ async function attemptConsoleLogin(
 const MATRIX_CR_LEVEL_TO_DASH_LEVEL: Record<number, 1 | 2 | 3> = { 1: 3, 2: 2, 3: 1 };
 
 /**
- * Matrix track: password login for ANY Human account (luo L1 / sunzong,
- * maizong L2 / observers L3) → session carrying the user's Matrix token
- * (server-side). Level 3 (e.g. luo) gets full access, no team restriction;
- * level 2 is scoped to accessibleTeams; level 1 is observer.
+ * Verify a user-supplied Controller admin token by calling an admin endpoint.
+ * Returns true only when the Controller accepts it.
  */
-async function attemptMatrixLogin(request: NextRequest, username: string, password: string): Promise<NextResponse> {
+async function verifyControllerToken(request: NextRequest, token: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams/`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Matrix track: password login for ANY Human account (luo L1 / sunzong,
+ * maizong L2 / observers L3) → session carrying server-side credentials.
+ *
+ * Credential selection (matches the workbench plugin's dual mode):
+ * - Level 3 via Matrix (e.g. luo, CR level 1): the Controller's Matrix auth
+ *   only accepts level-2 tokens, so luo's own Matrix token would 401 on every
+ *   data-plane call. A Controller admin token is REQUIRED and (after
+ *   verification) becomes the session's data-plane credential. The Matrix
+ *   token is still returned for the chat tab.
+ * - Level 2 (sunzong/maizong): the user's own Matrix token; A2 scopes reads
+ *   to accessibleTeams.
+ * - Level 1 (observer): the user's own Matrix token.
+ */
+async function attemptMatrixLogin(
+  request: NextRequest,
+  username: string,
+  password: string,
+  controllerToken: string,
+): Promise<NextResponse> {
   const matrix = await tryMatrixLogin(username, password);
   if (!matrix || !matrix.accessToken) {
     return NextResponse.json({ success: false, error: 'Invalid username or password' }, { status: 401 });
@@ -244,6 +272,29 @@ async function attemptMatrixLogin(request: NextRequest, username: string, passwo
     return NextResponse.json({ success: false, error: 'Invalid username or password' }, { status: 401 });
   }
 
+  // Level 3 via Matrix (e.g. luo): data plane needs a Controller admin token
+  // (the Controller's Matrix auth rejects level-1 tokens). Verify it.
+  let credential: { kind: 'matrix'; token: string } | { kind: 'controller-token'; token: string };
+  if (dashLevel === 3) {
+    if (!controllerToken) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'L1 账号登录需要 Controller 管理员 token（登录页可选字段，由部署管理员提供；不提供则数据面无权限）',
+        },
+        { status: 400 },
+      );
+    }
+    const valid = await verifyControllerToken(request, controllerToken);
+    if (!valid) {
+      return NextResponse.json({ success: false, error: 'Controller 管理员 token 无效' }, { status: 401 });
+    }
+    credential = { kind: 'controller-token', token: controllerToken };
+  } else {
+    credential = { kind: 'matrix', token: String(matrix.accessToken) };
+  }
+
   let cookieValue: string;
   try {
     ({ cookieValue } = createSession({
@@ -251,7 +302,7 @@ async function attemptMatrixLogin(request: NextRequest, username: string, passwo
       crLevel,
       // Level 3 (full admin) is not team-restricted; L2/L3 users are scoped.
       teams: dashLevel === 3 ? [] : (human.accessibleTeams ?? []),
-      credential: { kind: 'matrix', token: String(matrix.accessToken) },
+      credential,
     }));
   } catch (err) {
     return NextResponse.json(

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,30 @@
-// POST /api/auth/login - Authenticate via Higress Console
-// Also attempts Matrix login with the same credentials for seamless chat access.
+// POST /api/auth/login - Dual-track multi-user authentication (M19 / batch M).
+//
+// Track L1 (Higress Console admin):
+//   Console /session/login with the admin account (deployment assumption:
+//   Console admin = the L1 human, env DASHBOARD_L1_HUMAN, default "luo").
+//   Identity is resolved server-side via the admin SA: GET /humans/{L1} must
+//   exist with permissionLevel 1. The session carries the SA credential —
+//   the browser never receives it. The Higress Console session cookie is
+//   still forwarded so the gateway tab (/api/higress/*) keeps working.
+//
+// Track L2 (Matrix login):
+//   Server-side Matrix password login → own access token → whoami localpart →
+//   SA GET /humans/{localpart} must exist with permissionLevel 2. The session
+//   carries the user's Matrix token (server-side only) as the Controller
+//   credential — A2 chain scopes reads to accessibleTeams (T4 field-tested).
+//
+// Both tracks fail → 401. Session secret missing → login fails closed
+// (dashboard-session throws, logged once).
+//
+// External mode (AGENTTEAMS_HIGRESS_ADAPTER_MODE=external) keeps the upstream
+// #76 semantics: no init, Console-only, no Matrix (remote clients must not
+// receive internal homeserver tokens).
+
 import { NextRequest, NextResponse } from 'next/server';
-import { callHigressConsole, forwardCookies, getHigressConsoleURL, higressErrorResponse } from '../../higress/proxy-helper';
+import { callHigressConsole, forwardCookies, getHigressConsoleURL } from '../../higress/proxy-helper';
+import { getAuthToken, getControllerUrl } from '../../agentteams/proxy-helper';
+import { createSession, sessionCookieHeader } from '@/lib/dashboard-session';
 import { validateHomeserverUrl } from '@/lib/homeserver-allowlist';
 
 // Server-side default follows the embedded topology: the dashboard container
@@ -11,24 +34,34 @@ const MATRIX_HOMESERVER =
   process.env.AGENTTEAMS_MATRIX_URL ||
   'http://agentteams-controller:6167';
 
-export async function POST(request: NextRequest) {
+interface HumanRecord {
+  name?: string;
+  permissionLevel?: number;
+  accessibleTeams?: string[];
+  accessibleWorkers?: string[];
+}
+
+/**
+ * Resolve a Human CR via the admin SA token. Returns null when the controller
+ * is unreachable, the token is missing, or the human does not exist.
+ */
+async function fetchHumanViaSa(request: NextRequest, name: string): Promise<HumanRecord | null> {
+  const token = await getAuthToken();
+  if (!token) return null;
   try {
-    const body = await request.json();
-    const { username, password } = body;
-
-    if (!username || !password) {
-      return NextResponse.json({ success: false, error: 'Username and password are required' }, { status: 400 });
-    }
-
-    return await loginViaHigress(username, password);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ success: false, error: message }, { status: 502 });
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/humans/${encodeURIComponent(name)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as HumanRecord;
+  } catch {
+    return null;
   }
 }
 
 /**
- * Attempt Matrix login with the same credentials.
+ * Attempt Matrix login with the given credentials.
  * Returns the Matrix login result or null if it fails.
  */
 async function tryMatrixLogin(username: string, password: string): Promise<Record<string, unknown> | null> {
@@ -64,58 +97,195 @@ async function tryMatrixLogin(username: string, password: string): Promise<Recor
   }
 }
 
-/** Authenticate against Higress Console (original behaviour). */
-async function loginViaHigress(username: string, password: string) {
+export async function POST(request: NextRequest) {
+  const isExternal = process.env.AGENTTEAMS_HIGRESS_ADAPTER_MODE === 'external';
+
+  try {
+    const body = await request.json();
+    const { username, password } = body;
+
+    if (!username || !password) {
+      return NextResponse.json({ success: false, error: 'Username and password are required' }, { status: 400 });
+    }
+
+    // Dual track: try the Console (L1) first; on failure fall through to
+    // Matrix (L2). A Console success with an unresolvable L1 identity is a
+    // deployment misconfiguration — fail loudly instead of guessing.
+    // External mode (upstream #76): no init, no Matrix token/URL to the
+    // remote client; the server-side L1 CR lookup still applies.
+    const l1 = await attemptConsoleLogin(request, username, password, { allowMatrix: !isExternal });
+    if (l1.kind === 'session') {
+      return l1.response;
+    }
+    if (l1.kind === 'misconfigured') {
+      return l1.response;
+    }
+
+    return await attemptMatrixLogin(request, username, password);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    // Fail-closed: a missing session secret surfaces here (dashboard-session throws).
+    return NextResponse.json({ success: false, error: message }, { status: 502 });
+  }
+}
+
+type ConsoleAttempt =
+  | { kind: 'session'; response: NextResponse }
+  | { kind: 'misconfigured'; response: NextResponse }
+  | { kind: 'failed' };
+
+/**
+ * L1 track: Console admin login → SA human lookup (must be permissionLevel 1)
+ * → session with the SA credential. Forwards the Console session cookie so
+ * the gateway tab keeps working for L1.
+ */
+async function attemptConsoleLogin(
+  request: NextRequest,
+  username: string,
+  password: string,
+  opts: { allowMatrix: boolean },
+): Promise<ConsoleAttempt> {
   const consoleUrl = getHigressConsoleURL();
 
   // Embedded/direct deployments retain the upstream idempotent initializer.
-  // External mode must never bootstrap or change a shared Console admin during
-  // a Dashboard login; it authenticates only against an already-provisioned
-  // Console account.
-  if (process.env.AGENTTEAMS_HIGRESS_ADAPTER_MODE !== 'external') {
+  if (opts.allowMatrix) {
     try {
-      await callHigressConsole('/system/init', {
-        method: 'POST',
-        body: {
-          adminUser: {
-            name: username,
-            password,
-            displayName: username,
-          },
+    await callHigressConsole('/system/init', {
+      method: 'POST',
+      body: {
+        adminUser: {
+          name: username,
+          password,
+          displayName: username,
         },
-        consoleUrl,
-      });
+      },
+      consoleUrl,
+    });
     } catch {
       // Continue to the login attempt; initialization is best-effort only.
     }
   }
 
-  // Login to obtain the session cookie.
-  const { response, body: loginBody } = await callHigressConsole('/session/login', {
-    method: 'POST',
-    body: { username, password },
-    consoleUrl,
-  });
-
-  if (!response.ok) {
-    return higressErrorResponse(response, loginBody);
+  let consoleRes: Response;
+  try {
+    const result = await callHigressConsole('/session/login', {
+      method: 'POST',
+      body: { username, password },
+      consoleUrl,
+    });
+    consoleRes = result.response;
+  } catch {
+    return { kind: 'failed' };
+  }
+  if (!consoleRes.ok) {
+    return { kind: 'failed' };
   }
 
-  // External mode has no browser-reachable Matrix endpoint and must not return
-  // an internal homeserver URL or Matrix access token to the Tailnet client.
-  // Direct deployments retain the upstream convenience auto-login behavior.
-  const matrix = process.env.AGENTTEAMS_HIGRESS_ADAPTER_MODE === 'external'
-    ? null
-    : await tryMatrixLogin(username, password);
+  // Resolve the L1 identity from the Human CRD via the admin SA.
+  const l1Name = process.env.DASHBOARD_L1_HUMAN || 'luo';
+  const human = await fetchHumanViaSa(request, l1Name);
+  if (!human || human.permissionLevel !== 1) {
+    return {
+      kind: 'misconfigured',
+      response: NextResponse.json(
+        {
+          success: false,
+          error: `Console login ok, but L1 identity "${l1Name}" could not be resolved from the Controller (missing SA token or Human CR / wrong permissionLevel). Check DASHBOARD_L1_HUMAN and AGENTTEAMS_AUTH_TOKEN.`,
+        },
+        { status: 503 },
+      ),
+    };
+  }
 
-  // Forward Set-Cookie headers from Higress Console back to the browser.
+  let cookieValue: string;
+  try {
+    ({ cookieValue } = createSession({
+      user: human.name || l1Name,
+      crLevel: 1,
+      teams: human.accessibleTeams ?? [],
+      credential: { kind: 'sa' },
+    }));
+  } catch (err) {
+    return {
+      kind: 'misconfigured',
+      response: NextResponse.json(
+        { success: false, error: `Session store unavailable: ${err instanceof Error ? err.message : 'unknown'}` },
+        { status: 503 },
+      ),
+    };
+  }
+
+  // Chat convenience: L1's own Matrix token (client-side, chat only).
+  // External mode must not return an internal homeserver URL or Matrix access
+  // token to the remote client (upstream #76).
+  const matrix = opts.allowMatrix ? await tryMatrixLogin(username, password) : null;
+
   const responseHeaders = new Headers();
   responseHeaders.set('content-type', 'application/json');
   responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-  forwardCookies(response.headers, responseHeaders);
+  // Dashboard session first, then the Higress Console cookie (gateway tab).
+  responseHeaders.append('set-cookie', sessionCookieHeader(cookieValue));
+  forwardCookies(consoleRes.headers, responseHeaders);
+
+  return {
+    kind: 'session',
+    response: new NextResponse(
+      JSON.stringify({
+        success: true,
+        user: { username: human.name || l1Name, level: 3 },
+        mode: 'higress',
+        matrix,
+      }),
+      { status: 200, headers: responseHeaders },
+    ),
+  };
+}
+
+/**
+ * L2 track: Matrix password login → own access token → Human CR must be
+ * permissionLevel 2 → session carrying the user's Matrix token (server-side).
+ */
+async function attemptMatrixLogin(request: NextRequest, username: string, password: string): Promise<NextResponse> {
+  const matrix = await tryMatrixLogin(username, password);
+  if (!matrix || !matrix.accessToken) {
+    return NextResponse.json({ success: false, error: 'Invalid username or password' }, { status: 401 });
+  }
+
+  const userId = typeof matrix.userId === 'string' ? matrix.userId : '';
+  const localpart = userId.startsWith('@') ? userId.slice(1).split(':')[0] : username;
+  const human = await fetchHumanViaSa(request, localpart);
+  if (!human || human.permissionLevel !== 2) {
+    return NextResponse.json({ success: false, error: 'Invalid username or password' }, { status: 401 });
+  }
+
+  let cookieValue: string;
+  try {
+    ({ cookieValue } = createSession({
+      user: human.name || localpart,
+      crLevel: 2,
+      teams: human.accessibleTeams ?? [],
+      credential: { kind: 'matrix', token: String(matrix.accessToken) },
+    }));
+  } catch (err) {
+    return NextResponse.json(
+      { success: false, error: `Session store unavailable: ${err instanceof Error ? err.message : 'unknown'}` },
+      { status: 503 },
+    );
+  }
+
+  const responseHeaders = new Headers();
+  responseHeaders.set('content-type', 'application/json');
+  responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  responseHeaders.set('set-cookie', sessionCookieHeader(cookieValue));
 
   return new NextResponse(
-    JSON.stringify({ success: true, user: { username }, mode: 'higress', matrix }),
-    { status: 200, headers: responseHeaders }
+    JSON.stringify({
+      success: true,
+      user: { username: human.name || localpart, level: 2 },
+      mode: 'matrix',
+      matrix,
+    }),
+    { status: 200, headers: responseHeaders },
   );
 }
+

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -106,7 +106,10 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { username, password } = body;
-    const controllerToken = typeof body.controllerToken === 'string' ? body.controllerToken.trim() : '';
+    // Optional admin account verification — only consumed by the Matrix track
+    // for top-permission (CR level 1) accounts; see attemptMatrixLogin.
+    const adminUsername = typeof body.adminUsername === 'string' ? body.adminUsername.trim() : '';
+    const adminPassword = typeof body.adminPassword === 'string' ? body.adminPassword : '';
 
     if (!username || !password) {
       return NextResponse.json({ success: false, error: 'Username and password are required' }, { status: 400 });
@@ -124,7 +127,7 @@ export async function POST(request: NextRequest) {
       return l1.response;
     }
 
-    return await attemptMatrixLogin(request, username, password, controllerToken);
+    return await attemptMatrixLogin(request, username, password, adminUsername, adminPassword);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     // Fail-closed: a missing session secret surfaces here (dashboard-session throws).
@@ -222,40 +225,48 @@ async function attemptConsoleLogin(
 const MATRIX_CR_LEVEL_TO_DASH_LEVEL: Record<number, 1 | 2 | 3> = { 1: 3, 2: 2, 3: 1 };
 
 /**
- * Verify a user-supplied Controller admin token by calling an admin endpoint.
- * Returns true only when the Controller accepts it.
+ * Verify the admin account's Console credentials (deployment admin username +
+ * password). Returns true only when the Console accepts them. Used to gate
+ * admin-level data-plane access for top-permission accounts logging in via
+ * the Matrix track — replaces pasting the raw Controller token: the token
+ * never leaves the server (it is the AGENTTEAMS_AUTH_TOKEN env value).
  */
-async function verifyControllerToken(request: NextRequest, token: string): Promise<boolean> {
+async function verifyAdminConsoleCredentials(username: string, password: string): Promise<boolean> {
   try {
-    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams/`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(5000),
+    const { response } = await callHigressConsole('/session/login', {
+      method: 'POST',
+      body: { username, password },
+      consoleUrl: getHigressConsoleURL(),
     });
-    return res.ok;
+    return response.ok;
   } catch {
     return false;
   }
 }
 
 /**
- * Matrix track: password login for ANY Human account (luo L1 / sunzong,
- * maizong L2 / observers L3) → session carrying server-side credentials.
+ * Matrix track: password login for ANY Human account (top-permission level
+ * 1 / operators level 2 / observers level 3) → session carrying server-side
+ * credentials. The level is derived from the Human CR's permissionLevel —
+ * never from the username string.
  *
- * Credential selection (matches the workbench plugin's dual mode):
- * - Level 3 via Matrix (e.g. luo, CR level 1): the Controller's Matrix auth
- *   only accepts level-2 tokens, so luo's own Matrix token would 401 on every
- *   data-plane call. A Controller admin token is REQUIRED and (after
- *   verification) becomes the session's data-plane credential. The Matrix
- *   token is still returned for the chat tab.
- * - Level 2 (sunzong/maizong): the user's own Matrix token; A2 scopes reads
- *   to accessibleTeams.
- * - Level 1 (observer): the user's own Matrix token.
+ * Credential selection:
+ * - Dashboard level 3 via Matrix (CR level 1): the Controller's Matrix auth
+ *   only accepts level-2 tokens, so the user's own Matrix token would 401 on
+ *   every data-plane call. Admin-level data access is gated on VERIFYING THE
+ *   ADMIN ACCOUNT'S CONSOLE PASSWORD (adminUsername/adminPassword). On
+ *   success the session uses the server's SA token (kind 'sa') — it never
+ *   leaves the server and is never pasted by the user. The Matrix token is
+ *   still returned for the chat tab.
+ * - Dashboard level 2/3 (CR level 2/3): the user's own Matrix token; A2
+ *   scopes level-2 reads to accessibleTeams.
  */
 async function attemptMatrixLogin(
   request: NextRequest,
   username: string,
   password: string,
-  controllerToken: string,
+  adminUsername: string,
+  adminPassword: string,
 ): Promise<NextResponse> {
   const matrix = await tryMatrixLogin(username, password);
   if (!matrix || !matrix.accessToken) {
@@ -272,25 +283,25 @@ async function attemptMatrixLogin(
     return NextResponse.json({ success: false, error: 'Invalid username or password' }, { status: 401 });
   }
 
-  // Level 3 via Matrix (e.g. luo): data plane needs a Controller admin token
-  // (the Controller's Matrix auth rejects level-1 tokens). Verify it.
-  let credential: { kind: 'matrix'; token: string } | { kind: 'controller-token'; token: string };
+  // Level 3 via Matrix (CR level 1): the data plane needs admin-grade access
+  // (the Controller's Matrix auth rejects level-1 tokens). Gate it on the
+  // admin account's Console password, then use the server-side SA token.
+  let credential: { kind: 'sa' } | { kind: 'matrix'; token: string };
   if (dashLevel === 3) {
-    if (!controllerToken) {
+    if (!adminUsername || !adminPassword) {
       return NextResponse.json(
         {
           success: false,
-          error:
-            'L1 账号登录需要 Controller 管理员 token（登录页可选字段，由部署管理员提供；不提供则数据面无权限）',
+          error: '该账号需要管理员账号验证：请在「管理员账号验证」中填写管理员账号与密码（由部署管理员告知）',
         },
         { status: 400 },
       );
     }
-    const valid = await verifyControllerToken(request, controllerToken);
-    if (!valid) {
-      return NextResponse.json({ success: false, error: 'Controller 管理员 token 无效' }, { status: 401 });
+    const adminOk = await verifyAdminConsoleCredentials(adminUsername, adminPassword);
+    if (!adminOk) {
+      return NextResponse.json({ success: false, error: '管理员账号验证失败（账号或密码不正确）' }, { status: 401 });
     }
-    credential = { kind: 'controller-token', token: controllerToken };
+    credential = { kind: 'sa' };
   } else {
     credential = { kind: 'matrix', token: String(matrix.accessToken) };
   }

--- a/src/app/api/auth/logout/route.test.ts
+++ b/src/app/api/auth/logout/route.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+
+describe('POST /api/auth/logout (M19)', () => {
+  it('clears the dashboard session cookie', async () => {
+    const res = await POST(new NextRequest('http://dashboard.test/api/auth/logout', { method: 'POST' }));
+    const cookies = res.headers.getSetCookie();
+    expect(cookies.some((c) => c.startsWith('at_dash_sess=') && c.includes('Max-Age=0'))).toBe(true);
+  });
+
+  it('also clears the Higress Console cookie when present', async () => {
+    const request = new NextRequest('http://dashboard.test/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: 'at_dash_sess=x; _hi_sess=y' },
+    });
+    const res = await POST(request);
+    const cookies = res.headers.getSetCookie();
+    expect(cookies.some((c) => c.startsWith('_hi_sess=') && c.includes('Max-Age=0'))).toBe(true);
+  });
+
+  it('does not emit a _hi_sess clear when that cookie is absent', async () => {
+    const res = await POST(new NextRequest('http://dashboard.test/api/auth/logout', { method: 'POST' }));
+    const cookies = res.headers.getSetCookie();
+    expect(cookies.some((c) => c.startsWith('_hi_sess='))).toBe(false);
+  });
+});

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,22 @@
+// POST /api/auth/logout - Clear the dashboard session (M19).
+//
+// Also clears the Higress Console cookie (_hi_sess) when present, so a full
+// logout leaves no stale credentials in the browser.
+import { NextResponse } from 'next/server';
+import { clearSessionCookieHeader, parseCookies } from '@/lib/dashboard-session';
+
+const HIGRESS_SESSION_COOKIE = '_hi_sess';
+
+export async function POST(request: Request) {
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+  headers.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+  headers.append('set-cookie', clearSessionCookieHeader());
+
+  const cookies = parseCookies(request.headers.get('cookie'));
+  if (cookies[HIGRESS_SESSION_COOKIE]) {
+    headers.append('set-cookie', `${HIGRESS_SESSION_COOKIE}=; Path=/; HttpOnly; Max-Age=0`);
+  }
+
+  return new NextResponse(JSON.stringify({ success: true }), { status: 200, headers });
+}

--- a/src/app/api/auth/session/route.test.ts
+++ b/src/app/api/auth/session/route.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import {
+  SESSION_COOKIE_NAME,
+  __resetSessionStoreForTests,
+  createSession,
+} from '@/lib/dashboard-session';
+
+const SECRET = 'a1'.repeat(32);
+
+function requestWith(cookie?: string) {
+  const headers = new Headers();
+  if (cookie) headers.set('cookie', cookie);
+  return new NextRequest('http://dashboard.test/api/auth/session', { headers });
+}
+
+describe('GET /api/auth/session (M19 dashboard session)', () => {
+  beforeEach(() => {
+    __resetSessionStoreForTests();
+    process.env.DASHBOARD_SESSION_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    __resetSessionStoreForTests();
+    delete process.env.DASHBOARD_SESSION_SECRET;
+  });
+
+  it('reports unauthenticated without a session cookie', async () => {
+    const data = await (await GET(requestWith())).json();
+    expect(data).toEqual({ authenticated: false });
+  });
+
+  it('reports the L1 (Console) session as level 3 / higress mode', async () => {
+    const { cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    const data = await (await GET(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`))).json();
+    expect(data).toEqual({ authenticated: true, username: 'luo', level: 3, mode: 'higress' });
+  });
+
+  it('reports the L2 (Matrix) session as level 2 / matrix mode with the human name', async () => {
+    const { cookieValue } = createSession({
+      user: 'sunzong',
+      crLevel: 2,
+      teams: ['biz-team'],
+      credential: { kind: 'matrix', token: 'syt_secret' },
+    });
+    const res = await GET(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`));
+    const data = await res.json();
+    expect(data).toEqual({ authenticated: true, username: 'sunzong', level: 2, mode: 'matrix' });
+    // The Matrix token must never leave the server.
+    expect(JSON.stringify(data)).not.toContain('syt_secret');
+  });
+
+  it('ignores unrelated cookies (no session cookie present)', async () => {
+    const data = await (await GET(requestWith('_hi_sess=abc'))).json();
+    expect(data).toEqual({ authenticated: false });
+  });
+});

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,44 +1,25 @@
-// GET /api/auth/session - Validate the browser's session via Higress Console
+// GET /api/auth/session - Resolve the browser's dashboard session (M19).
+//
+// The dashboard session cookie (at_dash_sess) is created by the dual-track
+// login. `username` is the Human CR name (never a Higress consumer name —
+// the old /v1/consumers probe reported the first consumer, which is why the
+// UI used to show "manager" for everyone). `level` is the dashboard
+// rbac-engine level (3 Admin / 2 Operator / 1 Observer) used by the UI
+// level gate; the security boundary remains server-side (middleware +
+// Controller A2).
 import { NextRequest, NextResponse } from 'next/server';
-import { callHigressConsole, getHigressConsoleURL } from '../../higress/proxy-helper';
+import { getSessionFromRequest } from '@/lib/dashboard-session';
 
 export async function GET(request: NextRequest) {
-  try {
-    const cookie = request.headers.get('cookie');
-    if (!cookie) {
-      return NextResponse.json({ authenticated: false }, { status: 200 });
-    }
-
-    return await validateViaHigress(cookie);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ authenticated: false, error: message }, { status: 200 });
-  }
-}
-
-/** Validate session by probing Higress Console (original behaviour). */
-async function validateViaHigress(cookie: string) {
-  const consoleUrl = getHigressConsoleURL();
-
-  const { response, body } = await callHigressConsole('/v1/consumers', {
-    method: 'GET',
-    cookie,
-    consoleUrl,
-  });
-
-  if (!response.ok) {
+  const session = getSessionFromRequest(request);
+  if (!session) {
     return NextResponse.json({ authenticated: false }, { status: 200 });
   }
 
-  // Try to extract a display name/username from the profile if available.
-  let username: string | undefined;
-  if (typeof body === 'object' && body !== null && 'data' in body) {
-    const data = (body as { data?: unknown }).data;
-    if (Array.isArray(data) && data.length > 0 && typeof data[0] === 'object' && data[0] !== null) {
-      const first = data[0] as { name?: string };
-      username = first.name;
-    }
-  }
-
-  return NextResponse.json({ authenticated: true, username, mode: 'higress' }, { status: 200 });
+  return NextResponse.json({
+    authenticated: true,
+    username: session.user,
+    level: session.level,
+    mode: session.credential.kind === 'sa' ? 'higress' : 'matrix',
+  }, { status: 200 });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { AgentTeamsDashboard } from '@/components/dashboard/agent-teams-dashboar
 import { LoginPage } from '@/components/auth/login-page';
 import { SetupWizard } from '@/components/setup/setup-wizard';
 import { QueryProvider } from '@/lib/query-provider';
+import { useAgentTeamsStore } from '@/lib/agentteams-store';
 import { SearchProvider } from '@/lib/search-context';
 import { apiUrl } from '@/lib/api-base';
 import { ThemeProvider } from '@/components/theme/theme-provider';
@@ -38,6 +39,10 @@ export default function Home() {
           return;
         }
         setAuth({ status: 'authenticated', username: data.username });
+        // M19: publish the dashboard level for the UI level gate (nav items).
+        // Falls back to 3 (full nav) when the session endpoint predates the
+        // level field or in AUTH_DISABLED dev setups.
+        useAgentTeamsStore.getState().setUserLevel(data.level ?? 3);
         fetch(apiUrl('/api/agentteams/setup/status/'), { credentials: 'same-origin' })
           .then((res) => res.json().catch(() => ({})))
           .then((sdata) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,10 @@ export default function Home() {
         // Falls back to 3 (full nav) when the session endpoint predates the
         // level field or in AUTH_DISABLED dev setups.
         useAgentTeamsStore.getState().setUserLevel(data.level ?? 3);
+        // Account chip in the header (identity = the session's own username).
+        if (data.username) {
+          useAgentTeamsStore.getState().setSessionUser(data.username);
+        }
         fetch(apiUrl('/api/agentteams/setup/status/'), { credentials: 'same-origin' })
           .then((res) => res.json().catch(() => ({})))
           .then((sdata) => {

--- a/src/components/auth/login-page.tsx
+++ b/src/components/auth/login-page.tsx
@@ -17,6 +17,8 @@ interface LoginPageProps {
 export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPageProps) {
   const [username, setUsername] = useState(defaultUsername);
   const [password, setPassword] = useState('');
+  const [controllerToken, setControllerToken] = useState('');
+  const [tokenVisible, setTokenVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const setMatrixAuth = useMatrixStore((s) => s.setMatrixAuth);
@@ -31,7 +33,11 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
         method: 'POST',
         credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({
+          username,
+          password,
+          ...(controllerToken ? { controllerToken } : {}),
+        }),
       });
 
       const data = await res.json();
@@ -90,6 +96,33 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
               disabled={isLoading}
             />
           </div>
+          <div className="space-y-1.5">
+            <button
+              type="button"
+              onClick={() => setTokenVisible((v) => !v)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {tokenVisible ? '收起 Controller 管理员 token ▲' : 'L1 账号（luo）？展开 Controller 管理员 token ▼'}
+            </button>
+            {tokenVisible && (
+              <div className="space-y-2">
+                <Input
+                  id="controller-token"
+                  type="password"
+                  placeholder="Controller 管理员 token"
+                  value={controllerToken}
+                  onChange={(e) => setControllerToken(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
+                  disabled={isLoading}
+                />
+                <p className="text-xs text-muted-foreground">
+                  由部署管理员提供（Node1: docker exec agentteams-controller cat /var/run/agentteams/cli-token）。
+                  L1 账号数据面必须填；L2 账号（sunzong/maizong）留空即可。
+                </p>
+              </div>
+            )}
+          </div>
+
           {error && (
             <div className="flex items-center gap-2 text-destructive text-sm">
               <AlertCircle className="w-4 h-4 shrink-0" />

--- a/src/components/auth/login-page.tsx
+++ b/src/components/auth/login-page.tsx
@@ -17,8 +17,9 @@ interface LoginPageProps {
 export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPageProps) {
   const [username, setUsername] = useState(defaultUsername);
   const [password, setPassword] = useState('');
-  const [controllerToken, setControllerToken] = useState('');
-  const [tokenVisible, setTokenVisible] = useState(false);
+  const [adminUsername, setAdminUsername] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+  const [adminVisible, setAdminVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const setMatrixAuth = useMatrixStore((s) => s.setMatrixAuth);
@@ -36,7 +37,7 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
         body: JSON.stringify({
           username,
           password,
-          ...(controllerToken ? { controllerToken } : {}),
+          ...(adminUsername ? { adminUsername, adminPassword } : {}),
         }),
       });
 
@@ -99,25 +100,32 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
           <div className="space-y-1.5">
             <button
               type="button"
-              onClick={() => setTokenVisible((v) => !v)}
+              onClick={() => setAdminVisible((v) => !v)}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
-              {tokenVisible ? '收起 Controller 管理员 token ▲' : 'L1 账号（luo）？展开 Controller 管理员 token ▼'}
+              {adminVisible ? '收起管理员账号验证 ▲' : '管理员账号验证（仅最高权限账号需要）▼'}
             </button>
-            {tokenVisible && (
+            {adminVisible && (
               <div className="space-y-2">
                 <Input
-                  id="controller-token"
+                  id="admin-username"
+                  placeholder="管理员账号"
+                  value={adminUsername}
+                  onChange={(e) => setAdminUsername(e.target.value)}
+                  disabled={isLoading}
+                />
+                <Input
+                  id="admin-password"
                   type="password"
-                  placeholder="Controller 管理员 token"
-                  value={controllerToken}
-                  onChange={(e) => setControllerToken(e.target.value)}
+                  placeholder="管理员密码"
+                  value={adminPassword}
+                  onChange={(e) => setAdminPassword(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
                   disabled={isLoading}
                 />
                 <p className="text-xs text-muted-foreground">
-                  由部署管理员提供（Node1: docker exec agentteams-controller cat /var/run/agentteams/cli-token）。
-                  L1 账号数据面必须填；L2 账号（sunzong/maizong）留空即可。
+                  仅当你的账号是最高权限（Human CR level 1）且需要管理数据时填写，管理员账号与密码由部署管理员告知；
+                  普通账号（level 2/3）留空即可。
                 </p>
               </div>
             )}

--- a/src/components/auth/login-page.tsx
+++ b/src/components/auth/login-page.tsx
@@ -63,7 +63,7 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
             </div>
             <div>
               <CardTitle className="text-lg">AgentTeams Dashboard</CardTitle>
-              <CardDescription>管理员账号登录（首次登录自动注册）</CardDescription>
+              <CardDescription>账号登录（L1 管理员 / L2 Matrix 账号）</CardDescription>
             </div>
           </div>
         </CardHeader>

--- a/src/components/auth/login-page.tsx
+++ b/src/components/auth/login-page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { apiUrl } from '@/lib/api-base';
 import { useMatrixStore } from '@/lib/matrix-store';
 import { Lock, LogIn, RefreshCw, AlertCircle } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -63,7 +63,6 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
             </div>
             <div>
               <CardTitle className="text-lg">AgentTeams Dashboard</CardTitle>
-              <CardDescription>账号登录（L1 管理员 / L2 Matrix 账号）</CardDescription>
             </div>
           </div>
         </CardHeader>

--- a/src/components/auth/login-page.tsx
+++ b/src/components/auth/login-page.tsx
@@ -19,6 +19,7 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
   const [password, setPassword] = useState('');
   const [adminUsername, setAdminUsername] = useState('');
   const [adminPassword, setAdminPassword] = useState('');
+  const [controllerToken, setControllerToken] = useState('');
   const [adminVisible, setAdminVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,6 +39,7 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
           username,
           password,
           ...(adminUsername ? { adminUsername, adminPassword } : {}),
+          ...(controllerToken ? { controllerToken } : {}),
         }),
       });
 
@@ -103,7 +105,7 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
               onClick={() => setAdminVisible((v) => !v)}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
-              {adminVisible ? '收起管理员账号验证 ▲' : '管理员账号验证（仅最高权限账号需要）▼'}
+              {adminVisible ? '收起管理员账号验证 ▲' : '管理员账号验证（仅L1账号需要）▼'}
             </button>
             {adminVisible && (
               <div className="space-y-2">
@@ -123,9 +125,23 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
                   onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
                   disabled={isLoading}
                 />
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <div className="h-px flex-1 bg-border" />
+                  或
+                  <div className="h-px flex-1 bg-border" />
+                </div>
+                <Input
+                  id="controller-token"
+                  type="password"
+                  placeholder="Controller 管理员 token（与上两种方式二选一）"
+                  value={controllerToken}
+                  onChange={(e) => setControllerToken(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
+                  disabled={isLoading}
+                />
                 <p className="text-xs text-muted-foreground">
-                  仅当你的账号是最高权限（Human CR level 1）且需要管理数据时填写，管理员账号与密码由部署管理员告知；
-                  普通账号（level 2/3）留空即可。
+                  仅 L1 账号（Human CR level 1，需管理数据时）填写：填管理员账号与密码（部署管理员告知），或直接填
+                  Controller 管理员 token，二选一。L2/L3 账号留空即可。
                 </p>
               </div>
             )}

--- a/src/components/dashboard/agent-teams-dashboard.tsx
+++ b/src/components/dashboard/agent-teams-dashboard.tsx
@@ -86,7 +86,7 @@ export function AgentTeamsDashboard() {
   const [isRefreshingAll, setIsRefreshingAll] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { isConnected, openSettings, controllerUrl, connectionLatency, reconnectInterval,
-    taskBoardVisible, projectsVisible } = useAgentTeamsStore();
+    taskBoardVisible, projectsVisible, userLevel } = useAgentTeamsStore();
   const { isLoggedIn: matrixLoggedIn, isSyncing: matrixSyncing } = useMatrixStore();
   const notifications = useNotificationStore((s) => s.notifications);
   const { searchQuery, setSearchQuery } = useSearch();
@@ -111,13 +111,13 @@ export function AgentTeamsDashboard() {
   const isPluginSection = isPluginSectionId(activeSection);
 
   const visibleNavItems = useMemo(
-    () => navItems.filter((item) => isNavItemVisible(item, mode, taskBoardVisible, projectsVisible)),
-    [mode, taskBoardVisible, projectsVisible]
+    () => navItems.filter((item) => isNavItemVisible(item, mode, taskBoardVisible, projectsVisible, userLevel)),
+    [mode, taskBoardVisible, projectsVisible, userLevel]
   );
 
   const visibleCreateActions = useMemo(
-    () => createActions.filter((action) => isCreateActionVisible(action, mode, taskBoardVisible, projectsVisible)),
-    [mode, taskBoardVisible, projectsVisible]
+    () => createActions.filter((action) => isCreateActionVisible(action, mode, taskBoardVisible, projectsVisible, userLevel)),
+    [mode, taskBoardVisible, projectsVisible, userLevel]
   );
 
   const checkConnection = useAgentTeamsStore((s) => s.checkConnection);

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -100,8 +100,10 @@ export function DashboardHeader({
 
   // 退出登录：清服务端 session（at_dash_sess + 残留 _hi_sess）→ 回登录页。
   const handleLogout = () => {
+    // The login UI is rendered at the ROOT path (page.tsx shows LoginPage when
+    // unauthenticated) — there is no /login route (404).
     void fetch(apiUrl('/api/auth/logout'), { method: 'POST', credentials: 'same-origin' }).finally(() => {
-      window.location.replace('/login');
+      window.location.replace('/');
     });
   };
 

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -107,7 +107,7 @@ export function DashboardHeader({
     });
   };
 
-  const levelLabel = userLevel === 3 ? '管理员' : userLevel === 2 ? '操作者' : '观察者';
+  const levelLabel = userLevel === 3 ? '管理员' : userLevel === 2 ? 'L2' : '观察者';
 
   const visibleActions = useMemo(
     () => actions.filter((action) => isCreateActionVisible(action, mode, undefined, undefined, userLevel)),

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -18,7 +18,10 @@ import {
   Contrast,
   Settings,
   Menu,
+  UserCircle,
+  LogOut,
 } from 'lucide-react';
+import { apiUrl } from '@/lib/api-base';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
@@ -93,6 +96,16 @@ export function DashboardHeader({
 
   const searchResults = useGlobalSearch(debouncedQuery, workers, teams, managers, humans);
   const userLevel = useAgentTeamsStore((s) => s.userLevel);
+  const sessionUser = useAgentTeamsStore((s) => s.sessionUser);
+
+  // 退出登录：清服务端 session（at_dash_sess + 残留 _hi_sess）→ 回登录页。
+  const handleLogout = () => {
+    void fetch(apiUrl('/api/auth/logout'), { method: 'POST', credentials: 'same-origin' }).finally(() => {
+      window.location.replace('/login');
+    });
+  };
+
+  const levelLabel = userLevel === 3 ? '管理员' : userLevel === 2 ? '操作者' : '观察者';
 
   const visibleActions = useMemo(
     () => actions.filter((action) => isCreateActionVisible(action, mode, undefined, undefined, userLevel)),
@@ -264,6 +277,40 @@ export function DashboardHeader({
         )}
 
         <NotificationPopover />
+
+        {sessionUser && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-9 gap-2 px-2 text-xs">
+                <UserCircle className="h-4 w-4" />
+                <span className="max-w-[120px] truncate">{sessionUser}</span>
+                <Badge
+                  variant="secondary"
+                  className={`text-[10px] ${
+                    userLevel === 3
+                      ? 'bg-red-500/10 text-red-600 dark:text-red-400'
+                      : userLevel === 2
+                        ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+                        : 'bg-cyan-500/10 text-cyan-600 dark:text-cyan-400'
+                  }`}
+                >
+                  {levelLabel}
+                </Badge>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuLabel>当前账号</DropdownMenuLabel>
+              <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                {sessionUser} · {levelLabel}
+              </div>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleLogout} className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400">
+                <LogOut className="mr-2 h-4 w-4" />
+                退出登录
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
 
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useState, useMemo } from 'react';
 import type { RefObject } from 'react';
 import { useTheme } from '@/components/theme/theme-provider';
+import { useAgentTeamsStore } from '@/lib/agentteams-store';
 import {
   Search,
   Bot,
@@ -91,10 +92,11 @@ export function DashboardHeader({
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   const searchResults = useGlobalSearch(debouncedQuery, workers, teams, managers, humans);
+  const userLevel = useAgentTeamsStore((s) => s.userLevel);
 
   const visibleActions = useMemo(
-    () => actions.filter((action) => isCreateActionVisible(action, mode)),
-    [actions, mode]
+    () => actions.filter((action) => isCreateActionVisible(action, mode, undefined, undefined, userLevel)),
+    [actions, mode, userLevel]
   );
 
   // Cycle through the built-in themes: light → dark → high-contrast → light.

--- a/src/components/dashboard/mobile-sidebar.tsx
+++ b/src/components/dashboard/mobile-sidebar.tsx
@@ -47,9 +47,10 @@ export function MobileSidebar({
 }: MobileSidebarProps) {
   const taskBoardVisible = useAgentTeamsStore((s) => s.taskBoardVisible);
   const projectsVisible = useAgentTeamsStore((s) => s.projectsVisible);
+  const userLevel = useAgentTeamsStore((s) => s.userLevel);
   const visibleItems = useMemo(
-    () => navItems.filter((item) => isNavItemVisible(item, mode, taskBoardVisible, projectsVisible)),
-    [mode, taskBoardVisible, projectsVisible]
+    () => navItems.filter((item) => isNavItemVisible(item, mode, taskBoardVisible, projectsVisible, userLevel)),
+    [mode, taskBoardVisible, projectsVisible, userLevel]
   );
 
   // Group items by their group field

--- a/src/components/dashboard/nav-items.test.ts
+++ b/src/components/dashboard/nav-items.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { sectionMap } from './agent-teams-dashboard';
-import { navItems, navGroups } from './nav-items';
+import { createActions, isCreateActionVisible, isNavItemVisible, navItems, navGroups } from './nav-items';
 
 describe('Navigation with groups', () => {
   it('exposes grouped top-level entries', () => {
@@ -44,5 +44,39 @@ describe('Navigation with groups', () => {
 
   it('maps every navigation entry to a section', () => {
     expect(navItems.map((item) => item.id).every((id) => sectionMap[id])).toBe(true);
+  });
+});
+
+describe('UI level gate (M19 dual track)', () => {
+  it('hides admin-only nav items for L2 (level 2) users', () => {
+    const ids = navItems
+      .filter((item) => isNavItemVisible(item, undefined, true, true, 2))
+      .map((item) => item.id);
+    expect(ids).not.toContain('managers');
+    expect(ids).not.toContain('humans');
+    // Team-scoped surfaces stay visible for L2.
+    expect(ids).toContain('workers');
+    expect(ids).toContain('teams');
+    expect(ids).toContain('audit');
+  });
+
+  it('keeps every nav item for L1 (level 3) users', () => {
+    const ids = navItems
+      .filter((item) => isNavItemVisible(item, undefined, true, true, 3))
+      .map((item) => item.id);
+    expect(ids).toContain('managers');
+    expect(ids).toContain('humans');
+  });
+
+  it('hides the create-human action for L2 users', () => {
+    const l2 = createActions.filter((a) => isCreateActionVisible(a, undefined, true, true, 2)).map((a) => a.id);
+    expect(l2).not.toContain('create-human');
+    expect(l2).toContain('create-worker');
+    const l1 = createActions.filter((a) => isCreateActionVisible(a, undefined, true, true, 3)).map((a) => a.id);
+    expect(l1).toContain('create-human');
+  });
+
+  it('defaults to full visibility when the level is unknown (fail-open UI, server enforces)', () => {
+    expect(isNavItemVisible(navItems.find((i) => i.id === 'managers')!, undefined, true, true, undefined)).toBe(true);
   });
 });

--- a/src/components/dashboard/nav-items.ts
+++ b/src/components/dashboard/nav-items.ts
@@ -32,6 +32,12 @@ export interface NavItem {
   hiddenByFlag?: 'taskBoard' | 'projects';
   /** Experimental feature — sidebar shows a small "Beta" pill on the label. */
   isBeta?: boolean;
+  /**
+   * Minimum dashboard rbac level required to see this item (M19).
+   * 3 = Admin/L1 only. UI convenience gate; the Controller enforces the
+   * real boundary.
+   */
+  minLevel?: 1 | 2 | 3;
 }
 
 export const navItems: NavItem[] = [
@@ -41,9 +47,12 @@ export const navItems: NavItem[] = [
   { id: 'tasks', label: '任务看板', icon: ListTodo, group: 'runtime', hiddenByFlag: 'taskBoard', isBeta: true },
   { id: 'projects', label: '项目', icon: GitBranch, group: 'runtime', hiddenByFlag: 'projects', isBeta: true },
   { id: 'workers', label: 'Workers', icon: Bot, group: 'runtime' },
-  { id: 'managers', label: 'Managers', icon: Crown, group: 'runtime' },
+  // L1-only (minLevel 3): the Controller's A2 chain 403s L2 (Matrix token)
+  // reads on managers, and the humans list exposes sensitive fields
+  // (initialPassword) that must not be visible to team-level users.
+  { id: 'managers', label: 'Managers', icon: Crown, group: 'runtime', minLevel: 3 },
   { id: 'teams', label: '团队', icon: Users, group: 'runtime' },
-  { id: 'humans', label: 'Humans', icon: UserCheck, group: 'runtime' },
+  { id: 'humans', label: 'Humans', icon: UserCheck, group: 'runtime', minLevel: 3 },
   // 资源中心分组
   { id: 'skills', label: '市场', icon: Sparkles, group: 'resource' },
   { id: 'models', label: '模型', icon: Brain, group: 'resource' },
@@ -62,8 +71,12 @@ export function isNavItemVisible(
   item: NavItem,
   mode: DeploymentMode | null | undefined,
   taskBoardVisible?: boolean,
-  projectsVisible?: boolean
+  projectsVisible?: boolean,
+  userLevel?: number
 ): boolean {
+  // UI level gate (M19): admin-only sections for L2 users. Convenience
+  // layer only — the Controller (A2) enforces the real boundary.
+  if (item.minLevel && (userLevel ?? 3) < item.minLevel) return false;
   if (item.hiddenByFlag === 'taskBoard') {
     // Prefer the caller-provided value (reactive); fall back to the live
     // zustand store for non-React call sites.
@@ -87,12 +100,14 @@ export interface CreateAction {
   group?: NavGroup;
   modes?: DeploymentMode[];
   hiddenByFlag?: 'taskBoard' | 'projects';
+  /** Minimum dashboard rbac level required (M19), same as NavItem. */
+  minLevel?: 1 | 2 | 3;
 }
 
 export const createActions: readonly CreateAction[] = [
   { id: 'create-worker', label: '创建 Worker', icon: Bot, section: 'workers', group: 'runtime' },
   { id: 'create-team', label: '创建团队', icon: Users, section: 'teams', group: 'runtime' },
-  { id: 'create-human', label: '创建 Human', icon: UserCheck, section: 'humans', group: 'runtime' },
+  { id: 'create-human', label: '创建 Human', icon: UserCheck, section: 'humans', group: 'runtime', minLevel: 3 },
   { id: 'open-chat', label: '打开聊天', icon: MessageSquare, section: 'chat', group: 'core' },
 ] as const;
 
@@ -100,8 +115,10 @@ export function isCreateActionVisible(
   action: CreateAction,
   mode: DeploymentMode | null | undefined,
   taskBoardVisible?: boolean,
-  projectsVisible?: boolean
+  projectsVisible?: boolean,
+  userLevel?: number
 ): boolean {
+  if (action.minLevel && (userLevel ?? 3) < action.minLevel) return false;
   if (action.hiddenByFlag === 'taskBoard') {
     const visible = taskBoardVisible ?? useAgentTeamsStore.getState().taskBoardVisible;
     if (!visible) return false;

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -148,9 +148,10 @@ export function Sidebar({
 }: SidebarProps) {
   const taskBoardVisible = useAgentTeamsStore((s) => s.taskBoardVisible);
   const projectsVisible = useAgentTeamsStore((s) => s.projectsVisible);
+  const userLevel = useAgentTeamsStore((s) => s.userLevel);
   const visibleItems = useMemo(
-    () => navItems.filter((item) => isNavItemVisible(item, mode, taskBoardVisible, projectsVisible)),
-    [mode, taskBoardVisible, projectsVisible]
+    () => navItems.filter((item) => isNavItemVisible(item, mode, taskBoardVisible, projectsVisible, userLevel)),
+    [mode, taskBoardVisible, projectsVisible, userLevel]
   );
 
   // Group items by their group field

--- a/src/lib/agentteams-store.ts
+++ b/src/lib/agentteams-store.ts
@@ -41,6 +41,14 @@ interface AgentTeamsState {
   userLevel: number;
 
   /**
+   * Current dashboard session username (from /api/auth/session on mount).
+   * Null when unauthenticated. Drives the header account chip.
+   * Deliberately NOT persisted (partialize) — identity must never survive
+   * a page reload without a fresh session check.
+   */
+  sessionUser: string | null;
+
+  /**
    * Whether the 项目 nav item is visible (beta feature). Defaults to true
    * so the section is on out of the box; users can opt out in Settings.
    * Hidden = the nav item is removed, the section route still works if
@@ -57,6 +65,7 @@ interface AgentTeamsState {
   setTaskBoardVisible: (_val: boolean) => void;
   setProjectsVisible: (_val: boolean) => void;
   setUserLevel: (_val: number) => void;
+  setSessionUser: (_val: string | null) => void;
   addConnectionAttempt: (_attempt: ConnectionAttempt) => void;
 }
 
@@ -81,6 +90,7 @@ export const useAgentTeamsStore = create<AgentTeamsState>()(
       taskBoardVisible: true,
       projectsVisible: true,
       userLevel: 3,
+      sessionUser: null,
 
       setControllerUrl: (url: string) => {
         set({ controllerUrl: url });
@@ -161,6 +171,10 @@ export const useAgentTeamsStore = create<AgentTeamsState>()(
 
       setUserLevel: (val: number) => {
         set({ userLevel: val });
+      },
+
+      setSessionUser: (val: string | null) => {
+        set({ sessionUser: val });
       },
 
       setProjectsVisible: (val: boolean) => {

--- a/src/lib/agentteams-store.ts
+++ b/src/lib/agentteams-store.ts
@@ -31,6 +31,16 @@ interface AgentTeamsState {
   taskBoardVisible: boolean;
 
   /**
+   * Dashboard rbac level of the logged-in user (M19 dual track):
+   * 3 Admin (L1, SA credential) / 2 Operator (L2, own Matrix token) /
+   * 1 Observer. Used ONLY for the UI level gate — the security boundary is
+   * server-side (middleware + Controller A2). Default 3 so unauthenticated
+   * dev setups (AUTH_DISABLED) keep full nav; the session endpoint sets the
+   * real level on mount. Deliberately NOT persisted.
+   */
+  userLevel: number;
+
+  /**
    * Whether the 项目 nav item is visible (beta feature). Defaults to true
    * so the section is on out of the box; users can opt out in Settings.
    * Hidden = the nav item is removed, the section route still works if
@@ -46,6 +56,7 @@ interface AgentTeamsState {
   setReconnectInterval: (_ms: number) => void;
   setTaskBoardVisible: (_val: boolean) => void;
   setProjectsVisible: (_val: boolean) => void;
+  setUserLevel: (_val: number) => void;
   addConnectionAttempt: (_attempt: ConnectionAttempt) => void;
 }
 
@@ -69,6 +80,7 @@ export const useAgentTeamsStore = create<AgentTeamsState>()(
       connectionHistory: [],
       taskBoardVisible: true,
       projectsVisible: true,
+      userLevel: 3,
 
       setControllerUrl: (url: string) => {
         set({ controllerUrl: url });
@@ -145,6 +157,10 @@ export const useAgentTeamsStore = create<AgentTeamsState>()(
 
       setTaskBoardVisible: (val: boolean) => {
         set({ taskBoardVisible: val });
+      },
+
+      setUserLevel: (val: number) => {
+        set({ userLevel: val });
       },
 
       setProjectsVisible: (val: boolean) => {

--- a/src/lib/dashboard-session.test.ts
+++ b/src/lib/dashboard-session.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createHmac, randomBytes } from 'crypto';
+import {
+  SESSION_COOKIE_NAME,
+  __resetSessionStoreForTests,
+  clearSessionCookieHeader,
+  createSession,
+  destroySession,
+  getSessionFromRequest,
+  mapCrLevelToDashLevel,
+  parseCookies,
+  sessionCookieHeader,
+  validateSessionToken,
+} from './dashboard-session';
+
+const SECRET = 'a'.repeat(64);
+
+function fakeRequest(cookieHeader: string | null) {
+  return { headers: { get: (name: string) => (name.toLowerCase() === 'cookie' ? cookieHeader : null) } };
+}
+
+beforeEach(() => {
+  __resetSessionStoreForTests();
+  process.env.DASHBOARD_SESSION_SECRET = SECRET;
+  delete process.env.DASHBOARD_COOKIE_SECURE;
+});
+
+describe('mapCrLevelToDashLevel (E5 inversion)', () => {
+  it('maps CRD 1 (L1) to dashboard Admin 3', () => expect(mapCrLevelToDashLevel(1)).toBe(3));
+  it('maps CRD 2 (L2) to dashboard Operator 2', () => expect(mapCrLevelToDashLevel(2)).toBe(2));
+  it('maps CRD 3 (L3) to dashboard Observer 1', () => expect(mapCrLevelToDashLevel(3)).toBe(1));
+  it('maps unknown levels down to Observer 1 (fail-safe)', () => {
+    expect(mapCrLevelToDashLevel(0)).toBe(1);
+    expect(mapCrLevelToDashLevel(99)).toBe(1);
+  });
+});
+
+describe('createSession / validateSessionToken', () => {
+  it('round-trips user, mapped level, teams and credential', () => {
+    const { sessionId, cookieValue } = createSession({
+      user: 'sunzong',
+      crLevel: 2,
+      teams: ['biz-team'],
+      credential: { kind: 'matrix', token: 'syt_token_x' },
+    });
+    expect(sessionId).toHaveLength(64);
+    const session = validateSessionToken(cookieValue);
+    expect(session).not.toBeNull();
+    expect(session?.user).toBe('sunzong');
+    expect(session?.level).toBe(2);
+    expect(session?.crLevel).toBe(2);
+    expect(session?.teams).toEqual(['biz-team']);
+    expect(session?.credential).toEqual({ kind: 'matrix', token: 'syt_token_x' });
+  });
+
+  it('maps L1 (CRD 1) to dashboard level 3 with SA credential', () => {
+    const { cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    expect(validateSessionToken(cookieValue)?.level).toBe(3);
+    expect(validateSessionToken(cookieValue)?.credential).toEqual({ kind: 'sa' });
+  });
+
+  it('rejects a tampered payload', () => {
+    const { cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    const [encoded] = cookieValue.split('.');
+    const tampered = Buffer.from(
+      JSON.stringify({ sid: (JSON.parse(Buffer.from(encoded, 'base64url').toString()) as { sid: string }).sid, user: 'luo', iat: Date.now(), exp: Date.now() + 100000 }),
+    ).toString('base64url');
+    expect(validateSessionToken(`${tampered}.${cookieValue.split('.')[1]}`)).toBeNull();
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const { cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    const encoded = cookieValue.split('.')[0];
+    const otherSig = createHmac('sha256', 'b'.repeat(64)).update(encoded).digest('base64url');
+    expect(validateSessionToken(`${encoded}.${otherSig}`)).toBeNull();
+  });
+
+  it('rejects an expired token (valid signature, past exp)', () => {
+    const payload = JSON.stringify({ sid: randomBytes(32).toString('hex'), user: 'luo', iat: 1, exp: 2 });
+    const encoded = Buffer.from(payload).toString('base64url');
+    const signature = createHmac('sha256', SECRET).update(encoded).digest('base64url');
+    expect(validateSessionToken(`${encoded}.${signature}`)).toBeNull();
+  });
+
+  it('rejects a session destroyed server-side even with a valid cookie', () => {
+    const { sessionId, cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    destroySession(sessionId);
+    expect(validateSessionToken(cookieValue)).toBeNull();
+  });
+
+  it('never returns a token in the cookie value (tokens stay server-side)', () => {
+    const { cookieValue } = createSession({
+      user: 'sunzong',
+      crLevel: 2,
+      credential: { kind: 'matrix', token: 'SECRET_MATRIX_TOKEN' },
+    });
+    expect(cookieValue).not.toContain('SECRET_MATRIX_TOKEN');
+  });
+});
+
+describe('secret handling (fail closed)', () => {
+  it('refuses to create sessions without DASHBOARD_SESSION_SECRET', () => {
+    delete process.env.DASHBOARD_SESSION_SECRET;
+    expect(() => createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } })).toThrow();
+  });
+
+  it('refuses short secrets (< 32 bytes hex)', () => {
+    process.env.DASHBOARD_SESSION_SECRET = 'short';
+    expect(() => createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } })).toThrow();
+    expect(validateSessionToken('x.y')).toBeNull();
+  });
+});
+
+describe('cookie plumbing', () => {
+  it('parses a Cookie header and resolves the session from a request', () => {
+    const { cookieValue } = createSession({ user: 'maizong', crLevel: 2, teams: ['market-team'], credential: { kind: 'matrix', token: 't' } });
+    const session = getSessionFromRequest(fakeRequest(`other=1; ${SESSION_COOKIE_NAME}=${cookieValue}`));
+    expect(session?.user).toBe('maizong');
+    expect(session?.teams).toEqual(['market-team']);
+  });
+
+  it('returns null when the cookie is absent', () => {
+    expect(getSessionFromRequest(fakeRequest(null))).toBeNull();
+    expect(getSessionFromRequest(fakeRequest('unrelated=1'))).toBeNull();
+  });
+
+  it('builds HttpOnly/SameSite=Lax cookies without Secure by default (LAN HTTP)', () => {
+    const header = sessionCookieHeader('abc.def');
+    expect(header).toContain('HttpOnly');
+    expect(header).toContain('SameSite=Lax');
+    expect(header).toContain('Path=/');
+    expect(header).not.toContain('Secure');
+  });
+
+  it('adds Secure only when DASHBOARD_COOKIE_SECURE=1', () => {
+    process.env.DASHBOARD_COOKIE_SECURE = '1';
+    expect(sessionCookieHeader('abc.def')).toContain('Secure');
+  });
+
+  it('clears the cookie with Max-Age=0', () => {
+    expect(clearSessionCookieHeader()).toContain('Max-Age=0');
+  });
+
+  it('parseCookies trims and decodes', () => {
+    expect(parseCookies(' a = b%40c ; d=e ')).toEqual({ a: 'b@c', d: 'e' });
+  });
+});

--- a/src/lib/dashboard-session.test.ts
+++ b/src/lib/dashboard-session.test.ts
@@ -98,6 +98,28 @@ describe('createSession / validateSessionToken', () => {
   });
 });
 
+describe('store identity across module instances (middleware vs route bundles)', () => {
+  // Next.js bundles the middleware chunk and the app-router chunk separately:
+  // each gets its own module instance of this file. If the session store were
+  // plain module-level state, the middleware could never see a session created
+  // by the login route (and every data request would 401 with a valid cookie).
+  // The store must live on globalThis so all bundles in the standalone node
+  // process share one instance.
+  it('a session created in one module instance validates in another', async () => {
+    const modA = await import('./dashboard-session');
+    // Vitest cache-bust suffix: forces a second module instance (simulates
+    // the middleware bundle vs the app-router bundle in the standalone server).
+    // @ts-expect-error query-suffixed specifier is not resolvable by tsc
+    const modB = await import('./dashboard-session?instance=2');
+    const { cookieValue } = modA.createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+    expect(modB.validateSessionToken(cookieValue)).not.toBeNull();
+    // Logout in one bundle must be visible in the other.
+    const second = modA.createSession({ user: 'sunzong', crLevel: 2, credential: { kind: 'matrix', token: 't' } });
+    modA.destroySession(second.sessionId);
+    expect(modB.validateSessionToken(second.cookieValue)).toBeNull();
+  });
+});
+
 describe('secret handling (fail closed)', () => {
   it('refuses to create sessions without DASHBOARD_SESSION_SECRET', () => {
     delete process.env.DASHBOARD_SESSION_SECRET;

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -28,12 +28,14 @@ const MAX_SESSIONS = 1000;
 
 /** Controller credential carried server-side per session. */
 export type ControllerCredential =
-  | { kind: 'sa' } // L1 via Console track: admin SA token from env (never leaves the server)
-  | { kind: 'matrix'; token: string } // L2: the user's own Matrix access token
-  | { kind: 'controller-token'; token: string }; // L1 via Matrix track: admin Controller
-  // token pasted at login (the Controller's Matrix auth only accepts level-2
-  // tokens, so a level-1 human like luo needs an admin-grade token for the
-  // data plane — same dual mode as the workbench plugin's admin-token mode).
+  | { kind: 'sa' } // Admin data-plane access: the admin SA token from env
+  //   (never leaves the server). Used by the Console track AND by
+  //   top-permission (CR level 1) accounts logging in via the Matrix track
+  //   after their admin account password has been verified — the Controller's
+  //   Matrix auth only accepts level-2 tokens, so a level-1 Matrix token
+  //   cannot be the data-plane credential.
+  | { kind: 'matrix'; token: string }; // Own-permission accounts (CR level 2/3):
+  //   the user's own Matrix access token; A2 scopes reads to accessibleTeams.
 
 export interface DashboardSession {
   sid: string;

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -50,10 +50,17 @@ interface SessionStore {
   insertionOrder: string[];
 }
 
-const store: SessionStore = {
-  sessions: new Map(),
-  insertionOrder: [],
-};
+// Store instance lives on globalThis, NOT at module level. Next.js bundles
+// the middleware chunk and the app-router chunk separately, so each would get
+// its own module instance — and with a module-level Map the middleware could
+// never see sessions created by the login route (every data request would
+// 401 with a perfectly valid cookie). All bundles run in the same standalone
+// node process, so globalThis is the one state they all share.
+// (Constraint: single process — container restart / multi-replica = everyone
+// re-logs in, which is the documented behavior.)
+const globalForSessions = globalThis as typeof globalThis & { __agentteamsSessions?: SessionStore };
+const store: SessionStore =
+  globalForSessions.__agentteamsSessions ??= { sessions: new Map(), insertionOrder: [] };
 
 function getSecret(): string | null {
   const secret = process.env.DASHBOARD_SESSION_SECRET || '';

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -43,7 +43,7 @@ export type ControllerCredential =
 
 export interface DashboardSession {
   sid: string;
-  /** Human CR name / display username (luo / sunzong / maizong). */
+  /** Human CR name / display username (the Matrix localpart of the account). */
   user: string;
   /** Dashboard rbac-engine level: 1 Observer / 2 Operator / 3 Admin. */
   level: 1 | 2 | 3;

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -31,9 +31,13 @@ export type ControllerCredential =
   | { kind: 'sa' } // Admin data-plane access: the admin SA token from env
   //   (never leaves the server). Used by the Console track AND by
   //   top-permission (CR level 1) accounts logging in via the Matrix track
-  //   after their admin account password has been verified — the Controller's
+  //   after their admin account PASSWORD has been verified — the Controller's
   //   Matrix auth only accepts level-2 tokens, so a level-1 Matrix token
   //   cannot be the data-plane credential.
+  | { kind: 'controller-token'; token: string } // CR level 1 via the Matrix
+  //   track with a pasted Controller admin token (verified against the
+  //   Controller at login, held server-side only — same as the workbench
+  //   plugin's admin-token mode).
   | { kind: 'matrix'; token: string }; // Own-permission accounts (CR level 2/3):
   //   the user's own Matrix access token; A2 scopes reads to accessibleTeams.
 

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -28,8 +28,12 @@ const MAX_SESSIONS = 1000;
 
 /** Controller credential carried server-side per session. */
 export type ControllerCredential =
-  | { kind: 'sa' } // L1: use the admin SA token from env (never leave the server)
-  | { kind: 'matrix'; token: string }; // L2: the user's own Matrix access token
+  | { kind: 'sa' } // L1 via Console track: admin SA token from env (never leaves the server)
+  | { kind: 'matrix'; token: string } // L2: the user's own Matrix access token
+  | { kind: 'controller-token'; token: string }; // L1 via Matrix track: admin Controller
+  // token pasted at login (the Controller's Matrix auth only accepts level-2
+  // tokens, so a level-1 human like luo needs an admin-grade token for the
+  // data plane — same dual mode as the workbench plugin's admin-token mode).
 
 export interface DashboardSession {
   sid: string;

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -1,0 +1,196 @@
+// Dashboard session store — multi-user login (M19 / batch M).
+//
+// Design (合一文档 §11.1 v1.4):
+// - The browser receives a signed, HttpOnly session cookie. It contains only a
+//   session id + display name — NEVER a Controller/Matrix token.
+// - Per-user credentials live in a server-side in-memory map (see
+//   proxy-helper: "NEVER trust browser-supplied Authorization header").
+// - Controller credential selection:
+//     L1 (dashboard level 3) → the admin SA token from env (full access)
+//     L2 (dashboard level 2) → the user's own Matrix access token (A2 chain:
+//       whoami → Human CR → team-scoped reads + same-team project writes)
+// - Level mapping (E5, 级别量表反转): the Human CRD scale is INVERTED relative
+//   to this dashboard's rbac-engine scale.
+//     CRD 1 (L1 admin)  → dashboard 3 (Admin)
+//     CRD 2 (L2 team)   → dashboard 2 (Operator)
+//     CRD 3 (L3 worker) → dashboard 1 (Observer)
+// - Container restart ⇒ in-memory store lost ⇒ everyone re-logs in. Documented.
+// - The session secret MUST be provided via DASHBOARD_SESSION_SECRET (hex,
+//   ≥32 bytes). Missing/short secret = fail closed (login refused, loud log).
+//
+// Reference implementation: git d9182c4^:src/lib/auth-local.ts (deleted 7/3).
+
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+export const SESSION_COOKIE_NAME = 'at_dash_sess';
+const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const MAX_SESSIONS = 1000;
+
+/** Controller credential carried server-side per session. */
+export type ControllerCredential =
+  | { kind: 'sa' } // L1: use the admin SA token from env (never leave the server)
+  | { kind: 'matrix'; token: string }; // L2: the user's own Matrix access token
+
+export interface DashboardSession {
+  sid: string;
+  /** Human CR name / display username (luo / sunzong / maizong). */
+  user: string;
+  /** Dashboard rbac-engine level: 1 Observer / 2 Operator / 3 Admin. */
+  level: 1 | 2 | 3;
+  /** Human CR permissionLevel (1=L1 / 2=L2 / 3=L3) — kept for audit/debug. */
+  crLevel: number;
+  /** Human CR accessibleTeams (L2 scoping; informational — Controller enforces). */
+  teams: string[];
+  credential: ControllerCredential;
+  createdAt: number;
+}
+
+interface SessionStore {
+  sessions: Map<string, DashboardSession>;
+  insertionOrder: string[];
+}
+
+const store: SessionStore = {
+  sessions: new Map(),
+  insertionOrder: [],
+};
+
+function getSecret(): string | null {
+  const secret = process.env.DASHBOARD_SESSION_SECRET || '';
+  if (secret.length < 64) {
+    return null; // hex of ≥32 bytes
+  }
+  return secret;
+}
+
+let secretWarned = false;
+function requireSecret(): string {
+  const secret = getSecret();
+  if (!secret) {
+    if (!secretWarned) {
+      secretWarned = true;
+      console.error(
+        '[dashboard-session] DASHBOARD_SESSION_SECRET is missing or too short (<64 hex chars). ' +
+          'Multi-user login is DISABLED (fail closed). Set it in the dashboard container env.',
+      );
+    }
+    throw new Error('DASHBOARD_SESSION_SECRET not configured');
+  }
+  return secret;
+}
+
+function sign(encoded: string, secret: string): string {
+  return createHmac('sha256', secret).update(encoded).digest('base64url');
+}
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/** Map Human CRD permissionLevel → dashboard rbac-engine level (E5 inversion). */
+export function mapCrLevelToDashLevel(crLevel: number): 1 | 2 | 3 {
+  if (crLevel === 1) return 3;
+  if (crLevel === 2) return 2;
+  return 1;
+}
+
+export interface CreateSessionInput {
+  user: string;
+  crLevel: number;
+  teams?: string[];
+  credential: ControllerCredential;
+}
+
+/** Create a session and return the signed cookie value. */
+export function createSession(input: CreateSessionInput): { sessionId: string; cookieValue: string } {
+  const secret = requireSecret();
+  const sid = randomBytes(32).toString('hex');
+  const session: DashboardSession = {
+    sid,
+    user: input.user,
+    level: mapCrLevelToDashLevel(input.crLevel),
+    crLevel: input.crLevel,
+    teams: input.teams ?? [],
+    credential: input.credential,
+    createdAt: Date.now(),
+  };
+  store.sessions.set(sid, session);
+  store.insertionOrder.push(sid);
+  if (store.insertionOrder.length > MAX_SESSIONS) {
+    const evicted = store.insertionOrder.shift();
+    if (evicted) store.sessions.delete(evicted);
+  }
+  const payload = JSON.stringify({ sid, user: session.user, iat: Date.now(), exp: Date.now() + SESSION_MAX_AGE_MS });
+  const encoded = Buffer.from(payload).toString('base64url');
+  return { sessionId: sid, cookieValue: `${encoded}.${sign(encoded, secret)}` };
+}
+
+/** Validate a signed cookie value and return the live session (if still present server-side). */
+export function validateSessionToken(token: string): DashboardSession | null {
+  const secret = getSecret();
+  if (!secret) return null;
+  try {
+    const dot = token.indexOf('.');
+    if (dot <= 0) return null;
+    const encoded = token.slice(0, dot);
+    const signature = token.slice(dot + 1);
+    if (!timingSafeEqualStr(sign(encoded, secret), signature)) return null;
+    const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString()) as {
+      sid?: string;
+      exp?: number;
+    };
+    if (!payload.sid || typeof payload.exp !== 'number' || payload.exp < Date.now()) return null;
+    return store.sessions.get(payload.sid) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function destroySession(sessionId: string): void {
+  store.sessions.delete(sessionId);
+  store.insertionOrder = store.insertionOrder.filter((s) => s !== sessionId);
+}
+
+/** Parse the `Cookie` header of a request into a record. */
+export function parseCookies(header: string | null | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx <= 0) continue;
+    const key = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (key) out[key] = decodeURIComponent(value);
+  }
+  return out;
+}
+
+/** Resolve the dashboard session from a request Cookie header. */
+export function getSessionFromRequest(request: { headers: { get(_name: string): string | null } }): DashboardSession | null {
+  const cookies = parseCookies(request.headers.get('cookie'));
+  const token = cookies[SESSION_COOKIE_NAME];
+  if (!token) return null;
+  return validateSessionToken(token);
+}
+
+/** Build the Set-Cookie header value for a session. */
+export function sessionCookieHeader(cookieValue: string): string {
+  const secure = process.env.DASHBOARD_COOKIE_SECURE === '1' ? '; Secure' : '';
+  return (
+    `${SESSION_COOKIE_NAME}=${cookieValue}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${Math.floor(SESSION_MAX_AGE_MS / 1000)}${secure}`
+  );
+}
+
+/** Set-Cookie value that clears the session cookie. */
+export function clearSessionCookieHeader(): string {
+  return `${SESSION_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
+}
+
+/** Test/ops helper — drop all in-memory sessions. */
+export function __resetSessionStoreForTests(): void {
+  store.sessions.clear();
+  store.insertionOrder.length = 0;
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from './middleware';
+import {
+  SESSION_COOKIE_NAME,
+  __resetSessionStoreForTests,
+  createSession,
+} from '@/lib/dashboard-session';
+
+const SECRET = 'f'.repeat(64);
+
+function dataRequest(path: string, cookie?: string) {
+  const headers = new Headers();
+  if (cookie) headers.set('cookie', cookie);
+  return new NextRequest(`http://dashboard.test${path}`, { headers });
+}
+
+function l2Cookie(user = 'sunzong') {
+  const { cookieValue } = createSession({
+    user,
+    crLevel: 2,
+    teams: ['biz-team'],
+    credential: { kind: 'matrix', token: 'syt_test' },
+  });
+  return cookieValue;
+}
+
+function l1Cookie() {
+  const { cookieValue } = createSession({ user: 'luo', crLevel: 1, credential: { kind: 'sa' } });
+  return cookieValue;
+}
+
+describe('middleware auth gate (M19 dashboard session)', () => {
+  beforeEach(() => {
+    __resetSessionStoreForTests();
+    process.env.DASHBOARD_SESSION_SECRET = SECRET;
+    delete process.env.AGENTTEAMS_AUTH_DISABLED;
+  });
+
+  afterEach(() => {
+    __resetSessionStoreForTests();
+    delete process.env.DASHBOARD_SESSION_SECRET;
+    delete process.env.AGENTTEAMS_AUTH_DISABLED;
+  });
+
+  it('401 on /api/agentteams/* without a session cookie', async () => {
+    const res = await middleware(dataRequest('/api/agentteams/teams'));
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('401 on a forged (tampered) session cookie', async () => {
+    const cookieValue = l2Cookie();
+    const tampered = cookieValue.slice(0, -4) + 'xxxx';
+    const res = await middleware(dataRequest('/api/agentteams/teams', `${SESSION_COOKIE_NAME}=${tampered}`));
+    expect(res.status).toBe(401);
+  });
+
+  it('401 on a cookie from a destroyed session (restart semantics)', async () => {
+    const { cookieValue } = createSession({ user: 'sunzong', crLevel: 2, credential: { kind: 'matrix', token: 't' } });
+    __resetSessionStoreForTests(); // simulate container restart
+    const res = await middleware(dataRequest('/api/agentteams/teams', `${SESSION_COOKIE_NAME}=${cookieValue}`));
+    expect(res.status).toBe(401);
+  });
+
+  // Identity-header injection (x-agentteams-user/level) is asserted
+  // end-to-end in proxy-helper.test.ts ("forwards the server-resolved
+  // x-agentteams identity headers"); NextResponse.next does not expose the
+  // overridden request headers on the response object.
+  it('lets an L2 session through (gate open)', async () => {
+    const res = await middleware(dataRequest('/api/agentteams/teams', `${SESSION_COOKIE_NAME}=${l2Cookie()}`));
+    expect(res.status).toBe(200);
+  });
+
+  it('lets an L1 (Console) session through (gate open)', async () => {
+    const res = await middleware(dataRequest('/api/agentteams/teams', `${SESSION_COOKIE_NAME}=${l1Cookie()}`));
+    expect(res.status).toBe(200);
+  });
+
+  it('keeps the PUBLIC_PATHS escape (setup/status without a session)', async () => {
+    const res = await middleware(dataRequest('/api/agentteams/setup/status'));
+    expect(res.status).toBe(200);
+  });
+
+  it('keeps the AGENTTEAMS_AUTH_DISABLED escape hatch', async () => {
+    process.env.AGENTTEAMS_AUTH_DISABLED = 'true';
+    const res = await middleware(dataRequest('/api/agentteams/teams'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-agentteams-auth-mode')).toBe('disabled');
+  });
+
+  it('passes OPTIONS preflight through (no credentials on preflight)', async () => {
+    const res = await middleware(new NextRequest('http://dashboard.test/api/agentteams/teams', { method: 'OPTIONS' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('redirects legacy /dashboard/ URLs to root', async () => {
+    const res = await middleware(dataRequest('/dashboard/workers'));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://dashboard.test/workers');
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { validateHigressSession } from './lib/api-auth';
+import { getSessionFromRequest } from './lib/dashboard-session';
 
 // Force Node.js runtime because api-auth.ts imports higress/proxy-helper which
 // uses AbortController/timeout patterns that are safer under Node runtime.
@@ -48,8 +48,11 @@ export async function middleware(request: NextRequest) {
   }
 
   // API auth gate: protect ALL /api/agentteams/* routes.
-  // The SA token authenticates Dashboard→Controller, not the browser caller.
-  // All browser requests (GET included) must present a valid Higress session cookie.
+  // Identity = the dashboard session cookie (at_dash_sess), created by the
+  // dual-track login (M19): L1 = Higress Console admin (SA credential,
+  // dashboard level 3) or L2 = Matrix login (own Matrix token, level 2).
+  // The Controller credential (SA or Matrix token) never leaves the server —
+  // see proxy-helper: "NEVER trust browser-supplied Authorization header".
   if (pathname.startsWith('/api/agentteams/')) {
     const isPublicPath = PUBLIC_PATHS.some((p) => pathname.startsWith(p));
     if (isPublicPath) {
@@ -80,14 +83,18 @@ export async function middleware(request: NextRequest) {
       return res;
     }
 
-    const { valid, user } = await validateHigressSession(request);
-    if (!valid) {
+    const session = getSessionFromRequest(request);
+    if (!session) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Forward the resolved identity downstream so route handlers (and the
     // Controller proxy) can apply server-side RBAC + audit attribution.
-    return NextResponse.next({ request: { headers: withUserHeaders(request, user) } });
+    // `level` is already the dashboard rbac-engine level (E5 mapping applied
+    // at session creation: CRD 1→3, 2→2, 3→1).
+    return NextResponse.next({
+      request: { headers: withUserHeaders(request, { name: session.user, level: session.level }) },
+    });
   }
 
   return NextResponse.next();


### PR DESCRIPTION
# Multi-user login with server-side session store (dual track)

## Summary

The dashboard had no real multi-user identity. Every data-plane call shared one admin service-account token; the "logged-in user" was extracted from the first record of the Higress Console `/v1/consumers` list — always the `manager` gateway consumer, so every audit entry was attributed to the wrong actor; and the only account that could log in at all was the Console admin (the Console is single-operator with no multi-user API), so operator accounts (Human CR `permissionLevel` 2/3) had no door into the dashboard.

This PR reworks login and the session model so every Human CR account can log in as itself, and the data plane acts as that account:

- **Dual-track login** (`POST /api/auth/login`):
  - **Console track** — the deployment admin account. Identity is the Console username itself (no Human CR required); the session carries the server-side SA credential at level 3 (full access incl. gateway/Audit/Storage). The Console session cookie is still forwarded so the gateway tab keeps working.
  - **Matrix track** — any Human account. Server-side Matrix password login → own access token → localpart → Human CR lookup via the admin SA. `permissionLevel` maps to the dashboard level (1→3 full, 2→2 scoped to `accessibleTeams`, 3→1 observer); a missing CR → generic 401. Level 2/3 sessions carry the user's **own** Matrix token as the Controller credential, so the Controller's A2 chain scopes their reads/writes to `accessibleTeams` (out-of-scope writes already fail with 403 there).
  - **Level 3 via Matrix requires admin verification**: the Controller's Matrix authenticator only accepts level-2 tokens, so a level-1 account's own token cannot serve as the data-plane credential. The login form offers two alternatives (same as the workbench plugin's admin-token mode): the admin account's Console password, verified server-side by a second Console login (session then uses the env SA), or a pasted Controller admin token, verified server-side against `GET /api/v1/teams` (session then carries that token). Either credential never leaves the server and never reaches a cookie.
- **Server-side session store** — in-memory `{sessionId → {user, level, credential}}` shared across Next bundle instances via `globalThis` (middleware and route handlers are separate module graphs; a module-level Map silently duplicates). Cookie `at_dash_sess` = HMAC-signed `{sessionId, user}`, `HttpOnly` + `SameSite=Lax`; no `Secure` flag by default (LAN HTTP deployments), opt-in via `DASHBOARD_COOKIE_SECURE=1`. Fail-closed: without `DASHBOARD_SESSION_SECRET` (≥64 hex chars) login returns 503 with a clear error instead of degrading. Known v1 trade-off (documented): container restart invalidates all sessions.
- **Per-request identity & scoping** — `middleware` gates `/api/agentteams/*` on the dashboard session (replacing the `/v1/consumers` probe) and injects the real `x-agentteams-user` / `x-agentteams-user-level`; `proxy-helper` selects the per-session Controller Bearer (level 2/3 = own Matrix token, admin = env SA) and keeps the existing "never trust browser Authorization when the SA env is present" rule. New endpoints: `GET /api/auth/session` (`{username, level, mode}`) and `POST /api/auth/logout`.
- **UI level-gating** — nav and quick actions respect levels (`Managers` / `Humans` / "Create Human" require level 3); the header shows an account chip (`username · level`) with a logout action returning to `/` (the login UI renders at the root path). The Console auto-initializer/auto-register path is removed: it created a Console admin from whatever account name first logged in — a privilege-escalation hole once real accounts log in.
- **Install & env** — `install/agentteams-dashboard.sh` generates and persists `DASHBOARD_SESSION_SECRET` (openssl rand -hex 32, mode 600, stable across rebuilds); `.env.example` documents it.

**Deployment note (one line):** existing single-admin deployments add one env var — `DASHBOARD_SESSION_SECRET` (`openssl rand -hex 32`, reuse the same value across container rebuilds; a changed value invalidates all sessions). Audit `actor` changes from the constant (wrong) `manager` to the real username starting with the first login after upgrade. The `AUTH_DISABLED` escape hatch still works.

## What's included

- `src/lib/dashboard-session.ts` (new) + `dashboard-session.test.ts` — signed-cookie session store, level mapping, fail-closed secret, globalThis sharing.
- `src/app/api/auth/login/route.ts` (+ test) — dual-track login rewritten: Console track, Matrix track with Human CR level lookup, level-3 admin verification (password or pasted token), generic 401, cookie that never contains credentials.
- `src/app/api/auth/session/route.ts`, `src/app/api/auth/logout/route.ts` (+ tests) — new session introspection and logout.
- `src/middleware.ts` (+ test) — session gate on `/api/agentteams/*`, real user/level header injection.
- `src/app/api/agentteams/proxy-helper.ts` (+ test) — per-session Controller Bearer selection (own Matrix token / pasted admin token / env SA), browser Authorization still never trusted.
- `src/components/auth/login-page.tsx` — single form for all accounts: username/password + collapsible "admin verification" (admin account password **or** Controller admin token) shown for level-3-via-Matrix.
- `src/components/dashboard/{nav-items,sidebar,mobile-sidebar,agent-teams-dashboard,header}.ts(x)` — level-gated nav/quick actions, account chip with logout.
- `src/app/page.tsx`, `src/lib/agentteams-store.ts` — login rendering at root path, level in the client store.
- `install/agentteams-dashboard.sh`, `.env.example` — secret generation/persistence and env documentation.
- `eslint.config.mjs`, `.gitignore` — `dist/**` ignored (local build artifacts).

## Data boundary

- **No credential leaves the server.** The admin SA stays in env; a level-2/3 user's Matrix token and a pasted admin token live only in the server-side session store. The signed cookie carries `{sessionId, user}` only — never a token.
- **No schema/CRD change.** No Controller change, no new upstream API consumed beyond existing ones (Matrix login, `GET /humans/{name}`, `GET /api/v1/teams` for token verification).
- **Purely additive for existing callers** — the `AUTH_DISABLED` escape hatch and all `/api/higress/*` (Console session-gated) behavior are unchanged; level 3 keeps every tab.
- **Scope enforcement stays where it belongs** — read/write scoping for level 2/3 is enforced by the Controller's A2 chain on the user's own token; the dashboard adds no second (divergent) scoping layer. Out-of-scope writes already 403 at the Controller.
- **Removal, not regression, of the auto-initializer** — it is no longer reachable from the login flow; deployments with an already-initialized Console are unaffected (the old path was a silent no-op there).

## Tests

- New/updated, all green on Node 20: `dashboard-session.test.ts` (20: signing round-trip, tamper rejection, fail-closed secret, cross-bundle-instance store sharing); `auth/login/route.test.ts` (13: both tracks, permissionLevel mapping, missing CR 401, admin-verification matrix — missing 400 / wrong password 401 / invalid token 401 / valid token level-3 with no token in any cookie / level 2-3 ignoring admin fields); `auth/session` (4), `auth/logout` (3), `middleware.test.ts` (9: unauthenticated 401, level injection, AUTH_DISABLED bypass); `proxy-helper.test.ts` (10: Bearer selection matrix); `nav-items.test.ts` (level gating).
- Full suite: 148 files / 129 passing; the 19 failing files are pre-existing jsdom-environment failures on the local Node 25 container (theme store, plugin registry, …) with zero overlap with this diff — identical failure set on the unmodified base.
- `tsc --noEmit` clean; ESLint 0 errors; `next build` green (33/33 pages).

## Related

- Follow-ups (out of scope here): a Controller `whoami` endpoint (would replace the SA Human-CR lookup for token-less clients such as the workbench plugin) — separate upstream PR; button-level write hiding for level 2 (Controller 403 already fails closed); persistent session store surviving restarts (v2 candidate).
- Pairs with the workbench plugin's dual-mode admin authentication (admin-token mode); the plugin gaining the admin-password alternative is tracked separately.

---

# 多用户登录与服务端会话存储（双轨）

## 摘要

此前 dashboard 没有真正的多用户身份：所有数据面调用共用一个 admin 服务账号 token；"登录用户"从 Higress Console `/v1/consumers` 列表的第一条记录提取——恒为 `manager` 网关消费者，审计归因全部记错人；且唯一能登录的账号是 Console admin（Console 单操作员、无多用户 API），运营账号（Human CR `permissionLevel` 2/3）连登录的门都没有。

本 PR 重做登录与会话模型，让每个 Human CR 账号都以本人身份登录、数据面以该账号身份执行：

- **双轨登录**（`POST /api/auth/login`）：
  - **Console 轨**——部署管理员账号。身份 = Console 用户名本身（不要求有 Human CR），会话携带服务端 SA 凭据、级别 3（全量，含网关/Audit/Storage）；Console 会话 cookie 仍转发，网关 tab 不受影响。
  - **Matrix 轨**——任意 Human 账号。服务端 Matrix 密码登录 → 本人 access token → localpart → SA 查 Human CR；`permissionLevel` 映射 dashboard 级别（1→3 全量、2→2 限 `accessibleTeams`、3→1 观察员）；CR 不存在 → 通用 401。级别 2/3 会话携带用户**本人的** Matrix token 作为 Controller 凭据，由 Controller A2 链把其读/写限制在 `accessibleTeams`（越权写在 Controller 侧本就 403）。
  - **Matrix 轨级别 3 需要管理员验证**：Controller 的 Matrix 认证器只接受 level-2 token，L1 账号的本人 token 不能当数据面凭据。登录表单提供两个可选项（与工作台插件 admin-token 模式一致）：管理员账号的 Console 密码（服务端二次 Console 登录校验，通过后会话用 env SA）或粘贴 Controller 管理员 token（服务端对 `GET /api/v1/teams` 校验，通过后会话携带该 token）。两种凭据都不出服务端、不进 cookie。
- **服务端会话存储**——内存 `{sessionId → {user, level, credential}}`，经 `globalThis` 跨 Next 打包实例共享（middleware 与路由是两份独立模块图，模块级 Map 会被静默复制）；cookie `at_dash_sess` = HMAC 签名 `{sessionId, user}`，`HttpOnly` + `SameSite=Lax`；默认不加 `Secure`（LAN HTTP 部署），`DASHBOARD_COOKIE_SECURE=1` 可选开启。fail-closed：缺 `DASHBOARD_SESSION_SECRET`（≥64 hex 字符）登录返回 503 带明确报错，不静默降级。已知 v1 取舍（已文档化）：容器重启 = 全员重登。
- **按请求身份与范围**——`middleware` 用 dashboard 会话门控 `/api/agentteams/*`（替换 `/v1/consumers` 探针）并注入真实 `x-agentteams-user` / `x-agentteams-user-level`；`proxy-helper` 按会话选 Controller Bearer（级别 2/3=本人 Matrix token，管理员=env SA），保留"SA env 存在时永不信任浏览器 Authorization"既有规则。新增端点：`GET /api/auth/session`（`{username, level, mode}`）与 `POST /api/auth/logout`。
- **UI 级别门控**——导航与快捷动作按级别显隐（`Managers` / `Humans` / "创建 Human" 需级别 3）；头部显示账号芯片（`用户名 · 级别`）+ 退出登录（回根路径，登录 UI 渲染在根路径）。删除 Console 自动初始化/自动注册路径：它会把首个登录的账号名建成 Console admin——真实账号登录后即提权洞。
- **安装与环境变量**——`install/agentteams-dashboard.sh` 生成并持久化 `DASHBOARD_SESSION_SECRET`（openssl rand -hex 32，600 权限，重建容器复用）；`.env.example` 同步文档。

**部署注意（一句话）**：现有单 admin 部署只需加一个环境变量——`DASHBOARD_SESSION_SECRET`（`openssl rand -hex 32`，重建容器必须复用同值，换值=全员掉线重登）。升级后首次登录起，审计 `actor` 从恒定的（错误的）`manager` 变为真实用户名。`AUTH_DISABLED` 逃生门照常可用。

## 包含内容

- `src/lib/dashboard-session.ts`（新）+ `dashboard-session.test.ts`——签名 cookie 会话存储、级别映射、fail-closed secret、globalThis 跨实例共享。
- `src/app/api/auth/login/route.ts`（+测试）——双轨登录重写：Console 轨、Matrix 轨 Human CR 级别查询、级别 3 管理员验证（密码或粘贴 token）、通用 401、永不含凭据的 cookie。
- `src/app/api/auth/session/route.ts`、`src/app/api/auth/logout/route.ts`（+测试）——会话查询与退出。
- `src/middleware.ts`（+测试）——`/api/agentteams/*` 会话门控、真实 user/level 头注入。
- `src/app/api/agentteams/proxy-helper.ts`（+测试）——按会话选 Controller Bearer（本人 Matrix token / 粘贴管理员 token / env SA），浏览器 Authorization 仍永不信任。
- `src/components/auth/login-page.tsx`——全账号统一表单：用户名/密码 + 折叠"管理员账号验证"区（admin 账号密码 **或** Controller 管理员 token），Matrix 轨级别 3 时展开填写。
- `src/components/dashboard/{nav-items,sidebar,mobile-sidebar,agent-teams-dashboard,header}.ts(x)`——级别门控导航/快捷动作、账号芯片+退出。
- `src/app/page.tsx`、`src/lib/agentteams-store.ts`——根路径渲染登录、客户端 store 带级别。
- `install/agentteams-dashboard.sh`、`.env.example`——secret 生成/持久化与环境变量文档。
- `eslint.config.mjs`、`.gitignore`——忽略 `dist/**`（本地产物）。

## 数据边界

- **凭据不出服务端**。admin SA 留在 env；级别 2/3 用户的 Matrix token 与粘贴的管理员 token 只存在于服务端会话存储。签名 cookie 只含 `{sessionId, user}`，永不含 token。
- **无 schema/CRD 变更**。无 Controller 变更；未消费任何新上游 API（仅用既有端点：Matrix 登录、`GET /humans/{name}`、token 校验用 `GET /api/v1/teams`）。
- **对既有调用方纯增量**——`AUTH_DISABLED` 逃生门与 `/api/higress/*`（Console 会话门控）行为不变；级别 3 保留全部 tab。
- **范围强制留在它该在的地方**——级别 2/3 的读/写范围由 Controller A2 链在用户本人 token 上强制，dashboard 不叠第二套（会分叉的）范围层；越权写在 Controller 侧本就 403。
- **删除而非回退的是自动初始化**——登录流不再可达该路径；已初始化 Console 的部署不受影响（旧路径在那本来就是静默空操作）。

## 测试

- 新增/更新（Node 20 全绿）：`dashboard-session.test.ts`（20：签名往返、篡改拒绝、fail-closed secret、跨打包实例共享）；`auth/login/route.test.ts`（13：双轨、permissionLevel 映射、CR 缺失 401、管理员验证矩阵——缺 400 / 错密码 401 / 错 token 401 / 对 token 级别 3 且 cookie 零 token 泄漏 / 级别 2-3 忽略管理员字段）；`auth/session`（4）、`auth/logout`（3）、`middleware.test.ts`（9：未认证 401、级别注入、AUTH_DISABLED 旁路）；`proxy-helper.test.ts`（10：Bearer 选择矩阵）；`nav-items.test.ts`（级别门控）。
- 全量套件：148 files / 129 过；19 个失败文件 = 本地 Node 25 容器既有 jsdom 环境失败（theme store、plugin registry 等），与本 diff 零交集——未改动基线上失败集相同。
- `tsc --noEmit` 干净；ESLint 0 errors；`next build` 绿（33/33 页面）。

## 相关

- 后续项（不在本 PR）：Controller `whoami` 端点（为无 token 客户端如工作台插件替代 SA 查 Human CR 的路径）——单独上游 PR；级别 2 的按钮级写隐藏（Controller 403 已 fail-closed）；跨重启的持久化会话存储（v2 候选）。
- 与工作台插件的双模式管理员认证配对（插件现有 admin-token 模式）；插件补 admin 密码模式另行跟踪。
