### PR TITLE
feat(setup): first-launch backend configuration, shared multi-user mode, and SA-less L2 login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,9 @@ NEXT_PUBLIC_BASE_PATH=/dashboard
 # DASHBOARD_CONFIG_FILE=/data/agentteams-dashboard/config.json
 # One-time token for the pre-login setup write. Unset = auto-generated on
 # first need, persisted next to the config file, and printed once to the
-# server log ("one-time backend setup token").
+# server log ("one-time backend setup token"). In shared mode this env is
+# the ONLY token source (never persisted). Ignored when the gate is
+# disabled via DASHBOARD_SETUP_TOKEN_ENFORCE=0 below.
 # DASHBOARD_SETUP_TOKEN=
 # Optional SSRF filter for the setup "test connection" probe (comma-
 # separated hosts; empty = allow, fine for a local self-config tool).
@@ -105,6 +107,15 @@ NEXT_PUBLIC_BASE_PATH=/dashboard
 # should drop it (cluster super credential) and use the per-login
 # controller-token paste. Leave unset for one-instance-per-user.
 # DASHBOARD_SHARED_MODE=1
+# Installer opt-out of the pre-login setup token gate — F1f3. Set 0 to
+# make the pre-login (first-launch / ?setup=1) config save PLAIN: no
+# token required, no token generated/printed/persisted, and the setup
+# page hides the token field. The installer (deployer) makes this choice
+# at docker-run time. WARNING: while disabled, anyone who can reach the
+# dashboard can rewrite ALL backend addresses (redirects every user's
+# data plane) — trusted-LAN deployments only; the startup log records
+# the open state. Unset or 1 = gate enforced (default, F1e/F1f behavior).
+# DASHBOARD_SETUP_TOKEN_ENFORCE=0
 # Note: custom Matrix homeserver hosts also need MATRIX_HOMESERVER_ALLOWLIST
 # (L2 login forwards the user's token to the host; private IPs are rejected
 # unless explicitly allowed).

--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,21 @@ NEXT_PUBLIC_BASE_PATH=/dashboard
 # LLM API Key for AI Troubleshooting (optional)
 # AGENTTEAMS_LLM_API_KEY=sk-...
 # AGENTTEAMS_DEFAULT_MODEL=gpt-4
+
+# --- First-launch backend setup (F1) -------------------------------------
+# Standalone docker installs can skip all AGENTTEAMS_*_URL env vars: the
+# first-launch setup page (shown instead of the login form) writes a
+# dual-address config file that the dashboard prefers over env.
+# Config file location (a mounted volume is strongly recommended so the
+# config survives container rebuilds):
+# DASHBOARD_CONFIG_FILE=/data/agentteams-dashboard/config.json
+# One-time token for the pre-login setup write. Unset = auto-generated on
+# first need, persisted next to the config file, and printed once to the
+# server log ("one-time backend setup token").
+# DASHBOARD_SETUP_TOKEN=
+# Optional SSRF filter for the setup "test connection" probe (comma-
+# separated hosts; empty = allow, fine for a local self-config tool).
+# DASHBOARD_ALLOWED_HOSTS=
+# Note: custom Matrix homeserver hosts also need MATRIX_HOMESERVER_ALLOWLIST
+# (L2 login forwards the user's token to the host; private IPs are rejected
+# unless explicitly allowed).

--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,13 @@ NEXT_PUBLIC_BASE_PATH=/dashboard
 # disabled via DASHBOARD_SETUP_TOKEN_ENFORCE=0 below.
 # DASHBOARD_SETUP_TOKEN=
 # Optional SSRF filter for the setup "test connection" probe (comma-
-# separated hosts; empty = allow, fine for a local self-config tool).
+# separated hosts). The probe is NO LONGER unauthenticated (PR-91 review):
+# pre-login callers must hold the setup token (same door as the config
+# write), post-login callers hold a session. Empty = allow for those
+# session/token holders (local self-config posture; with
+# DASHBOARD_SETUP_TOKEN_ENFORCE=0 this also covers logged-out
+# trusted-LAN callers). Set it for a strict allowlist. The cloud metadata
+# sentinel (169.254.169.254) is denied in all modes.
 # DASHBOARD_ALLOWED_HOSTS=
 # Shared (multi-user) deployment — F1f. Set 1 when MULTIPLE humans share
 # this instance (e.g. admin L1 + team L2 on one container, as on Node1).

--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,17 @@ NEXT_PUBLIC_BASE_PATH=/dashboard
 # Optional SSRF filter for the setup "test connection" probe (comma-
 # separated hosts; empty = allow, fine for a local self-config tool).
 # DASHBOARD_ALLOWED_HOSTS=
+# Shared (multi-user) deployment — F1f. Set 1 when MULTIPLE humans share
+# this instance (e.g. admin L1 + team L2 on one container, as on Node1).
+# Effects: (A) only admin (L1) sessions may save the backend config;
+# (B) the setup token comes ONLY from DASHBOARD_SETUP_TOKEN env and is
+# never generated/persisted to the volume (with no env token the pre-login
+# setup path stays closed — set it so the ?setup=1 escape hatch works);
+# (C) every config write is audited with actor + level + changed fields;
+# (D) startup warns if AGENTTEAMS_AUTH_TOKEN is set — shared deployments
+# should drop it (cluster super credential) and use the per-login
+# controller-token paste. Leave unset for one-instance-per-user.
+# DASHBOARD_SHARED_MODE=1
 # Note: custom Matrix homeserver hosts also need MATRIX_HOMESERVER_ALLOWLIST
 # (L2 login forwards the user's token to the host; private IPs are rejected
 # unless explicitly allowed).

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ dev.log
 dev.out.log
 test
 prompt
+# The Next.js API route directory named `test` (POST /setup/backends/test)
+# is source, not test artifacts — the bare `test` pattern above would
+# keep swallowing it (route.ts was force-added back in F1a/F1c).
+!src/app/api/agentteams/setup/backends/test/
 
 server.log
 # Audit log (default location is ${cwd}/logs/audit.log.jsonl; overridable via

--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ docker run -d -p 13000:3000 \
 - `DASHBOARD_SESSION_SECRET` is **required** — login fails closed without
   it. Generate once and keep it stable across container rebuilds.
 - `DASHBOARD_SETUP_TOKEN_ENFORCE=0` lets the installer skip the pre-login
-  setup token (trusted-LAN deployments; the startup log records the open
-  state). Omit it to keep the one-time token gate.
+  setup token (trusted-LAN deployments only; the startup log records the
+  open state). Omit it to keep the pre-login token gate — the same token
+  stays the owner gate for `?setup=1` reconfiguration until the volume is
+  reset (it is not consumed by the first save).
 - Team admins (L1) verify once more at login: the admin password (needs
   `AGENTTEAMS_AUTH_TOKEN` below) or a controller token pasted in the login
   form.
@@ -186,7 +188,9 @@ docker run -d -p 13000:3000 \
 
 Effects: only admin (L1) sessions may save the backend config (L2 save
 returns 403); the setup token is read from env only and never written to the
-volume; every config write is audited with actor + level + changed fields.
+volume — with no env token the pre-login setup path is closed (fail-closed;
+set it so the `?setup=1` escape hatch works); every config write is audited
+with actor + level + changed fields.
 `AGENTTEAMS_AUTH_TOKEN` enables the L1 admin-password login path — without
 it, L1 pastes the controller token at each login instead.
 
@@ -214,10 +218,10 @@ docker build -t agentteams-dashboard:local .
 | `AGENTTEAMS_AUTH_TOKEN_FILE` | Token file path (supports rotation) | — |
 | `DASHBOARD_SESSION_SECRET` | HMAC secret for session cookies — **required** for login | — |
 | `DASHBOARD_CONFIG_FILE` | Backend config file written by the first-launch setup page (file takes precedence over `AGENTTEAMS_*_URL` env) | `/data/agentteams-dashboard/config.json` |
-| `DASHBOARD_SETUP_TOKEN` | Pre-login setup token. Unset = auto-generated and printed once to the log (standalone); in shared mode the env is the only source | — |
+| `DASHBOARD_SETUP_TOKEN` | Pre-login setup token. Unset = auto-generated and printed once to the log (standalone); in shared mode the env is the only source (absent = pre-login path closed, fail-closed) | — |
 | `DASHBOARD_SETUP_TOKEN_ENFORCE` | `0` = pre-login config save needs no token (trusted LAN) | unset (gate enforced) |
 | `DASHBOARD_SHARED_MODE` | `1` = multiple users share this instance (L1-only config save, audited writes) | unset (one user per instance) |
-| `DASHBOARD_ALLOWED_HOSTS` | Optional SSRF filter for the setup "test connection" probe | unset (allow) |
+| `DASHBOARD_ALLOWED_HOSTS` | Strict allowlist for the setup "test connection" probe (it is token/session-gated; the metadata sentinel 169.254.169.254 is denied in all modes) | unset (allow for session/token holders) |
 | `DATABASE_URL` | SQLite database path | `file:./db/dashboard.db` |
 | `NEXT_PUBLIC_BASE_PATH` | URL base path (embedded deployment) | `/dashboard` |
 

--- a/README.md
+++ b/README.md
@@ -146,16 +146,60 @@ npm start
 
 ### Docker
 
+The same image serves every deployment form; the form is chosen by env flags
+at `docker run` time.
+
+**Standalone — one instance per user (default).** After `docker run`, open
+the URL: the first-launch page collects the backend addresses (Controller /
+Matrix / MinIO / Higress / SGLang, internal + external each), you save, and
+the login page appears. Team members (L2) then log in with **their own
+Matrix account and password only** — no tokens, no admin credentials.
+
 ```bash
-# Pull and run the pre-built image
 docker run -d -p 13000:3000 \
   --name agentteams-dashboard \
-  -e AGENTTEAMS_CONTROLLER_URL=http://host.docker.internal:8090 \
-  -e NEXT_PUBLIC_MATRIX_API_URL=http://host.docker.internal:6167 \
-  ghcr.io/agentteams-group/agentteams-dashboard:v1.2.3.1
+  --restart unless-stopped \
+  -v agentteams-dashboard-data:/data/agentteams-dashboard \
+  -e DASHBOARD_SESSION_SECRET="$(openssl rand -hex 32)" \
+  -e DASHBOARD_SETUP_TOKEN_ENFORCE=0 \
+  ghcr.io/agentteams-group/agentteams-dashboard:<tag>
+```
 
+- `DASHBOARD_SESSION_SECRET` is **required** — login fails closed without
+  it. Generate once and keep it stable across container rebuilds.
+- `DASHBOARD_SETUP_TOKEN_ENFORCE=0` lets the installer skip the pre-login
+  setup token (trusted-LAN deployments; the startup log records the open
+  state). Omit it to keep the one-time token gate.
+- Team admins (L1) verify once more at login: the admin password (needs
+  `AGENTTEAMS_AUTH_TOKEN` below) or a controller token pasted in the login
+  form.
+- Gateway Console features (model management, shared login) additionally
+  need `-e AGENTTEAMS_AI_GATEWAY_ADMIN_ALLOWED_HOSTS=<console-host>`.
+
+**Shared — multiple users on one instance.** Add:
+
+```bash
+  -e DASHBOARD_SHARED_MODE=1 \
+  -e DASHBOARD_SETUP_TOKEN="$(openssl rand -hex 16)" \
+  -e AGENTTEAMS_AUTH_TOKEN=<controller cli-token>
+```
+
+Effects: only admin (L1) sessions may save the backend config (L2 save
+returns 403); the setup token is read from env only and never written to the
+volume; every config write is audited with actor + level + changed fields.
+`AGENTTEAMS_AUTH_TOKEN` enables the L1 admin-password login path — without
+it, L1 pastes the controller token at each login instead.
+
+**Embedded** (installed by `install/agentteams-install.sh`): addresses come
+from the surrounding AgentTeams topology; the first-launch page only appears
+when nothing is configured.
+
+To reconfigure at any time: login page → "Cannot log in? Backend setup"
+(`?setup=1`).
+
+```bash
 # Or build from source
-docker build -t ghcr.io/agentteams-group/agentteams-dashboard:v1.2.3.1 .
+docker build -t agentteams-dashboard:local .
 ```
 
 ## ⚙️ Configuration
@@ -166,8 +210,14 @@ docker build -t ghcr.io/agentteams-group/agentteams-dashboard:v1.2.3.1 .
 | `NEXT_PUBLIC_AGENTTEAMS_CONTROLLER_URL` | Browser-facing Controller URL (optional) | — |
 | `NEXT_PUBLIC_MATRIX_API_URL` | Matrix Homeserver endpoint | — |
 | `MATRIX_HOMESERVER_ALLOWLIST` | Comma-separated homeserver hostnames allowed through the Matrix proxy (exclusive once set) | — |
-| `AGENTTEAMS_AUTH_TOKEN` | Controller auth token | — |
+| `AGENTTEAMS_AUTH_TOKEN` | Controller auth token — enables the L1 admin-password login path and (with `DASHBOARD_SHARED_MODE=1`) is the only admin credential source | — |
 | `AGENTTEAMS_AUTH_TOKEN_FILE` | Token file path (supports rotation) | — |
+| `DASHBOARD_SESSION_SECRET` | HMAC secret for session cookies — **required** for login | — |
+| `DASHBOARD_CONFIG_FILE` | Backend config file written by the first-launch setup page (file takes precedence over `AGENTTEAMS_*_URL` env) | `/data/agentteams-dashboard/config.json` |
+| `DASHBOARD_SETUP_TOKEN` | Pre-login setup token. Unset = auto-generated and printed once to the log (standalone); in shared mode the env is the only source | — |
+| `DASHBOARD_SETUP_TOKEN_ENFORCE` | `0` = pre-login config save needs no token (trusted LAN) | unset (gate enforced) |
+| `DASHBOARD_SHARED_MODE` | `1` = multiple users share this instance (L1-only config save, audited writes) | unset (one user per instance) |
+| `DASHBOARD_ALLOWED_HOSTS` | Optional SSRF filter for the setup "test connection" probe | unset (allow) |
 | `DATABASE_URL` | SQLite database path | `file:./db/dashboard.db` |
 | `NEXT_PUBLIC_BASE_PATH` | URL base path (embedded deployment) | `/dashboard` |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,16 +146,52 @@ npm start
 
 ### Docker 构建
 
+同一个镜像服务所有部署形态，形态由 `docker run` 时的 env 决定。
+
+**单机单用户（默认）**：`docker run` 后打开 URL → 首启页填后端地址
+（Controller / Matrix / MinIO / Higress / SGLang，各内网+外网）→ 保存 →
+进入登录页。团队成员（L2）用**自己的 Matrix 账号+密码**登录即可——零
+token、零管理凭据。
+
 ```bash
-# 直接拉取预构建镜像
 docker run -d -p 13000:3000 \
   --name agentteams-dashboard \
-  -e AGENTTEAMS_CONTROLLER_URL=http://host.docker.internal:8090 \
-  -e NEXT_PUBLIC_MATRIX_API_URL=http://host.docker.internal:6167 \
-  ghcr.io/agentteams-group/agentteams-dashboard:v1.2.3.1
+  --restart unless-stopped \
+  -v agentteams-dashboard-data:/data/agentteams-dashboard \
+  -e DASHBOARD_SESSION_SECRET="$(openssl rand -hex 32)" \
+  -e DASHBOARD_SETUP_TOKEN_ENFORCE=0 \
+  ghcr.io/agentteams-group/agentteams-dashboard:<tag>
+```
 
+- `DASHBOARD_SESSION_SECRET` **必填**——缺失时登录 fail closed。生成一次，
+  容器重建时保持稳定。
+- `DASHBOARD_SETUP_TOKEN_ENFORCE=0` = 安装者免 pre-login setup token（限
+  可信 LAN；启动日志记录开放状态）；不设置则保留一次性 token 门。
+- 团队管理员（L1）登录时多一步验证：admin 密码（需下面的
+  `AGENTTEAMS_AUTH_TOKEN`）或在登录表单粘贴 controller token。
+- 网关 Console 功能（模型管理、共享登录）另需
+  `-e AGENTTEAMS_AI_GATEWAY_ADMIN_ALLOWED_HOSTS=<console-host>`。
+
+**共享多用户（一台容器多人用）**，追加：
+
+```bash
+  -e DASHBOARD_SHARED_MODE=1 \
+  -e DASHBOARD_SETUP_TOKEN="$(openssl rand -hex 16)" \
+  -e AGENTTEAMS_AUTH_TOKEN=<controller cli-token>
+```
+
+效果：仅 L1 会话可保存后端配置（L2 保存返回 403）；setup token 只从 env
+读取、永不落卷；每次配置写审计 actor+级别+变更字段。`AGENTTEAMS_AUTH_TOKEN`
+启用 L1 admin 密码登录；不配则 L1 每次登录粘 controller token。
+
+**嵌入部署**（`install/agentteams-install.sh` 安装）：地址来自 AgentTeams
+拓扑 env；未配置时才出现首启页。
+
+任何时刻重配置：登录页 →「无法登录？后端配置」（`?setup=1`）。
+
+```bash
 # 或从源码构建
-docker build -t ghcr.io/agentteams-group/agentteams-dashboard:v1.2.3.1 .
+docker build -t agentteams-dashboard:local .
 ```
 
 ## ⚙️ 环境变量
@@ -166,8 +202,14 @@ docker build -t ghcr.io/agentteams-group/agentteams-dashboard:v1.2.3.1 .
 | `NEXT_PUBLIC_AGENTTEAMS_CONTROLLER_URL` | 浏览器端 Controller URL（可选） | — |
 | `NEXT_PUBLIC_MATRIX_API_URL` | Matrix Homeserver 地址 | — |
 | `MATRIX_HOMESERVER_ALLOWLIST` | Matrix 代理允许的 homeserver 主机名（逗号分隔，设置后排他生效） | — |
-| `AGENTTEAMS_AUTH_TOKEN` | Controller 认证 Token | — |
+| `AGENTTEAMS_AUTH_TOKEN` | Controller 认证 Token——启用 L1 admin 密码登录路径；`DASHBOARD_SHARED_MODE=1` 时是唯一的 admin 凭据来源 | — |
 | `AGENTTEAMS_AUTH_TOKEN_FILE` | Token 文件路径（支持轮转） | — |
+| `DASHBOARD_SESSION_SECRET` | 会话 cookie HMAC 密钥——登录**必填** | — |
+| `DASHBOARD_CONFIG_FILE` | 首启 setup 页写入的后端配置文件（文件优先于 `AGENTTEAMS_*_URL` env） | `/data/agentteams-dashboard/config.json` |
+| `DASHBOARD_SETUP_TOKEN` | Pre-login setup token。未设=自动生成并打一次日志（单机）；共享模式下 env 是唯一来源 | — |
+| `DASHBOARD_SETUP_TOKEN_ENFORCE` | `0` = pre-login 保存配置免 token（限可信 LAN） | 未设（门生效） |
+| `DASHBOARD_SHARED_MODE` | `1` = 多用户共享本实例（配置保存仅 L1、写操作审计） | 未设（一人一实例） |
+| `DASHBOARD_ALLOWED_HOSTS` | setup「测试连接」探针的可选 SSRF 过滤 | 未设（放行） |
 | `DATABASE_URL` | SQLite 数据库路径 | `file:./db/dashboard.db` |
 | `NEXT_PUBLIC_BASE_PATH` | URL 基础路径（嵌入部署时用） | `/dashboard` |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,9 @@ docker run -d -p 13000:3000 \
 - `DASHBOARD_SESSION_SECRET` **必填**——缺失时登录 fail closed。生成一次，
   容器重建时保持稳定。
 - `DASHBOARD_SETUP_TOKEN_ENFORCE=0` = 安装者免 pre-login setup token（限
-  可信 LAN；启动日志记录开放状态）；不设置则保留一次性 token 门。
+  可信 LAN；启动日志记录开放状态）；不设置则保留登录前 token 门——同一
+  token 可重复用于 `?setup=1` 重配，直到数据卷重置（首启保存不会消费
+  它）。
 - 团队管理员（L1）登录时多一步验证：admin 密码（需下面的
   `AGENTTEAMS_AUTH_TOKEN`）或在登录表单粘贴 controller token。
 - 网关 Console 功能（模型管理、共享登录）另需
@@ -181,7 +183,9 @@ docker run -d -p 13000:3000 \
 ```
 
 效果：仅 L1 会话可保存后端配置（L2 保存返回 403）；setup token 只从 env
-读取、永不落卷；每次配置写审计 actor+级别+变更字段。`AGENTTEAMS_AUTH_TOKEN`
+读取、永不落卷——缺 env token 时登录前配置路径关闭（fail-closed，
+`?setup=1` 逃生口不可用；需要逃生口就设它）；每次配置写审计
+actor+级别+变更字段。`AGENTTEAMS_AUTH_TOKEN`
 启用 L1 admin 密码登录；不配则 L1 每次登录粘 controller token。
 
 **嵌入部署**（`install/agentteams-install.sh` 安装）：地址来自 AgentTeams
@@ -206,10 +210,10 @@ docker build -t agentteams-dashboard:local .
 | `AGENTTEAMS_AUTH_TOKEN_FILE` | Token 文件路径（支持轮转） | — |
 | `DASHBOARD_SESSION_SECRET` | 会话 cookie HMAC 密钥——登录**必填** | — |
 | `DASHBOARD_CONFIG_FILE` | 首启 setup 页写入的后端配置文件（文件优先于 `AGENTTEAMS_*_URL` env） | `/data/agentteams-dashboard/config.json` |
-| `DASHBOARD_SETUP_TOKEN` | Pre-login setup token。未设=自动生成并打一次日志（单机）；共享模式下 env 是唯一来源 | — |
+| `DASHBOARD_SETUP_TOKEN` | Pre-login setup token。未设=自动生成并打一次日志（单机）；共享模式下 env 是唯一来源（缺=登录前路径关闭，fail-closed） | — |
 | `DASHBOARD_SETUP_TOKEN_ENFORCE` | `0` = pre-login 保存配置免 token（限可信 LAN） | 未设（门生效） |
 | `DASHBOARD_SHARED_MODE` | `1` = 多用户共享本实例（配置保存仅 L1、写操作审计） | 未设（一人一实例） |
-| `DASHBOARD_ALLOWED_HOSTS` | setup「测试连接」探针的可选 SSRF 过滤 | 未设（放行） |
+| `DASHBOARD_ALLOWED_HOSTS` | setup「测试连接」探针的严格白名单（探针已 token/会话门控；metadata 哨兵 169.254.169.254 全模式拒绝） | 未设（对 session/token 持有者放行） |
 | `DATABASE_URL` | SQLite 数据库路径 | `file:./db/dashboard.db` |
 | `NEXT_PUBLIC_BASE_PATH` | URL 基础路径（嵌入部署时用） | `/dashboard` |
 

--- a/src/app/api/agentteams/debug-log/route.test.ts
+++ b/src/app/api/agentteams/debug-log/route.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { unzipSync } from 'fflate';

--- a/src/app/api/agentteams/external-model-binding-guard.test.ts
+++ b/src/app/api/agentteams/external-model-binding-guard.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { rejectExternalModelProvider, rejectUnavailableExternalModelAlias } from './external-model-binding-guard';

--- a/src/app/api/agentteams/infrastructure/route.test.ts
+++ b/src/app/api/agentteams/infrastructure/route.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const originalFetch = globalThis.fetch;

--- a/src/app/api/agentteams/infrastructure/route.ts
+++ b/src/app/api/agentteams/infrastructure/route.ts
@@ -167,8 +167,10 @@ async function checkSglang(url: string | undefined): Promise<InfrastructureInfo[
     return { healthy: false, endpoint: '' };
   }
   const result = await probeBackend('sglang', url, TIMEOUT_MS);
-  if (result.ok) markWorking('sglang', url);
-  return { healthy: result.ok, endpoint: url };
+  // httpOk (status < 400), not ok (network connected): a 401/5xx probe must
+  // not mark the address working or report a healthy inference backend.
+  if (result.httpOk) markWorking('sglang', url, result.latencyMs);
+  return { healthy: result.httpOk, endpoint: url };
 }
 
 async function checkExternalService(endpoint: string | undefined) {

--- a/src/app/api/agentteams/infrastructure/route.ts
+++ b/src/app/api/agentteams/infrastructure/route.ts
@@ -87,7 +87,7 @@ async function checkKubernetes(): Promise<InfrastructureInfo['kubernetes']> {
   try {
     // Use Node.js https to query the in-cluster API server with the mounted CA/token.
     const https = await import('https');
-    const fs = await import('fs');
+    const fs = await import('node:fs');
 
     const ca = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt');
     const token = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf-8').trim();

--- a/src/app/api/agentteams/infrastructure/route.ts
+++ b/src/app/api/agentteams/infrastructure/route.ts
@@ -1,40 +1,50 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthToken } from '../proxy-helper';
+import {
+  markWorking,
+  pickBackendUrl,
+  probeBackend,
+} from '@/lib/backend-config';
 import type { InfrastructureInfo } from '@/lib/agentteams-api';
 
 const TIMEOUT_MS = 5000;
 
-// Defaults follow the embedded (single-container) topology: all platform
-// services live in the agentteams-controller container on the agentteams-net
-// docker network. Install scripts inject the env vars below; k8s deployments
-// must point them at the corresponding Services explicitly.
-const CONTROLLER_URL =
-  process.env.AGENTTEAMS_CONTROLLER_URL ||
-  process.env.AGENTTEAMS_API_URL ||
-  'http://agentteams-controller:8090';
-
-const MINIO_ENDPOINT =
-  process.env.AGENTTEAMS_FS_ENDPOINT ||
-  process.env.AGENTTEAMS_MINIO_ENDPOINT ||
-  process.env.AGENTTEAMS_MINIO_URL ||
-  'http://agentteams-controller:9000';
-
-const MATRIX_ENDPOINT =
-  process.env.AGENTTEAMS_MATRIX_URL ||
-  process.env.NEXT_PUBLIC_MATRIX_API_URL || // set by install/agentteams-dashboard.sh
-  'http://agentteams-controller:6167';
-
+// Per-request backend resolution (F1): config file (dual address + failover
+// working cache) > env vars > embedded topology defaults. The embedded
+// (single-container) topology keeps all platform services in the
+// agentteams-controller container on the agentteams-net docker network;
+// install scripts inject the env vars, k8s deployments point them at the
+// corresponding Services, and standalone installs fill the config file via
+// the first-launch setup page.
 const HIGRESS_MODE = process.env.AGENTTEAMS_HIGRESS_ADAPTER_MODE === 'external' ? 'external' : 'direct';
 // Higress exposes separate data-plane and Console endpoints in the embedded
 // topology. Dashboard runs in its own container, so loopback addresses are invalid.
 const EMBEDDED_HIGRESS_GATEWAY_ENDPOINT = 'http://aigw-local.agentteams.io:8080';
 const EMBEDDED_HIGRESS_CONSOLE_ENDPOINT = 'http://agentteams-controller:8001';
-const HIGRESS_GATEWAY_ENDPOINT =
-  process.env.AGENTTEAMS_AI_GATEWAY_URL ||
-  (HIGRESS_MODE === 'direct' ? EMBEDDED_HIGRESS_GATEWAY_ENDPOINT : undefined);
-const HIGRESS_CONSOLE_ENDPOINT =
-  process.env.AGENTTEAMS_AI_GATEWAY_ADMIN_URL ||
-  (HIGRESS_MODE === 'direct' ? EMBEDDED_HIGRESS_CONSOLE_ENDPOINT : undefined);
+
+function resolveControllerUrl(): string {
+  return pickBackendUrl('controller') || 'http://agentteams-controller:8090';
+}
+
+function resolveMinioEndpoint(): string {
+  return pickBackendUrl('minio') || 'http://agentteams-controller:9000';
+}
+
+function resolveMatrixEndpoint(): string {
+  return pickBackendUrl('matrix') || 'http://agentteams-controller:6167';
+}
+
+function resolveHigressGatewayEndpoint(): string | undefined {
+  return pickBackendUrl('higress-gateway') || (HIGRESS_MODE === 'direct' ? EMBEDDED_HIGRESS_GATEWAY_ENDPOINT : undefined);
+}
+
+function resolveHigressConsoleEndpoint(): string | undefined {
+  return pickBackendUrl('higress-console') || (HIGRESS_MODE === 'direct' ? EMBEDDED_HIGRESS_CONSOLE_ENDPOINT : undefined);
+}
+
+function resolveSglangEndpoint(): string | undefined {
+  return pickBackendUrl('sglang'); // optional backend; no embedded default
+}
 
 async function fetchWithTimeout(
   url: string,
@@ -52,15 +62,16 @@ async function fetchWithTimeout(
   }
 }
 
-async function checkController(): Promise<InfrastructureInfo['controller']> {
+async function checkController(url: string): Promise<InfrastructureInfo['controller']> {
   try {
-    const res = await fetchWithTimeout(`${CONTROLLER_URL}/healthz`);
+    const res = await fetchWithTimeout(`${url}/healthz`);
+    if (res.ok) markWorking('controller', url);
     const authToken = await getAuthToken();
     const headers: Record<string, string> = {};
     if (authToken) {
       headers.Authorization = `Bearer ${authToken}`;
     }
-    const versionRes = await fetchWithTimeout(`${CONTROLLER_URL}/api/v1/version`, { headers });
+    const versionRes = await fetchWithTimeout(`${url}/api/v1/version`, { headers });
     let version = 'unknown';
     if (versionRes.ok) {
       const data = await versionRes.json().catch(() => ({}));
@@ -122,30 +133,42 @@ async function checkKubernetes(): Promise<InfrastructureInfo['kubernetes']> {
   }
 }
 
-async function checkMinio(): Promise<InfrastructureInfo['minio']> {
+async function checkMinio(url: string): Promise<InfrastructureInfo['minio']> {
   try {
-    const res = await fetchWithTimeout(`${MINIO_ENDPOINT}/minio/health/live`);
+    const res = await fetchWithTimeout(`${url}/minio/health/live`);
+    if (res.ok) markWorking('minio', url);
     return {
       healthy: res.ok,
-      endpoint: MINIO_ENDPOINT,
+      endpoint: url,
       buckets: [], // Bucket list is provided by /api/agentteams/storage/buckets
     };
   } catch {
     return {
       healthy: false,
-      endpoint: MINIO_ENDPOINT,
+      endpoint: url,
       buckets: [],
     };
   }
 }
 
-async function checkMatrix(): Promise<InfrastructureInfo['matrix']> {
+async function checkMatrix(url: string): Promise<InfrastructureInfo['matrix']> {
   try {
-    const res = await fetchWithTimeout(`${MATRIX_ENDPOINT}/_matrix/client/versions`);
-    return { healthy: res.ok, homeserver: MATRIX_ENDPOINT };
+    const res = await fetchWithTimeout(`${url}/_matrix/client/versions`);
+    if (res.ok) markWorking('matrix', url);
+    return { healthy: res.ok, homeserver: url };
   } catch {
-    return { healthy: false, homeserver: MATRIX_ENDPOINT };
+    return { healthy: false, homeserver: url };
   }
+}
+
+// SGLang is an optional inference backend (model list / model management).
+async function checkSglang(url: string | undefined): Promise<InfrastructureInfo['sglang']> {
+  if (!url) {
+    return { healthy: false, endpoint: '' };
+  }
+  const result = await probeBackend('sglang', url, TIMEOUT_MS);
+  if (result.ok) markWorking('sglang', url);
+  return { healthy: result.ok, endpoint: url };
 }
 
 async function checkExternalService(endpoint: string | undefined) {
@@ -212,11 +235,16 @@ async function checkHigressGateway(endpoint: string | undefined) {
   }
 }
 
-async function checkHigress(): Promise<NonNullable<InfrastructureInfo['higress']>> {
+async function checkHigress(
+  gatewayEndpoint: string | undefined,
+  consoleEndpoint: string | undefined
+): Promise<NonNullable<InfrastructureInfo['higress']>> {
   const [gateway, console] = await Promise.all([
-    checkHigressGateway(HIGRESS_GATEWAY_ENDPOINT),
-    checkExternalService(HIGRESS_CONSOLE_ENDPOINT),
+    checkHigressGateway(gatewayEndpoint),
+    checkExternalService(consoleEndpoint),
   ]);
+  if (gateway.state === 'reachable' && gatewayEndpoint) markWorking('higress-gateway', gatewayEndpoint);
+  if (console.state === 'reachable' && consoleEndpoint) markWorking('higress-console', consoleEndpoint);
 
   // Runtime adaptation health tracks the Gateway data plane probe only.
   // The optional Console management address keeps its own status so an
@@ -231,12 +259,23 @@ async function checkHigress(): Promise<NonNullable<InfrastructureInfo['higress']
 
 // GET /api/agentteams/infrastructure - aggregate health of all platform components
 export async function GET(_request: NextRequest) {
-  const [controller, kubernetes, minio, matrix, higress] = await Promise.all([
-    checkController(),
+  // Resolve addresses per request (F1): the config file may have been
+  // written/updated since module load, and the failover working cache must
+  // be consulted (and refreshed) here.
+  const controllerUrl = resolveControllerUrl();
+  const minioEndpoint = resolveMinioEndpoint();
+  const matrixEndpoint = resolveMatrixEndpoint();
+  const higressGateway = resolveHigressGatewayEndpoint();
+  const higressConsole = resolveHigressConsoleEndpoint();
+  const sglangEndpoint = resolveSglangEndpoint();
+
+  const [controller, kubernetes, minio, matrix, higress, sglang] = await Promise.all([
+    checkController(controllerUrl),
     checkKubernetes(),
-    checkMinio(),
-    checkMatrix(),
-    checkHigress(),
+    checkMinio(minioEndpoint),
+    checkMatrix(matrixEndpoint),
+    checkHigress(higressGateway, higressConsole),
+    checkSglang(sglangEndpoint),
   ]);
 
   const info: InfrastructureInfo = {
@@ -245,6 +284,7 @@ export async function GET(_request: NextRequest) {
     minio,
     matrix,
     higress,
+    sglang,
   };
 
   return NextResponse.json(info);

--- a/src/app/api/agentteams/mode/route.ts
+++ b/src/app/api/agentteams/mode/route.ts
@@ -2,7 +2,7 @@
 // Returns 'embedded' or 'k8s'. This is used as a fallback when the Controller
 // API is unreachable at startup.
 import { NextResponse } from 'next/server';
-import fs from 'fs';
+import fs from 'node:fs';
 
 function isInKubernetesPod(): boolean {
   try {

--- a/src/app/api/agentteams/proxy-helper.test.ts
+++ b/src/app/api/agentteams/proxy-helper.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { NextRequest } from 'next/server';
 import { getControllerUrl, proxyToAgentTeams } from './proxy-helper';
 import {
@@ -10,7 +13,7 @@ import {
   destroySession,
   sessionCookieHeader,
 } from '@/lib/dashboard-session';
-import { forgetWorking } from '@/lib/backend-config';
+import { effectiveUrl, forgetWorking, pickBackendUrl } from '@/lib/backend-config';
 
 let server: Server;
 let controllerUrl: string;
@@ -299,5 +302,147 @@ describe('getControllerUrl ?controllerUrl= override gating (F1b)', () => {
   it('L2 session: no override parameter → default (unchanged behavior)', () => {
     const cookie = cookieFor('sunzong', 2, { kind: 'matrix', token: 'syt_l2_token' });
     expect(getControllerUrl(withCookie(cookie, ''))).toBe(DEFAULT_URL);
+  });
+});
+
+describe('proxyToAgentTeams failover (F1c — plugin catch-all parity)', () => {
+  let good: Server;
+  let auth: Server;
+  let goodUrl: string;
+  let authUrl: string;
+  let dead1: string;
+  let dead2: string;
+  let goodCalls = 0;
+  let authCalls = 0;
+  let configFile: string;
+
+  function closedLoopbackPort(): Promise<number> {
+    // Bind then close → the port is free (and refused) for the test.
+    const tmp = createServer();
+    const listen = new Promise<void>((resolve) => tmp.listen(0, '127.0.0.1', resolve));
+    return Promise.resolve(listen).then(async () => {
+      const a = tmp.address();
+      if (!a || typeof a === 'string') throw new Error('no tmp server');
+      await new Promise<void>((resolve) => tmp.close(() => resolve()));
+      return a.port;
+    });
+  }
+
+  beforeAll(async () => {
+    good = createServer((_req, res) => {
+      goodCalls += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true}');
+    });
+    auth = createServer((_req, res) => {
+      authCalls += 1;
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end('{"error":"unauthorized"}');
+    });
+    await Promise.all([
+      new Promise<void>((resolve) => good.listen(0, '127.0.0.1', resolve)),
+      new Promise<void>((resolve) => auth.listen(0, '127.0.0.1', resolve)),
+    ]);
+    const ga = good.address();
+    const aa = auth.address();
+    if (!ga || typeof ga === 'string' || !aa || typeof aa === 'string') throw new Error('no server');
+    goodUrl = `http://127.0.0.1:${ga.port}`;
+    authUrl = `http://127.0.0.1:${aa.port}`;
+    const [p1, p2] = await Promise.all([closedLoopbackPort(), closedLoopbackPort()]);
+    dead1 = `http://127.0.0.1:${p1}`;
+    dead2 = `http://127.0.0.1:${p2}`;
+    configFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-failover-')), 'config.json');
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      new Promise<void>((resolve) => good.close(() => resolve())),
+      new Promise<void>((resolve) => auth.close(() => resolve())),
+    ]);
+    fs.rmSync(path.dirname(configFile), { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    goodCalls = 0;
+    authCalls = 0;
+    forgetWorking('controller');
+    vi.stubEnv('DASHBOARD_CONFIG_FILE', configFile);
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', '');
+    vi.stubEnv('AGENTTEAMS_API_URL', '');
+    vi.stubEnv('DASHBOARD_SESSION_SECRET', 'c'.repeat(64));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    forgetWorking('controller');
+    if (fs.existsSync(configFile)) fs.rmSync(configFile);
+  });
+
+  function writeConfig(internal: string, external: string) {
+    fs.writeFileSync(
+      configFile,
+      JSON.stringify({ version: 1, backends: { controller: { internal, external } } }),
+    );
+  }
+
+  function req(query = ''): NextRequest {
+    return new NextRequest(`http://localhost/api/agentteams/teams${query}`, { method: 'GET' });
+  }
+
+  it('dead first candidate → same-address retry → walks to the working second candidate', async () => {
+    writeConfig(dead1, goodUrl);
+    const res = await proxyToAgentTeams(req(), dead1, '/api/v1/teams', { forwardBody: false, method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(goodCalls).toBe(1);
+    // the working cache now points at the address that actually served
+    expect(pickBackendUrl('controller')).toBe(goodUrl);
+  });
+
+  it('all candidates dead → 502 with per-address details', async () => {
+    writeConfig(dead1, dead2);
+    const res = await proxyToAgentTeams(req(), dead1, '/api/v1/teams', { forwardBody: false, method: 'GET' });
+    expect(res.status).toBe(502);
+    const data = (await res.json()) as { error: string; details: Array<{ url: string; error: string }> };
+    expect(data.error).toContain('unreachable');
+    expect(data.details.map((d) => d.url).sort()).toEqual([dead1, dead2].sort());
+    // no working address may be marked from a fully failed round
+    expect(effectiveUrl('controller')).toBeNull();
+  });
+
+  it('an HTTP 401 is returned as-is (no retry, not marked working)', async () => {
+    writeConfig(authUrl, goodUrl);
+    const res = await proxyToAgentTeams(req(), authUrl, '/api/v1/teams', { forwardBody: false, method: 'GET' });
+    expect(res.status).toBe(401);
+    expect(authCalls).toBe(1);
+    expect(goodCalls).toBe(0);
+    expect(effectiveUrl('controller')).toBeNull();
+  });
+
+  it('a valid ?controllerUrl= override pins a single address (no candidate walk)', async () => {
+    writeConfig(dead1, goodUrl);
+    const r1 = await proxyToAgentTeams(
+      req(`?controllerUrl=${encodeURIComponent(goodUrl)}`),
+      dead1,
+      '/api/v1/teams',
+      { forwardBody: false, method: 'GET' },
+    );
+    expect(r1.status).toBe(200);
+    expect(goodCalls).toBe(1);
+
+    // a dead override must NOT fall back to the config candidates
+    const r2 = await proxyToAgentTeams(
+      req(`?controllerUrl=${encodeURIComponent(dead2)}`),
+      dead1,
+      '/api/v1/teams',
+      { forwardBody: false, method: 'GET' },
+    );
+    expect(r2.status).toBe(502);
+    expect(goodCalls).toBe(1); // the good candidate was never walked
+  });
+
+  it('no config and no working cache → the passed primary is the single target', async () => {
+    const res = await proxyToAgentTeams(req(), goodUrl, '/api/v1/teams', { forwardBody: false, method: 'GET' });
+    expect(res.status).toBe(200);
+    expect(goodCalls).toBe(1);
   });
 });

--- a/src/app/api/agentteams/proxy-helper.test.ts
+++ b/src/app/api/agentteams/proxy-helper.test.ts
@@ -2,13 +2,15 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { NextRequest } from 'next/server';
-import { proxyToAgentTeams } from './proxy-helper';
+import { getControllerUrl, proxyToAgentTeams } from './proxy-helper';
 import {
   SESSION_COOKIE_NAME,
   __resetSessionStoreForTests,
   createSession,
   destroySession,
+  sessionCookieHeader,
 } from '@/lib/dashboard-session';
+import { forgetWorking } from '@/lib/backend-config';
 
 let server: Server;
 let controllerUrl: string;
@@ -226,5 +228,76 @@ describe('proxyToAgentTeams per-session credential (M19 dual track)', () => {
     destroySession(sessionId);
     await proxy(requestWith(`${SESSION_COOKIE_NAME}=${cookieValue}`, { authorization: 'Bearer browser-forged' }));
     expect(captured[0].authorization).toBe('Bearer sa-admin-token');
+  });
+});
+
+describe('getControllerUrl ?controllerUrl= override gating (F1b)', () => {
+  const OVERRIDE = 'http://127.0.0.1:9999'; // allowed by the SSRF host list
+  const DEFAULT_URL = 'http://ctl-default:8090';
+  const saved = {
+    secret: process.env.DASHBOARD_SESSION_SECRET,
+    controller: process.env.AGENTTEAMS_CONTROLLER_URL,
+    api: process.env.AGENTTEAMS_API_URL,
+    configFile: process.env.DASHBOARD_CONFIG_FILE,
+  };
+
+  beforeAll(() => {
+    process.env.DASHBOARD_SESSION_SECRET = 'f'.repeat(64);
+    process.env.AGENTTEAMS_CONTROLLER_URL = DEFAULT_URL;
+    process.env.AGENTTEAMS_API_URL = '';
+    process.env.DASHBOARD_CONFIG_FILE = '/nonexistent-dir-for-tests/config.json';
+    forgetWorking('controller');
+  });
+
+  afterAll(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    __resetSessionStoreForTests();
+  });
+
+  function withCookie(cookie: string | null, query: string): NextRequest {
+    const headers = new Headers();
+    if (cookie) headers.set('cookie', cookie);
+    return new NextRequest(`http://localhost/api/agentteams/healthz/${query}`, { headers });
+  }
+
+  function cookieFor(
+    user: string,
+    crLevel: number,
+    credential: { kind: 'sa' } | { kind: 'matrix'; token: string } | { kind: 'controller-token'; token: string },
+  ): string {
+    const { cookieValue } = createSession({ user, crLevel, credential });
+    return sessionCookieHeader(cookieValue);
+  }
+
+  it('L1 (level 3, sa credential): allowed-host override is honored', () => {
+    const cookie = cookieFor('luo', 1, { kind: 'sa' });
+    expect(getControllerUrl(withCookie(cookie, `?controllerUrl=${encodeURIComponent(OVERRIDE)}`))).toBe(OVERRIDE);
+  });
+
+  it('L2 (level 2, matrix credential): override is dropped, default used', () => {
+    const cookie = cookieFor('sunzong', 2, { kind: 'matrix', token: 'syt_l2_token' });
+    expect(getControllerUrl(withCookie(cookie, `?controllerUrl=${encodeURIComponent(OVERRIDE)}`))).toBe(DEFAULT_URL);
+  });
+
+  it('observer (level 1, matrix credential): override is dropped, default used', () => {
+    const cookie = cookieFor('viewer', 3, { kind: 'matrix', token: 'viewer_token' });
+    expect(getControllerUrl(withCookie(cookie, `?controllerUrl=${encodeURIComponent(OVERRIDE)}`))).toBe(DEFAULT_URL);
+  });
+
+  it('pre-login (no session): override still honored behind the SSRF list', () => {
+    expect(getControllerUrl(withCookie(null, `?controllerUrl=${encodeURIComponent(OVERRIDE)}`))).toBe(OVERRIDE);
+  });
+
+  it('L1 session: non-allowed host is still rejected by the SSRF list', () => {
+    const cookie = cookieFor('luo', 1, { kind: 'sa' });
+    expect(getControllerUrl(withCookie(cookie, '?controllerUrl=http%3A%2F%2Fevil.example.com'))).toBe(DEFAULT_URL);
+  });
+
+  it('L2 session: no override parameter → default (unchanged behavior)', () => {
+    const cookie = cookieFor('sunzong', 2, { kind: 'matrix', token: 'syt_l2_token' });
+    expect(getControllerUrl(withCookie(cookie, ''))).toBe(DEFAULT_URL);
   });
 });

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -1,9 +1,15 @@
 // Shared proxy helper for AgentTeams API routes
 import { NextRequest, NextResponse } from 'next/server';
 import { getSessionFromRequest } from '@/lib/dashboard-session';
-import { pickBackendUrl } from '@/lib/backend-config';
+import { markWorking, orderedCandidates, pickBackendUrl } from '@/lib/backend-config';
 
 const TIMEOUT_MS = 10000;
+// Request-layer failover (plugin catch-all parity): a transport error retries
+// the SAME address once after this backoff before walking to the next
+// candidate. An HTTP response — including 4xx/5xx — means the address is up
+// and is returned as-is (never retried); only status < 400 marks it working.
+const SAME_ADDRESS_RETRY_MS = 300;
+const SAME_ADDRESS_RETRIES = 1;
 
 // Allowed controller URL hosts to prevent SSRF (only applies to user-supplied ?controllerUrl=)
 // In production/k3s mode the env var AGENTTEAMS_CONTROLLER_URL is authoritative.
@@ -51,43 +57,58 @@ function getDefaultControllerUrl(): string {
   return process.env.AGENTTEAMS_API_URL || 'http://agentteams-controller:8090';
 }
 
-export function getControllerUrl(request: NextRequest): string {
-  const defaultUrl = getDefaultControllerUrl();
+/** A valid ?controllerUrl= override for this request (L1 / pre-login,
+ * SSRF-checked), or null when absent / invalid / not allowed.
+ *
+ * F1b: the per-request override is L1-only. An L2 (own-scope, Matrix
+ * credential) session must always hit the deployment-configured controller so
+ * the A2 self-scope chain and audit attribution stay intact — a redirected
+ * request would land on a controller that has no notion of this user's scope.
+ * Pre-login requests (login flow, public setup endpoints) keep the override
+ * behind the SSRF allowlist as before. Level 3 sessions are exactly the
+ * admin-credential sessions ('sa' / 'controller-token' — see the login
+ * route's credential selection).
+ */
+export function getControllerOverride(request: NextRequest): string | null {
   const url = request.nextUrl.searchParams.get('controllerUrl');
-  if (url) {
-    // F1b: the per-request override is L1-only. An L2 (own-scope, Matrix
-    // credential) session must always hit the deployment-configured
-    // controller so the A2 self-scope chain and audit attribution stay
-    // intact — a redirected request would land on a controller that has no
-    // notion of this user's scope. Pre-login requests (login flow, public
-    // setup endpoints) keep the override behind the SSRF allowlist as before.
-    // Level 3 sessions are exactly the admin-credential sessions ('sa' /
-    // 'controller-token' — see the login route's credential selection).
-    const session = getSessionFromRequest(request);
-    if (session && session.level < 3) {
-      return defaultUrl;
-    }
-    try {
-      const parsed = new URL(url);
-      if (!['http:', 'https:'].includes(parsed.protocol)) {
-        throw new Error('Invalid protocol');
-      }
-      if (
-        !ALLOWED_HOSTS.includes(parsed.hostname) &&
-        !parsed.hostname.endsWith('.svc') &&
-        !parsed.hostname.endsWith('.svc.cluster.local') &&
-        !parsed.hostname.endsWith('.cluster.local') &&
-        !parsed.hostname.endsWith('.local')
-      ) {
-        throw new Error('Host not allowed');
-      }
-    } catch {
-      // If validation fails, fall back to default
-      return defaultUrl;
+  if (!url) return null;
+  const session = getSessionFromRequest(request);
+  if (session && session.level < 3) return null;
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+    if (
+      !ALLOWED_HOSTS.includes(parsed.hostname) &&
+      !parsed.hostname.endsWith('.svc') &&
+      !parsed.hostname.endsWith('.svc.cluster.local') &&
+      !parsed.hostname.endsWith('.cluster.local') &&
+      !parsed.hostname.endsWith('.local')
+    ) {
+      return null;
     }
     return url;
+  } catch {
+    return null;
   }
-  return defaultUrl;
+}
+
+export function getControllerUrl(request: NextRequest): string {
+  const override = getControllerOverride(request);
+  if (override) return override;
+  return getDefaultControllerUrl();
+}
+
+/**
+ * Failover target set for the proxy fetch loop (plugin catch-all parity):
+ * an explicit override pins a single address; otherwise the working-first
+ * candidate order (fresh working address → config internal → external → env).
+ */
+export function proxyTargets(request: NextRequest, primary: string): string[] {
+  const override = getControllerOverride(request);
+  if (override) return [override];
+  const candidates = orderedCandidates('controller');
+  if (primary && !candidates.includes(primary)) candidates.unshift(primary);
+  return candidates.length > 0 ? candidates : [primary];
 }
 
 export async function proxyToAgentTeams(
@@ -108,48 +129,46 @@ export async function proxyToAgentTeams(
   } = {}
 ): Promise<NextResponse> {
   const { method = request.method, forwardBody = true, contentType } = options;
-  const targetUrl = new URL(path, controllerUrl).toString();
+  // F1c: walk the candidate set instead of a single URL — a dead first
+  // candidate must never 502 the data plane (plugin catch-all parity).
+  const targets = proxyTargets(request, controllerUrl);
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const fetchOptions: RequestInit = {
+    method,
+    headers: {},
+  };
+
+  // Per-session Controller credential (M19 dual-track):
+  // - L2 session → the user's own Matrix access token, held in the
+  //   server-side session store (A2 chain scopes the request to the user's
+  //   teams; token never touches the browser).
+  // - L1 session / AUTH_DISABLED → the admin SA token.
+  // When a server-side credential exists, NEVER trust the browser-supplied
+  // Authorization header (token-injection protection, upstream #89). The
+  // browser header is only a fallback when no server-side credential exists
+  // at all (legacy dev setups).
+  const session = getSessionFromRequest(request);
+  const sessionToken =
+    session?.credential.kind === 'matrix' || session?.credential.kind === 'controller-token'
+      ? session.credential.token
+      : undefined;
+  const saToken = await getAuthToken();
+  const authToken = sessionToken || saToken || (
+    request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') || undefined
+  );
+  if (authToken) {
+    (fetchOptions.headers as Record<string, string>)['authorization'] = `Bearer ${authToken}`;
+  }
+
+  // Forward the server-resolved identity (set by middleware from the
+  // dashboard session) so the controller can attribute write actions to the
+  // right user without trusting browser-supplied headers.
+  for (const name of ['x-agentteams-user', 'x-agentteams-user-level']) {
+    const value = request.headers.get(name);
+    if (value) (fetchOptions.headers as Record<string, string>)[name] = value;
+  }
 
   try {
-    const fetchOptions: RequestInit = {
-      method,
-      signal: controller.signal,
-      headers: {},
-    };
-
-    // Per-session Controller credential (M19 dual-track):
-    // - L2 session → the user's own Matrix access token, held in the
-    //   server-side session store (A2 chain scopes the request to the user's
-    //   teams; token never touches the browser).
-    // - L1 session / AUTH_DISABLED → the admin SA token.
-    // When a server-side credential exists, NEVER trust the browser-supplied
-    // Authorization header (token-injection protection, upstream #89). The
-    // browser header is only a fallback when no server-side credential exists
-    // at all (legacy dev setups).
-    const session = getSessionFromRequest(request);
-    const sessionToken =
-      session?.credential.kind === 'matrix' || session?.credential.kind === 'controller-token'
-        ? session.credential.token
-        : undefined;
-    const saToken = await getAuthToken();
-    const authToken = sessionToken || saToken || (
-      request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') || undefined
-    );
-    if (authToken) {
-      (fetchOptions.headers as Record<string, string>)['authorization'] = `Bearer ${authToken}`;
-    }
-
-    // Forward the server-resolved identity (set by middleware from the
-    // dashboard session) so the controller can attribute write actions to the
-    // right user without trusting browser-supplied headers.
-    for (const name of ['x-agentteams-user', 'x-agentteams-user-level']) {
-      const value = request.headers.get(name);
-      if (value) (fetchOptions.headers as Record<string, string>)[name] = value;
-    }
-
     if (forwardBody && ['POST', 'PUT', 'PATCH'].includes(method)) {
       if (contentType === 'multipart/form-data') {
         // Forward multipart as-is (don't set Content-Type, let fetch handle boundary)
@@ -165,58 +184,103 @@ export async function proxyToAgentTeams(
         (fetchOptions.headers as Record<string, string>)['content-type'] = 'application/json';
       }
     }
-
-    const res = await fetch(targetUrl, fetchOptions);
-    clearTimeout(timeout);
-
-    // For 204 No Content
-    if (res.status === 204) {
-      return new NextResponse(null, { status: 204 });
-    }
-
-    if (options.stream && res.body) {
-      // Stream the binary body through without buffering (D15).
-      const responseHeaders = new Headers();
-      const resCT = res.headers.get('content-type');
-      if (resCT) responseHeaders.set('content-type', resCT);
-      for (const name of options.passthroughHeaders ?? []) {
-        const value = res.headers.get(name);
-        if (value) responseHeaders.set(name, value);
-      }
-      responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-      return new NextResponse(res.body, {
-        status: res.status,
-        headers: responseHeaders,
-      });
-    }
-
-    const data = await res.arrayBuffer();
-    const responseHeaders = new Headers();
-    const resCT = res.headers.get('content-type');
-    if (resCT) responseHeaders.set('content-type', resCT);
-    // Pass through any explicitly requested headers (e.g. content-disposition
-    // for artifact downloads so RFC 5987 filenames survive the proxy).
-    for (const name of options.passthroughHeaders ?? []) {
-      const value = res.headers.get(name);
-      if (value) responseHeaders.set(name, value);
-    }
-    // API responses should never be cached by the browser; stale cached JSON
-    // causes the dashboard to show outdated or empty data after restarts.
-    responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-    responseHeaders.set('pragma', 'no-cache');
-    responseHeaders.set('expires', '0');
-
-    return new NextResponse(data, {
-      status: res.status,
-      headers: responseHeaders,
-    });
   } catch (err: unknown) {
-    clearTimeout(timeout);
-    const message = err instanceof Error && err.name === 'AbortError'
-      ? 'Request timeout'
-      : err instanceof Error
-        ? err.message
-        : 'Unknown error';
+    const message = err instanceof Error ? err.message : 'Failed to read request body';
     return NextResponse.json({ error: message }, { status: 502 });
   }
+
+  // Failover loop: for each candidate address, try up to SAME_ADDRESS_RETRIES
+  // extra times on the SAME address (300ms backoff) before walking on. An HTTP
+  // response — any status — means the address is up: return it as-is.
+  const failures: Array<{ url: string; error: string }> = [];
+  for (const target of targets) {
+    let targetUrl: string;
+    try {
+      targetUrl = new URL(path, target).toString();
+    } catch {
+      failures.push({ url: target, error: 'invalid controller URL' });
+      continue;
+    }
+    for (let attempt = 0; attempt <= SAME_ADDRESS_RETRIES; attempt++) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      try {
+        const res = await fetch(targetUrl, { ...fetchOptions, signal: controller.signal });
+        clearTimeout(timeout);
+        if (res.status < 400) markWorking('controller', target);
+
+        // For 204 No Content
+        if (res.status === 204) {
+          return new NextResponse(null, { status: 204 });
+        }
+
+        if (options.stream && res.body) {
+          // Stream the binary body through without buffering (D15).
+          const responseHeaders = new Headers();
+          const resCT = res.headers.get('content-type');
+          if (resCT) responseHeaders.set('content-type', resCT);
+          for (const name of options.passthroughHeaders ?? []) {
+            const value = res.headers.get(name);
+            if (value) responseHeaders.set(name, value);
+          }
+          responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+          return new NextResponse(res.body, {
+            status: res.status,
+            headers: responseHeaders,
+          });
+        }
+
+        const data = await res.arrayBuffer();
+        const responseHeaders = new Headers();
+        const resCT = res.headers.get('content-type');
+        if (resCT) responseHeaders.set('content-type', resCT);
+        // Pass through any explicitly requested headers (e.g. content-disposition
+        // for artifact downloads so RFC 5987 filenames survive the proxy).
+        for (const name of options.passthroughHeaders ?? []) {
+          const value = res.headers.get(name);
+          if (value) responseHeaders.set(name, value);
+        }
+        // API responses should never be cached by the browser; stale cached
+        // JSON causes the dashboard to show outdated or empty data.
+        responseHeaders.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+        responseHeaders.set('pragma', 'no-cache');
+        responseHeaders.set('expires', '0');
+
+        return new NextResponse(data, {
+          status: res.status,
+          headers: responseHeaders,
+        });
+      } catch (err: unknown) {
+        clearTimeout(timeout);
+        if (attempt < SAME_ADDRESS_RETRIES) {
+          // Same-address retry first (plugin catch-all): a one-off blip on
+          // this address should not force a switch to the other network.
+          await new Promise((resolve) => setTimeout(resolve, SAME_ADDRESS_RETRY_MS));
+          continue;
+        }
+        failures.push({
+          url: target,
+          error:
+            err instanceof Error && err.name === 'AbortError'
+              ? `timeout after ${TIMEOUT_MS}ms`
+              : err instanceof Error
+                ? err.message
+                : 'unknown error',
+        });
+        break;
+      }
+    }
+  }
+
+  console.error(
+    `[dashboard] controller failover exhausted (${targets.length} address(es))`,
+    JSON.stringify(failures),
+  );
+  return NextResponse.json(
+    {
+      error: `后端地址全部不可达 (all ${targets.length} backend address(es) unreachable)`,
+      details: failures,
+    },
+    { status: 502 },
+  );
 }

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -27,7 +27,7 @@ const ALLOWED_HOSTS = [
 async function readAuthTokenFromFile(path: string): Promise<string | undefined> {
   try {
     // Use dynamic import so this code can still run in non-Node environments (e.g. tests)
-    const fs = await import('fs');
+    const fs = await import('node:fs');
     return fs.readFileSync(path, 'utf-8').trim();
   } catch {
     return undefined;

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -1,6 +1,7 @@
 // Shared proxy helper for AgentTeams API routes
 import { NextRequest, NextResponse } from 'next/server';
 import { getSessionFromRequest } from '@/lib/dashboard-session';
+import { pickBackendUrl } from '@/lib/backend-config';
 
 const TIMEOUT_MS = 10000;
 
@@ -39,13 +40,15 @@ export async function getAuthToken(): Promise<string | undefined> {
 }
 
 function getDefaultControllerUrl(): string {
+  // F1 resolution: first-launch config file (dual address + failover) >
+  // env vars > embedded in-cluster default. pickBackendUrl also returns the
+  // last-known-working address while its probe TTL is fresh, so a flaky
+  // primary automatically falls back to the secondary.
+  const configured = pickBackendUrl('controller');
+  if (configured) return configured;
   // Default to the in-cluster service name so a missing env var does not
   // cause the dashboard to proxy to itself on localhost.
-  return (
-    process.env.AGENTTEAMS_CONTROLLER_URL ||
-    process.env.AGENTTEAMS_API_URL ||
-    'http://agentteams-controller:8090'
-  );
+  return process.env.AGENTTEAMS_API_URL || 'http://agentteams-controller:8090';
 }
 
 export function getControllerUrl(request: NextRequest): string {

--- a/src/app/api/agentteams/proxy-helper.ts
+++ b/src/app/api/agentteams/proxy-helper.ts
@@ -55,6 +55,18 @@ export function getControllerUrl(request: NextRequest): string {
   const defaultUrl = getDefaultControllerUrl();
   const url = request.nextUrl.searchParams.get('controllerUrl');
   if (url) {
+    // F1b: the per-request override is L1-only. An L2 (own-scope, Matrix
+    // credential) session must always hit the deployment-configured
+    // controller so the A2 self-scope chain and audit attribution stay
+    // intact — a redirected request would land on a controller that has no
+    // notion of this user's scope. Pre-login requests (login flow, public
+    // setup endpoints) keep the override behind the SSRF allowlist as before.
+    // Level 3 sessions are exactly the admin-credential sessions ('sa' /
+    // 'controller-token' — see the login route's credential selection).
+    const session = getSessionFromRequest(request);
+    if (session && session.level < 3) {
+      return defaultUrl;
+    }
     try {
       const parsed = new URL(url);
       if (!['http:', 'https:'].includes(parsed.protocol)) {

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -163,21 +163,52 @@ describe('POST /api/agentteams/setup/backends', () => {
     expect(fs.existsSync(configFile())).toBe(false);
   });
 
-  it('accepts the right token once, then is permanently one-shot (403 already-configured)', async () => {
-    const payload = JSON.stringify({
-      token: 'test-token-123',
-      backends: { controller: { internal: 'http://a:8090' }, matrix: { external: 'http://mx:6167' } },
-    });
-    const first = await POST(makeRequest({ method: 'POST', body: payload }));
+  // F1e: pre-login writes are token-gated and REPEATABLE (broken/changed
+  // environment escape hatch — plugin config-first parity). The one-shot
+  // "already-configured" 403 is retired: after first launch the same
+  // token overwrites the config.
+  it('pre-login: first launch creates, later token writes overwrite (mode update)', async () => {
+    const first = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({
+          token: 'test-token-123',
+          backends: { controller: { internal: 'http://a:8090' }, matrix: { external: 'http://mx:6167' } },
+        }),
+      }),
+    );
     expect(first.status).toBe(200);
     const firstData = (await first.json()) as { ok: boolean; mode: string };
     expect(firstData.ok).toBe(true);
     expect(firstData.mode).toBe('first-launch');
     expect(fs.existsSync(configFile())).toBe(true);
 
-    const second = await POST(makeRequest({ method: 'POST', body: payload }));
-    expect(second.status).toBe(403);
-    expect(await second.json()).toEqual({ error: 'already-configured' });
+    const second = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({
+          token: 'test-token-123',
+          backends: { controller: { internal: 'http://c:8090' } },
+        }),
+      }),
+    );
+    expect(second.status).toBe(200);
+    const secondData = (await second.json()) as { ok: boolean; mode: string };
+    expect(secondData.ok).toBe(true);
+    expect(secondData.mode).toBe('update');
+    // overwrite semantics: the second write replaces the first
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://c:8090' });
+    expect(readConfigSync()?.backends.matrix).toBeUndefined();
+
+    // without the token the pre-login path stays closed
+    const third = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({ backends: { controller: { internal: 'http://x:8090' } } }),
+      }),
+    );
+    expect(third.status).toBe(403);
+    expect(await third.json()).toEqual({ error: 'token-required' });
   });
 
   it('rejects malformed payloads with 400', async () => {

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -10,6 +10,7 @@ import {
   sessionCookieHeader,
 } from '@/lib/dashboard-session';
 import { BACKEND_NAMES, forgetWorking, readConfigSync } from '@/lib/backend-config';
+import { listAuditEvents, resetAuditLogForTests } from '@/lib/audit-log';
 import { GET, POST } from './route';
 
 let workDir: string;
@@ -196,9 +197,10 @@ describe('POST /api/agentteams/setup/backends', () => {
     const secondData = (await second.json()) as { ok: boolean; mode: string };
     expect(secondData.ok).toBe(true);
     expect(secondData.mode).toBe('update');
-    // overwrite semantics: the second write replaces the first
+    // F1f-E merge semantics: the sent backend (controller) is replaced,
+    // the unsent backend (matrix) is preserved.
     expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://c:8090' });
-    expect(readConfigSync()?.backends.matrix).toBeUndefined();
+    expect(readConfigSync()?.backends.matrix).toEqual({ external: 'http://mx:6167' });
 
     // without the token the pre-login path stays closed
     const third = await POST(
@@ -238,8 +240,10 @@ describe('POST /api/agentteams/setup/backends', () => {
       makeRequest({ method: 'POST', body: JSON.stringify({ backends: { matrix: { internal: 'http://b:6167' } } }) }, cookie),
     );
     expect(second.status).toBe(200);
-    // overwrite semantics: the second write replaces the first
-    expect(readConfigSync()?.backends.controller).toBeUndefined();
+    // F1f-E merge semantics: the sent backend (matrix) replaces its
+    // entry; the unsent backend (controller) is preserved — a partial
+    // save must never wipe the rest of the config.
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://a:8090' });
     expect(readConfigSync()?.backends.matrix).toEqual({ internal: 'http://b:6167' });
   });
 
@@ -284,5 +288,89 @@ describe('POST /api/agentteams/setup/backends', () => {
     expect(res.status).toBe(200);
     // the session (not the token) authorized the save
     expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://b:8090' });
+  });
+});
+
+describe('F1f shared mode (DASHBOARD_SHARED_MODE=1, e.g. Node1 multi-user)', () => {
+  beforeEach(async () => {
+    vi.stubEnv('DASHBOARD_SHARED_MODE', '1');
+    vi.stubEnv('AGENTTEAMS_AUDIT_LOG_PATH', path.join(workDir, 'audit-shared.jsonl'));
+    // audit log is append-only — reset per test so events don't leak across cases
+    await resetAuditLogForTests();
+  });
+
+  it('A: L2 save is rejected (403), L1 save works', async () => {
+    const l2 = await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) },
+        l2Cookie(),
+      ),
+    );
+    expect(l2.status).toBe(403);
+    expect(await l2.json()).toEqual({ error: 'shared-mode: only admin (L1) may save backend config' });
+
+    const l1 = await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) },
+        l1Cookie(),
+      ),
+    );
+    expect(l1.status).toBe(200);
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://a:8090' });
+  });
+
+  it('B: pre-login uses the env token only and never persists a token file', async () => {
+    const res = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({
+          token: 'test-token-123',
+          backends: { controller: { internal: 'http://a:8090' }, matrix: { external: 'http://mx:6167' } },
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { mode: string }).mode).toBe('first-launch');
+    expect(fs.existsSync(path.join(workDir, '.setup-token'))).toBe(false);
+  });
+
+  it('B: with no env token the pre-login path fails closed', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN', '');
+    const res = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({ token: 'test-token-123', backends: { controller: { internal: 'http://a:8090' } } }),
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'invalid-token' });
+    expect(fs.existsSync(path.join(workDir, '.setup-token'))).toBe(false);
+  });
+
+  it('C: saves are audited with actor, level and changed fields', async () => {
+    await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) },
+        l1Cookie(),
+      ),
+    );
+    const write = (await listAuditEvents({})).find((e) => e.action === 'config.write');
+    expect(write).toBeDefined();
+    expect(write?.actor).toBe('admin');
+    expect(write?.actor_level).toBe(3);
+    expect(write?.details).toContain('controller');
+  });
+
+  it('A+C: a rejected L2 save leaves no config and no audit write', async () => {
+    const res = await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://evil:8090' } } }) },
+        l2Cookie(),
+      ),
+    );
+    expect(res.status).toBe(403);
+    expect(readConfigSync()).toBeNull();
+    const writes = (await listAuditEvents({})).filter((e) => e.action === 'config.write');
+    expect(writes).toHaveLength(0);
   });
 });

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -374,3 +374,71 @@ describe('F1f shared mode (DASHBOARD_SHARED_MODE=1, e.g. Node1 multi-user)', () 
     expect(writes).toHaveLength(0);
   });
 });
+
+// F1f3: the installer may disable the pre-login setup token gate with
+// DASHBOARD_SETUP_TOKEN_ENFORCE=0 (trusted-LAN deployments): pre-login
+// saves are plain, no token is generated/persisted, the UI field hides.
+describe('F1f3: DASHBOARD_SETUP_TOKEN_ENFORCE=0 (installer opt-out)', () => {
+  it('pre-login save without token succeeds (standalone)', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN_ENFORCE', '0');
+    const res = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { ok: boolean; mode: string };
+    expect(data.ok).toBe(true);
+    expect(data.mode).toBe('first-launch');
+    expect(fs.existsSync(configFile())).toBe(true);
+  });
+
+  it('pre-login save without token succeeds in shared mode too', async () => {
+    vi.stubEnv('DASHBOARD_SHARED_MODE', '1');
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN', '');
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN_ENFORCE', '0');
+    const res = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { ok: boolean };
+    expect(data.ok).toBe(true);
+  });
+
+  it('ENFORCE=0 overrides a set DASHBOARD_SETUP_TOKEN (gate stays off)', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN_ENFORCE', '0');
+    // DASHBOARD_SETUP_TOKEN is still 'test-token-123' from beforeEach.
+    const res = await POST(
+      makeRequest({
+        method: 'POST',
+        body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }),
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('no token is generated or persisted (standalone)', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN', '');
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN_ENFORCE', '0');
+    const { getSetupToken } = await import('@/lib/backend-config');
+    expect(await getSetupToken()).toBe('');
+    expect(fs.existsSync(path.join(workDir, '.setup-token'))).toBe(false);
+  });
+
+  it('GET reports setupTokenRequired=false (UI hides the token field)', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN_ENFORCE', '0');
+    const res = await GET(makeRequest());
+    const data = (await res.json()) as { setupTokenRequired: boolean };
+    expect(data.setupTokenRequired).toBe(false);
+  });
+
+  it('default (env unset) keeps the gate: GET reports required', async () => {
+    const res = await GET(makeRequest());
+    const data = (await res.json()) as { setupTokenRequired: boolean };
+    expect(data.setupTokenRequired).toBe(true);
+  });
+});

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -49,14 +49,14 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-function makeRequest(init?: { method?: string; body?: string }, cookie?: string) {
+function makeRequest(
+  init?: { method?: string; body?: string },
+  cookie?: string,
+  url = 'http://localhost/api/agentteams/setup/backends',
+) {
   const headers = new Headers();
   if (cookie) headers.set('cookie', cookie);
-  return new NextRequest('http://localhost/api/agentteams/setup/backends', {
-    method: init?.method,
-    headers,
-    body: init?.body,
-  });
+  return new NextRequest(url, { method: init?.method, headers, body: init?.body });
 }
 
 function l1Cookie(): string {
@@ -78,8 +78,10 @@ function l2Cookie(): string {
 }
 
 describe('GET /api/agentteams/setup/backends', () => {
-  it('reports unconfigured standalone state with embedded auto-detect results', async () => {
-    const res = await GET(makeRequest());
+  it('reports unconfigured standalone state with embedded auto-detect results (token holder)', async () => {
+    const res = await GET(
+      makeRequest(undefined, undefined, 'http://localhost/api/agentteams/setup/backends?token=test-token-123'),
+    );
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
       configured: boolean;
@@ -93,10 +95,12 @@ describe('GET /api/agentteams/setup/backends', () => {
     expect(data.embedded.healthy?.controller).toBe(false);
   });
 
-  it('reports configured when env provides the required backends', async () => {
+  it('reports configured when env provides the required backends (token holder)', async () => {
     vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://ctl:8090');
     vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
-    const res = await GET(makeRequest());
+    const res = await GET(
+      makeRequest(undefined, undefined, 'http://localhost/api/agentteams/setup/backends?token=test-token-123'),
+    );
     const data = (await res.json()) as {
       configured: boolean;
       backends: Record<string, { candidates: string[] }>;
@@ -108,19 +112,88 @@ describe('GET /api/agentteams/setup/backends', () => {
     expect(data.embedded.healthy).toBeNull();
   });
 
-  it('file config overrides and extends env candidates', async () => {
+  it('file config overrides and extends env candidates (token holder)', async () => {
     fs.writeFileSync(
       configFile(),
       JSON.stringify({ version: 1, backends: { controller: { internal: 'http://in:8090' } } }),
     );
     vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
     vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
-    const res = await GET(makeRequest());
+    const res = await GET(
+      makeRequest(undefined, undefined, 'http://localhost/api/agentteams/setup/backends?token=test-token-123'),
+    );
     const data = (await res.json()) as {
       backends: Record<string, { candidates: string[] }>;
     };
     expect(data.backends.controller.candidates).toEqual(['http://in:8090', 'http://env:8090']);
     expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://in:8090' });
+  });
+
+  // PR-91 review (Block 1): the saved topology is NOT public pre-login.
+  it('anonymous GET reveals no saved topology (PR-91 Block 1)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({
+        version: 1,
+        backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } },
+      }),
+    );
+    vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      configured: boolean;
+      setupTokenRequired?: boolean;
+      embedded?: unknown;
+      backends?: unknown;
+      config?: unknown;
+      effective?: unknown;
+    };
+    // gate shape only — the root page's first-launch check needs these
+    expect(data.configured).toBe(true);
+    expect(data.setupTokenRequired).toBe(true);
+    expect(data.embedded).toBeDefined();
+    // no saved topology, no effective URLs, no structured config
+    expect(data.backends).toBeUndefined();
+    expect(data.config).toBeUndefined();
+    expect(data.effective).toBeUndefined();
+  });
+
+  it('pre-login ?token= holder sees candidates + effective (setup page prefill)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({
+        version: 1,
+        backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } },
+      }),
+    );
+    vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
+    const res = await GET(
+      makeRequest(undefined, undefined, 'http://localhost/api/agentteams/setup/backends?token=test-token-123'),
+    );
+    const data = (await res.json()) as {
+      backends?: Record<string, { candidates: string[] }>;
+      effective?: Record<string, string>;
+      config?: unknown;
+    };
+    expect(data.backends?.controller?.candidates).toEqual(['http://in:8090', 'http://out:8090']);
+    // the effective working cache is part of the owner view
+    expect(data.effective).toBeDefined();
+    // the structured `config` field stays session-only
+    expect(data.config).toBeUndefined();
+  });
+
+  it('a wrong ?token= gets the minimal shape (no topology)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://in:8090' } } }),
+    );
+    const res = await GET(
+      makeRequest(undefined, undefined, 'http://localhost/api/agentteams/setup/backends?token=wrong-token'),
+    );
+    const data = (await res.json()) as { backends?: unknown; effective?: unknown };
+    expect(data.backends).toBeUndefined();
+    expect(data.effective).toBeUndefined();
   });
 
   it('exposes the structured file config to L1 and L2 alike, never to pre-login', async () => {

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -67,6 +67,15 @@ function l1Cookie(): string {
   return sessionCookieHeader(cookieValue);
 }
 
+function l2Cookie(): string {
+  const { cookieValue } = createSession({
+    user: 'sunzong',
+    crLevel: 2, // CRD 2 -> dashboard level 2 (own-scope L2)
+    credential: { kind: 'matrix', token: 'dummy-matrix-token' },
+  });
+  return sessionCookieHeader(cookieValue);
+}
+
 describe('GET /api/agentteams/setup/backends', () => {
   it('reports unconfigured standalone state with embedded auto-detect results', async () => {
     const res = await GET(makeRequest());
@@ -113,7 +122,7 @@ describe('GET /api/agentteams/setup/backends', () => {
     expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://in:8090' });
   });
 
-  it('exposes the structured file config only to a level-3 session (F1b settings tab)', async () => {
+  it('exposes the structured file config to L1 and L2 alike, never to pre-login', async () => {
     fs.writeFileSync(
       configFile(),
       JSON.stringify({
@@ -121,14 +130,18 @@ describe('GET /api/agentteams/setup/backends', () => {
         backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } },
       }),
     );
+    const expected = { controller: { internal: 'http://in:8090', external: 'http://out:8090' } };
 
     const l1 = await GET(makeRequest(undefined, l1Cookie()));
-    const l1Data = (await l1.json()) as { config?: Record<string, { internal?: string; external?: string }> };
-    expect(l1Data.config).toEqual({ controller: { internal: 'http://in:8090', external: 'http://out:8090' } });
+    expect(((await l1.json()) as { config?: unknown }).config).toEqual(expected);
+
+    // L2 (standalone instance owner via the Matrix track) sees it too —
+    // the backend tab is visible to all logged-in users.
+    const l2 = await GET(makeRequest(undefined, l2Cookie()));
+    expect(((await l2.json()) as { config?: unknown }).config).toEqual(expected);
 
     const anon = await GET(makeRequest());
-    const anonData = (await anon.json()) as { config?: unknown };
-    expect(anonData.config).toBeUndefined();
+    expect(((await anon.json()) as { config?: unknown }).config).toBeUndefined();
   });
 });
 
@@ -195,18 +208,63 @@ describe('POST /api/agentteams/setup/backends', () => {
     expect(readConfigSync()?.backends.matrix).toEqual({ internal: 'http://b:6167' });
   });
 
-  it('L2 session (level 2) is rejected like an anonymous request', async () => {
-    const { cookieValue } = createSession({
-      user: 'worker-user',
-      crLevel: 2, // CRD 2 -> dashboard level 2
-      credential: { kind: 'matrix', token: 'dummy-matrix-token' },
-    });
+  it('L2 session (level 2) without a token is rejected (403 token-required)', async () => {
     const res = await POST(
       makeRequest(
         { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) },
-        sessionCookieHeader(cookieValue),
+        l2Cookie(),
       ),
     );
     expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'token-required' });
+  });
+
+  it('L2 session with a wrong token is rejected (403 invalid-token)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://old:8090' } } }),
+    );
+    const res = await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ token: 'nope', backends: { controller: { internal: 'http://b:8090' } } }) },
+        l2Cookie(),
+      ),
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'invalid-token' });
+    // the wrong token must not have touched the config
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://old:8090' });
+  });
+
+  it('L2 session with the setup token (owner) can update the config', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://old:8090' } } }),
+    );
+    const res = await POST(
+      makeRequest(
+        {
+          method: 'POST',
+          body: JSON.stringify({ token: 'test-token-123', backends: { controller: { internal: 'http://new:8090' } } }),
+        },
+        l2Cookie(),
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, mode: 'owner-update' });
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://new:8090' });
+
+    // repeatable — the owner keeps editing rights (not one-shot like pre-login)
+    const again = await POST(
+      makeRequest(
+        {
+          method: 'POST',
+          body: JSON.stringify({ token: 'test-token-123', backends: { sglang: { internal: 'http://gpu:8000' } } }),
+        },
+        l2Cookie(),
+      ),
+    );
+    expect(again.status).toBe(200);
+    expect(readConfigSync()?.backends.sglang).toEqual({ internal: 'http://gpu:8000' });
   });
 });

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -69,7 +69,7 @@ function l1Cookie(): string {
 
 describe('GET /api/agentteams/setup/backends', () => {
   it('reports unconfigured standalone state with embedded auto-detect results', async () => {
-    const res = await GET();
+    const res = await GET(makeRequest());
     expect(res.status).toBe(200);
     const data = (await res.json()) as {
       configured: boolean;
@@ -86,7 +86,7 @@ describe('GET /api/agentteams/setup/backends', () => {
   it('reports configured when env provides the required backends', async () => {
     vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://ctl:8090');
     vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
-    const res = await GET();
+    const res = await GET(makeRequest());
     const data = (await res.json()) as {
       configured: boolean;
       backends: Record<string, { candidates: string[] }>;
@@ -105,12 +105,30 @@ describe('GET /api/agentteams/setup/backends', () => {
     );
     vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
     vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
-    const res = await GET();
+    const res = await GET(makeRequest());
     const data = (await res.json()) as {
       backends: Record<string, { candidates: string[] }>;
     };
     expect(data.backends.controller.candidates).toEqual(['http://in:8090', 'http://env:8090']);
     expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://in:8090' });
+  });
+
+  it('exposes the structured file config only to a level-3 session (F1b settings tab)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({
+        version: 1,
+        backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } },
+      }),
+    );
+
+    const l1 = await GET(makeRequest(undefined, l1Cookie()));
+    const l1Data = (await l1.json()) as { config?: Record<string, { internal?: string; external?: string }> };
+    expect(l1Data.config).toEqual({ controller: { internal: 'http://in:8090', external: 'http://out:8090' } });
+
+    const anon = await GET(makeRequest());
+    const anonData = (await anon.json()) as { config?: unknown };
+    expect(anonData.config).toBeUndefined();
   });
 });
 

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -170,7 +170,9 @@ describe('POST /api/agentteams/setup/backends', () => {
     });
     const first = await POST(makeRequest({ method: 'POST', body: payload }));
     expect(first.status).toBe(200);
-    expect(await first.json()).toEqual({ ok: true, mode: 'first-launch' });
+    const firstData = (await first.json()) as { ok: boolean; mode: string };
+    expect(firstData.ok).toBe(true);
+    expect(firstData.mode).toBe('first-launch');
     expect(fs.existsSync(configFile())).toBe(true);
 
     const second = await POST(makeRequest({ method: 'POST', body: payload }));
@@ -197,7 +199,9 @@ describe('POST /api/agentteams/setup/backends', () => {
       makeRequest({ method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) }, cookie),
     );
     expect(first.status).toBe(200);
-    expect(await first.json()).toEqual({ ok: true, mode: 'l1-update' });
+    const firstData = (await first.json()) as { ok: boolean; mode: string };
+    expect(firstData.ok).toBe(true);
+    expect(firstData.mode).toBe('update');
 
     const second = await POST(
       makeRequest({ method: 'POST', body: JSON.stringify({ backends: { matrix: { internal: 'http://b:6167' } } }) }, cookie),
@@ -208,18 +212,34 @@ describe('POST /api/agentteams/setup/backends', () => {
     expect(readConfigSync()?.backends.matrix).toEqual({ internal: 'http://b:6167' });
   });
 
-  it('L2 session (level 2) without a token is rejected (403 token-required)', async () => {
+  // F1c (plugin parity, decided 9/9 — one instance per user, no shared
+  // instances): an L2 session saves WITHOUT any token, exactly like the
+  // plugin's config page is open to the user of this host.
+  it('L2 session (level 2) can update the config directly, no token needed', async () => {
     const res = await POST(
       makeRequest(
         { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) },
         l2Cookie(),
       ),
     );
-    expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ error: 'token-required' });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { ok: boolean; mode: string };
+    expect(data.ok).toBe(true);
+    expect(data.mode).toBe('update');
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://a:8090' });
+
+    // repeatable — not one-shot like pre-login
+    const again = await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ backends: { sglang: { internal: 'http://gpu:8000' } } }) },
+        l2Cookie(),
+      ),
+    );
+    expect(again.status).toBe(200);
+    expect(readConfigSync()?.backends.sglang).toEqual({ internal: 'http://gpu:8000' });
   });
 
-  it('L2 session with a wrong token is rejected (403 invalid-token)', async () => {
+  it('a stale token in the body is ignored for logged-in sessions (no owner-credential path anymore)', async () => {
     fs.writeFileSync(
       configFile(),
       JSON.stringify({ version: 1, backends: { controller: { internal: 'http://old:8090' } } }),
@@ -230,41 +250,8 @@ describe('POST /api/agentteams/setup/backends', () => {
         l2Cookie(),
       ),
     );
-    expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ error: 'invalid-token' });
-    // the wrong token must not have touched the config
-    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://old:8090' });
-  });
-
-  it('L2 session with the setup token (owner) can update the config', async () => {
-    fs.writeFileSync(
-      configFile(),
-      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://old:8090' } } }),
-    );
-    const res = await POST(
-      makeRequest(
-        {
-          method: 'POST',
-          body: JSON.stringify({ token: 'test-token-123', backends: { controller: { internal: 'http://new:8090' } } }),
-        },
-        l2Cookie(),
-      ),
-    );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, mode: 'owner-update' });
-    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://new:8090' });
-
-    // repeatable — the owner keeps editing rights (not one-shot like pre-login)
-    const again = await POST(
-      makeRequest(
-        {
-          method: 'POST',
-          body: JSON.stringify({ token: 'test-token-123', backends: { sglang: { internal: 'http://gpu:8000' } } }),
-        },
-        l2Cookie(),
-      ),
-    );
-    expect(again.status).toBe(200);
-    expect(readConfigSync()?.backends.sglang).toEqual({ internal: 'http://gpu:8000' });
+    // the session (not the token) authorized the save
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://b:8090' });
   });
 });

--- a/src/app/api/agentteams/setup/backends/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/route.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment node
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { NextRequest } from 'next/server';
+import {
+  __resetSessionStoreForTests,
+  createSession,
+  sessionCookieHeader,
+} from '@/lib/dashboard-session';
+import { BACKEND_NAMES, forgetWorking, readConfigSync } from '@/lib/backend-config';
+import { GET, POST } from './route';
+
+let workDir: string;
+
+function configFile() {
+  return path.join(workDir, 'config.json');
+}
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-backends-'));
+});
+
+afterAll(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv('DASHBOARD_CONFIG_FILE', configFile());
+  vi.stubEnv('DASHBOARD_SETUP_TOKEN', 'test-token-123');
+  // ≥64 hex chars (32+ bytes) — the session store fails closed below that.
+  vi.stubEnv('DASHBOARD_SESSION_SECRET', '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+  // No env-configured backends by default (standalone first-launch scenario).
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', '');
+  vi.stubEnv('AGENTTEAMS_API_URL', '');
+  vi.stubEnv('AGENTTEAMS_MATRIX_URL', '');
+  vi.stubEnv('NEXT_PUBLIC_MATRIX_API_URL', '');
+  __resetSessionStoreForTests();
+  for (const name of BACKEND_NAMES) forgetWorking(name);
+});
+
+afterEach(() => {
+  for (const file of [configFile(), path.join(workDir, '.setup-token')]) {
+    if (fs.existsSync(file)) fs.rmSync(file);
+  }
+  vi.unstubAllEnvs();
+});
+
+function makeRequest(init?: { method?: string; body?: string }, cookie?: string) {
+  const headers = new Headers();
+  if (cookie) headers.set('cookie', cookie);
+  return new NextRequest('http://localhost/api/agentteams/setup/backends', {
+    method: init?.method,
+    headers,
+    body: init?.body,
+  });
+}
+
+function l1Cookie(): string {
+  const { cookieValue } = createSession({
+    user: 'admin',
+    crLevel: 1, // CRD 1 -> dashboard level 3 (L1 admin)
+    credential: { kind: 'controller-token', token: 'dummy-sa-token' },
+  });
+  return sessionCookieHeader(cookieValue);
+}
+
+describe('GET /api/agentteams/setup/backends', () => {
+  it('reports unconfigured standalone state with embedded auto-detect results', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      configured: boolean;
+      backends: Record<string, { configured: boolean; candidates: string[] }>;
+      embedded: { healthy: Record<string, boolean> | null };
+    };
+    expect(data.configured).toBe(false);
+    expect(data.backends.controller.configured).toBe(false);
+    expect(data.backends.sglang.configured).toBe(false);
+    // unconfigured -> embedded defaults were probed (all unreachable in tests)
+    expect(data.embedded.healthy?.controller).toBe(false);
+  });
+
+  it('reports configured when env provides the required backends', async () => {
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://ctl:8090');
+    vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
+    const res = await GET();
+    const data = (await res.json()) as {
+      configured: boolean;
+      backends: Record<string, { candidates: string[] }>;
+      embedded: { healthy: Record<string, boolean> | null };
+    };
+    expect(data.configured).toBe(true);
+    expect(data.backends.controller.candidates).toEqual(['http://ctl:8090']);
+    // configured -> no embedded probe (zero latency cost)
+    expect(data.embedded.healthy).toBeNull();
+  });
+
+  it('file config overrides and extends env candidates', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://in:8090' } } }),
+    );
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
+    vi.stubEnv('AGENTTEAMS_MATRIX_URL', 'http://mx:6167');
+    const res = await GET();
+    const data = (await res.json()) as {
+      backends: Record<string, { candidates: string[] }>;
+    };
+    expect(data.backends.controller.candidates).toEqual(['http://in:8090', 'http://env:8090']);
+    expect(readConfigSync()?.backends.controller).toEqual({ internal: 'http://in:8090' });
+  });
+});
+
+describe('POST /api/agentteams/setup/backends', () => {
+  it('rejects a pre-login write without a token (403 token-required)', async () => {
+    const res = await POST(
+      makeRequest({ method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) }),
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'token-required' });
+  });
+
+  it('rejects a wrong token (403 invalid-token) and leaves no file', async () => {
+    const res = await POST(
+      makeRequest({ method: 'POST', body: JSON.stringify({ token: 'nope', backends: { controller: { internal: 'http://a:8090' } } }) }),
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'invalid-token' });
+    expect(fs.existsSync(configFile())).toBe(false);
+  });
+
+  it('accepts the right token once, then is permanently one-shot (403 already-configured)', async () => {
+    const payload = JSON.stringify({
+      token: 'test-token-123',
+      backends: { controller: { internal: 'http://a:8090' }, matrix: { external: 'http://mx:6167' } },
+    });
+    const first = await POST(makeRequest({ method: 'POST', body: payload }));
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ ok: true, mode: 'first-launch' });
+    expect(fs.existsSync(configFile())).toBe(true);
+
+    const second = await POST(makeRequest({ method: 'POST', body: payload }));
+    expect(second.status).toBe(403);
+    expect(await second.json()).toEqual({ error: 'already-configured' });
+  });
+
+  it('rejects malformed payloads with 400', async () => {
+    const cases = [
+      JSON.stringify({ token: 'test-token-123', backends: { nope: { internal: 'http://a' } } }),
+      JSON.stringify({ token: 'test-token-123', backends: { controller: { internal: 'ftp://a' } } }),
+      JSON.stringify({ token: 'test-token-123', backends: {} }),
+    ];
+    for (const body of cases) {
+      const res = await POST(makeRequest({ method: 'POST', body }));
+      expect(res.status).toBe(400);
+    }
+    expect(fs.existsSync(configFile())).toBe(false);
+  });
+
+  it('L1 session (level 3) can update the config repeatedly, no token needed', async () => {
+    const cookie = l1Cookie();
+    const first = await POST(
+      makeRequest({ method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) }, cookie),
+    );
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ ok: true, mode: 'l1-update' });
+
+    const second = await POST(
+      makeRequest({ method: 'POST', body: JSON.stringify({ backends: { matrix: { internal: 'http://b:6167' } } }) }, cookie),
+    );
+    expect(second.status).toBe(200);
+    // overwrite semantics: the second write replaces the first
+    expect(readConfigSync()?.backends.controller).toBeUndefined();
+    expect(readConfigSync()?.backends.matrix).toEqual({ internal: 'http://b:6167' });
+  });
+
+  it('L2 session (level 2) is rejected like an anonymous request', async () => {
+    const { cookieValue } = createSession({
+      user: 'worker-user',
+      crLevel: 2, // CRD 2 -> dashboard level 2
+      credential: { kind: 'matrix', token: 'dummy-matrix-token' },
+    });
+    const res = await POST(
+      makeRequest(
+        { method: 'POST', body: JSON.stringify({ backends: { controller: { internal: 'http://a:8090' } } }) },
+        sessionCookieHeader(cookieValue),
+      ),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -1,10 +1,14 @@
 // /api/agentteams/setup/backends — dashboard-level backend address config (F1).
 //
-// GET (public, pre-login readable): reports whether the dashboard is usable
-// (required backends have at least one candidate address). Drives the
-// first-launch gate on the root page: unconfigured -> backend setup UI
-// instead of the login form. The embedded auto-detect probe only runs in the
-// unconfigured case so normal deployments pay zero extra latency.
+// GET (gate-shape public, topology gated — PR-91 review): the anonymous
+// response reports only { configured, setupTokenRequired, embedded } so a
+// logged-out caller cannot enumerate the saved topology. Candidates and
+// effective are served to an authenticated session or a pre-login caller
+// with the setup token (?token= — same owner gate as the pre-login write),
+// which the ?setup=1 reconfigure page uses to prefill the saved addresses.
+// Drives the first-launch gate on the root page: unconfigured -> backend
+// setup UI instead of the login form. The embedded auto-detect probe only
+// runs in the unconfigured case so normal deployments pay zero extra latency.
 //
 // POST (auth modes — F1c + F1f shared-mode hardening):
 //   - post-login, standalone (default, one instance per user): any logged-in
@@ -43,7 +47,6 @@
 // Every successful save re-probes the saved backends (plugin put_config →
 // refresh_effective) and returns `effective` / `switched` for the UI banner.
 import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'node:crypto';
 import { getSessionFromRequest } from '@/lib/dashboard-session';
 import {
   BACKEND_NAMES,
@@ -52,7 +55,6 @@ import {
   backendCandidates,
   configExists,
   effectiveUrl,
-  getSetupToken,
   isHttpUrl,
   isSetupTokenEnforced,
   isSharedMode,
@@ -61,6 +63,7 @@ import {
   refreshEffective,
   saveConfigOneShot,
   updateConfig,
+  verifySetupToken,
   type BackendAddrs,
   type BackendName,
 } from '@/lib/backend-config';
@@ -124,12 +127,29 @@ export async function GET(request: NextRequest) {
     healthy = Object.fromEntries(probed);
   }
 
-  // The structured file config (internal/external per backend) is exposed
-  // to any AUTHENTICATED session — the settings backend tab is visible and
-  // editable to L1 and L2 alike (plugin parity: whoever uses this instance
-  // edits this instance's config). Pre-login callers (the first-launch
-  // page) get candidates and embedded defaults only.
+  // PR-91 review (Block 1): the saved topology (candidates + effective) is
+  // NOT public pre-login — anyone who can reach the dashboard must not be
+  // able to enumerate the internal controller/matrix/minio/higress
+  // addresses. Full detail is served to:
+  //   - any authenticated session (settings backend tab, L1 and L2 alike),
+  //   - a pre-login caller holding the setup token (?token= — the same
+  //     owner gate as the pre-login write), so the ?setup=1 reconfigure
+  //     page can prefill the saved addresses once the operator has the
+  //     token.
+  // Everyone else gets the gate-shape only: configured / setupTokenRequired
+  // / embedded defaults (hardcoded in the source, not deployment data).
   const session = getSessionFromRequest(request);
+  const queryToken = request.nextUrl.searchParams.get('token');
+  const prefillAuthorized =
+    !session && queryToken ? await verifySetupToken(queryToken) : !!session;
+  if (!prefillAuthorized) {
+    return NextResponse.json({
+      configured,
+      setupTokenRequired: isSetupTokenEnforced(),
+      embedded: { defaults: EMBEDDED_DEFAULTS, healthy },
+    });
+  }
+
   const authedConfig = session ? { config: config?.backends ?? {} } : {};
 
   // Effective (working-cache) address per backend — the "在生效" badge data.
@@ -269,12 +289,5 @@ function diffBackends(
   return changed.join('; ');
 }
 
-async function verifySetupToken(token: string): Promise<boolean> {
-  const expected = await getSetupToken();
-  // B: shared mode without a DASHBOARD_SETUP_TOKEN env — the pre-login
-  // write path is closed (fails closed, no timing comparison on empty).
-  if (!expected) return false;
-  const a = Buffer.from(token);
-  const b = Buffer.from(expected);
-  return a.length === b.length && crypto.timingSafeEqual(a, b);
-}
+// verifySetupToken is shared with POST /setup/backends/test — one
+// implementation in @/lib/backend-config (PR-91 review).

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -6,21 +6,25 @@
 // instead of the login form. The embedded auto-detect probe only runs in the
 // unconfigured case so normal deployments pay zero extra latency.
 //
-// POST (three auth modes):
-//   - post-login L1: session at dashboard level 3 (admin) may create or
-//     overwrite the config at any time, no token needed.
-//   - post-login owner: session at level < 3 presenting the first-launch
-//     setup token (body.token). The standalone instance owner typically
-//     logs in via the Matrix track (level < 3); the one-time setup token
-//     shown at first launch is their owner credential for later edits.
-//     In a multi-user deployment only the owner (who ran first launch)
-//     holds it, so a peer L2 cannot shadow the deployment env config
-//     (config file > env).
+// POST (two auth modes — plugin parity, F1c):
+//   - post-login (L1 or L2, any level): any logged-in user may create or
+//     overwrite the config. The deployment model is one instance per user
+//     (own docker, remote AgentTeams), so the instance's users ARE the
+//     plugin's "user of this host" — the plugin's config page is equally
+//     open to whoever is logged into the host, with no extra credential.
+//     The SSRF surface of user-supplied addresses stays pinned by
+//     DASHBOARD_ALLOWED_HOSTS; config editing does not touch credentials
+//     (L1 SA token / L2 session tokens stay server-side).
 //   - pre-login one-shot: body.token must equal the setup token AND the
 //     config file must not exist yet. This is the only way a logged-out
 //     browser can write backend addresses (first launch on a standalone
-//     docker install). After the file exists, this mode is permanently
-//     rejected — no config re-do from the login screen.
+//     docker install — the plugin has no equivalent because the host is
+//     already authenticated; this is the dashboard's install-method
+//     difference, approved 9/9). After the file exists, this mode is
+//     permanently rejected — no config re-do from the login screen.
+//
+// Every successful save re-probes the saved backends (plugin put_config →
+// refresh_effective) and returns `effective` / `switched` for the UI banner.
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'node:crypto';
 import { getSessionFromRequest } from '@/lib/dashboard-session';
@@ -30,11 +34,12 @@ import {
   REQUIRED_BACKENDS,
   backendCandidates,
   configExists,
+  effectiveUrl,
   getSetupToken,
   isHttpUrl,
-  markWorking,
   probeBackend,
   readConfigSync,
+  refreshEffective,
   saveConfigOneShot,
   updateConfig,
   type BackendAddrs,
@@ -93,25 +98,33 @@ export async function GET(request: NextRequest) {
     const probed = await Promise.all(
       BACKEND_NAMES.filter((name) => EMBEDDED_DEFAULTS[name]).map(async (name) => {
         const result = await probeBackend(name, EMBEDDED_DEFAULTS[name] as string, 2000);
-        return [name, result.ok] as const;
+        return [name, result.httpOk] as const;
       }),
     );
     healthy = Object.fromEntries(probed);
   }
 
   // The structured file config (internal/external per backend) is exposed
-  // to any AUTHENTICATED session — the settings backend tab is visible to
-  // L1 and L2 alike (L2 = standalone instance owner who logged in via the
-  // Matrix track). Pre-login callers (the first-launch page) get candidates
-  // and embedded defaults only.
+  // to any AUTHENTICATED session — the settings backend tab is visible and
+  // editable to L1 and L2 alike (plugin parity: whoever uses this instance
+  // edits this instance's config). Pre-login callers (the first-launch
+  // page) get candidates and embedded defaults only.
   const session = getSessionFromRequest(request);
   const authedConfig = session ? { config: config?.backends ?? {} } : {};
+
+  // Effective (working-cache) address per backend — the "在生效" badge data.
+  const effective: Partial<Record<BackendName, string>> = {};
+  for (const name of BACKEND_NAMES) {
+    const url = effectiveUrl(name);
+    if (url) effective[name] = url;
+  }
 
   return NextResponse.json({
     configured,
     backends: perBackend,
     embedded: { defaults: EMBEDDED_DEFAULTS, healthy },
     ...authedConfig,
+    effective,
   });
 }
 
@@ -132,33 +145,17 @@ export async function POST(request: NextRequest) {
   const session = getSessionFromRequest(request);
   const token = typeof body?.token === 'string' ? body.token : undefined;
 
-  if (session && session.level >= 3) {
-    // L1 admin (post-login): repeatable create/overwrite.
+  if (session) {
+    // Post-login (L1 or L2, plugin parity): repeatable create/overwrite.
     const result = await updateConfig(parsed.backends);
     if (!result.ok) {
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
-    return NextResponse.json({ ok: true, mode: 'l1-update' });
-  }
-
-  if (session && session.level < 3) {
-    // Post-login owner path: the standalone instance owner who logged in
-    // via the Matrix track (level < 3) edits the config with the
-    // first-launch setup token (their owner credential). A peer L2 in a
-    // multi-user deployment does not hold it → cannot shadow env.
-    if (!(token && (await verifySetupToken(token)))) {
-      return NextResponse.json(
-        { error: token ? 'invalid-token' : 'token-required' },
-        { status: 403 },
-      );
-    }
-    const result = await updateConfig(parsed.backends);
-    if (!result.ok) {
-      return NextResponse.json({ error: result.error }, { status: 400 });
-    }
-    // The owner just proved these addresses — seed the failover cache.
-    seedWorkingCache(parsed.backends);
-    return NextResponse.json({ ok: true, mode: 'owner-update' });
+    // Re-probe what was just saved (plugin put_config → refresh_effective):
+    // the effective address is latency-elected from real probes, not seeded
+    // blindly.
+    const { effective, switched } = await refreshEffective(Object.keys(parsed.backends) as BackendName[]);
+    return NextResponse.json({ ok: true, mode: 'update', effective, switched });
   }
 
   // Pre-login one-shot: token-gated, only while no config exists.
@@ -175,9 +172,10 @@ export async function POST(request: NextRequest) {
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
-  // The user just proved these addresses — seed the failover working cache.
-  seedWorkingCache(parsed.backends);
-  return NextResponse.json({ ok: true, mode: 'first-launch' });
+  // Re-probe the fresh config so the effective cache is honest from the
+  // first request (replaces the old blind first-address seed).
+  const { effective, switched } = await refreshEffective(Object.keys(parsed.backends) as BackendName[]);
+  return NextResponse.json({ ok: true, mode: 'first-launch', effective, switched });
 }
 
 async function verifySetupToken(token: string): Promise<boolean> {
@@ -185,11 +183,4 @@ async function verifySetupToken(token: string): Promise<boolean> {
   const a = Buffer.from(token);
   const b = Buffer.from(expected);
   return a.length === b.length && crypto.timingSafeEqual(a, b);
-}
-
-function seedWorkingCache(backends: Partial<Record<BackendName, BackendAddrs>>): void {
-  for (const [name, addrs] of Object.entries(backends)) {
-    const first = addrs?.internal || addrs?.external;
-    if (first) markWorking(name as BackendName, first);
-  }
 }

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -69,7 +69,7 @@ const BACKEND_NAMES_SET: BackendNameSet = Object.fromEntries(
   BACKEND_NAMES.map((name) => [name, name]),
 );
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const config = readConfigSync();
   const perBackend: Record<string, { configured: boolean; candidates: string[] }> = {};
   let configured = true;
@@ -92,10 +92,19 @@ export async function GET() {
     healthy = Object.fromEntries(probed);
   }
 
+  // The structured file config (internal/external per backend) is only
+  // exposed to a level-3 (L1 admin) session — it feeds the settings dialog
+  // backend tab. Pre-login callers (the first-launch page) get candidates
+  // and embedded defaults only.
+  const session = getSessionFromRequest(request);
+  const l1Config =
+    session && session.level >= 3 ? { config: config?.backends ?? {} } : {};
+
   return NextResponse.json({
     configured,
     backends: perBackend,
     embedded: { defaults: EMBEDDED_DEFAULTS, healthy },
+    ...l1Config,
   });
 }
 

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -15,13 +15,18 @@
 //     The SSRF surface of user-supplied addresses stays pinned by
 //     DASHBOARD_ALLOWED_HOSTS; config editing does not touch credentials
 //     (L1 SA token / L2 session tokens stay server-side).
-//   - pre-login one-shot: body.token must equal the setup token AND the
-//     config file must not exist yet. This is the only way a logged-out
-//     browser can write backend addresses (first launch on a standalone
-//     docker install — the plugin has no equivalent because the host is
-//     already authenticated; this is the dashboard's install-method
-//     difference, approved 9/9). After the file exists, this mode is
-//     permanently rejected — no config re-do from the login screen.
+//   - pre-login (token-gated, repeatable — F1e): body.token must equal the
+//     setup token. First launch creates the config; afterwards the same
+//     token remains the ONLY owner gate for re-configuring from a
+//     logged-out browser — the escape hatch for broken/changed
+//     environments (wrong addresses, network move), reachable from the
+//     login screen via ?setup=1. Plugin parity (config-first): the config
+//     surface stays reachable before login and login is downstream of it;
+//     the dashboard's install-method difference (a web login gate the
+//     host-embedded plugin lacks) keeps the token as the pre-login write
+//     authority — it plugs the auth-bypass threat (a logged-out attacker
+//     redirecting the controller to a fake backend to spoof L1 password
+//     verification). Losing the token = `docker volume rm` factory reset.
 //
 // Every successful save re-probes the saved backends (plugin put_config →
 // refresh_effective) and returns `effective` / `switched` for the UI banner.
@@ -158,24 +163,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true, mode: 'update', effective, switched });
   }
 
-  // Pre-login one-shot: token-gated, only while no config exists.
+  // Pre-login: token-gated, repeatable (F1e). First launch creates the
+  // config; afterwards the same token overwrites it (broken/changed
+  // environment escape hatch — see header). No session, no other path.
   if (!token) {
     return NextResponse.json({ error: 'token-required' }, { status: 403 });
   }
   if (!(await verifySetupToken(token))) {
     return NextResponse.json({ error: 'invalid-token' }, { status: 403 });
   }
-  if (await configExists()) {
-    return NextResponse.json({ error: 'already-configured' }, { status: 403 });
-  }
-  const result = await saveConfigOneShot(parsed.backends);
+  const existed = await configExists();
+  const result = existed ? await updateConfig(parsed.backends) : await saveConfigOneShot(parsed.backends);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
-  // Re-probe the fresh config so the effective cache is honest from the
-  // first request (replaces the old blind first-address seed).
+  // Re-probe the saved config so the effective cache is honest from the
+  // first request (plugin put_config → refresh_effective).
   const { effective, switched } = await refreshEffective(Object.keys(parsed.backends) as BackendName[]);
-  return NextResponse.json({ ok: true, mode: 'first-launch', effective, switched });
+  return NextResponse.json({ ok: true, mode: existed ? 'update' : 'first-launch', effective, switched });
 }
 
 async function verifySetupToken(token: string): Promise<boolean> {

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -1,0 +1,151 @@
+// /api/agentteams/setup/backends — dashboard-level backend address config (F1).
+//
+// GET (public, pre-login readable): reports whether the dashboard is usable
+// (required backends have at least one candidate address). Drives the
+// first-launch gate on the root page: unconfigured -> backend setup UI
+// instead of the login form. The embedded auto-detect probe only runs in the
+// unconfigured case so normal deployments pay zero extra latency.
+//
+// POST (two auth modes):
+//   - pre-login one-shot: body.token must equal the setup token AND the
+//     config file must not exist yet. This is the only way a logged-out
+//     browser can write backend addresses (first launch on a standalone
+//     docker install). After the file exists, this mode is permanently
+//     rejected — no config re-do from the login screen.
+//   - post-login L1: session at dashboard level 3 (admin) may create or
+//     overwrite the config at any time.
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'node:crypto';
+import { getSessionFromRequest } from '@/lib/dashboard-session';
+import {
+  BACKEND_NAMES,
+  EMBEDDED_DEFAULTS,
+  REQUIRED_BACKENDS,
+  backendCandidates,
+  configExists,
+  getSetupToken,
+  isHttpUrl,
+  markWorking,
+  probeBackend,
+  readConfigSync,
+  saveConfigOneShot,
+  updateConfig,
+  type BackendAddrs,
+  type BackendName,
+} from '@/lib/backend-config';
+
+type BackendNameSet = Record<string, BackendName>;
+
+function parseBackendsPayload(
+  raw: unknown,
+): { backends?: Partial<Record<BackendName, BackendAddrs>>; error?: string } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { error: 'backends must be an object' };
+  }
+  const out: Partial<Record<BackendName, BackendAddrs>> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!(key in BACKEND_NAMES_SET)) {
+      return { error: `unknown backend "${key}"` };
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { error: `backend "${key}" must be an object` };
+    }
+    const entry = value as Record<string, unknown>;
+    const addrs: BackendAddrs = {};
+    for (const slot of ['internal', 'external'] as const) {
+      const candidate = entry[slot];
+      if (candidate === undefined || candidate === null || candidate === '') continue;
+      if (typeof candidate !== 'string' || !isHttpUrl(candidate)) {
+        return { error: `backend "${key}" ${slot} must be an http(s) URL` };
+      }
+      addrs[slot] = candidate.trim();
+    }
+    if (addrs.internal || addrs.external) out[key as BackendName] = addrs;
+  }
+  return { backends: out };
+}
+
+const BACKEND_NAMES_SET: BackendNameSet = Object.fromEntries(
+  BACKEND_NAMES.map((name) => [name, name]),
+);
+
+export async function GET() {
+  const config = readConfigSync();
+  const perBackend: Record<string, { configured: boolean; candidates: string[] }> = {};
+  let configured = true;
+  for (const name of BACKEND_NAMES) {
+    const candidates = backendCandidates(name, config);
+    perBackend[name] = { configured: candidates.length > 0, candidates };
+    if (REQUIRED_BACKENDS.includes(name) && candidates.length === 0) configured = false;
+  }
+
+  let healthy: Record<string, boolean> | null = null;
+  if (!configured) {
+    // First-launch auto-detect: probe the embedded topology defaults in
+    // parallel so the setup page can offer a one-click "use defaults".
+    const probed = await Promise.all(
+      BACKEND_NAMES.filter((name) => EMBEDDED_DEFAULTS[name]).map(async (name) => {
+        const result = await probeBackend(name, EMBEDDED_DEFAULTS[name] as string, 2000);
+        return [name, result.ok] as const;
+      }),
+    );
+    healthy = Object.fromEntries(probed);
+  }
+
+  return NextResponse.json({
+    configured,
+    backends: perBackend,
+    embedded: { defaults: EMBEDDED_DEFAULTS, healthy },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => null)) as {
+    token?: unknown;
+    backends?: unknown;
+  } | null;
+
+  const parsed = parseBackendsPayload(body?.backends);
+  if (parsed.error || !parsed.backends) {
+    return NextResponse.json({ error: parsed.error ?? 'invalid payload' }, { status: 400 });
+  }
+  if (Object.keys(parsed.backends).length === 0) {
+    return NextResponse.json({ error: 'at least one address is required' }, { status: 400 });
+  }
+
+  const session = getSessionFromRequest(request);
+  if (session && session.level >= 3) {
+    // L1 admin (post-login): repeatable create/overwrite.
+    const result = await updateConfig(parsed.backends);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+    return NextResponse.json({ ok: true, mode: 'l1-update' });
+  }
+
+  // Pre-login one-shot: token-gated, only while no config exists.
+  const token = typeof body?.token === 'string' ? body.token : undefined;
+  if (!token) {
+    return NextResponse.json({ error: 'token-required' }, { status: 403 });
+  }
+  const expected = await getSetupToken();
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+  const valid = a.length === b.length && crypto.timingSafeEqual(a, b);
+  if (!valid) {
+    return NextResponse.json({ error: 'invalid-token' }, { status: 403 });
+  }
+  if (await configExists()) {
+    return NextResponse.json({ error: 'already-configured' }, { status: 403 });
+  }
+  const result = await saveConfigOneShot(parsed.backends);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+  // The user just proved these addresses — seed the failover working cache.
+  for (const [name, addrs] of Object.entries(parsed.backends)) {
+    const first = addrs?.internal || addrs?.external;
+    if (first) markWorking(name as BackendName, first);
+  }
+  return NextResponse.json({ ok: true, mode: 'first-launch' });
+}

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -54,6 +54,7 @@ import {
   effectiveUrl,
   getSetupToken,
   isHttpUrl,
+  isSetupTokenEnforced,
   isSharedMode,
   probeBackend,
   readConfigSync,
@@ -140,6 +141,9 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     configured,
+    // F1f3: lets the setup page hide the token field when the installer
+    // disabled the pre-login gate (DASHBOARD_SETUP_TOKEN_ENFORCE=0).
+    setupTokenRequired: isSetupTokenEnforced(),
     backends: perBackend,
     embedded: { defaults: EMBEDDED_DEFAULTS, healthy },
     ...authedConfig,
@@ -187,14 +191,18 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true, mode: 'update', effective, switched });
   }
 
-  // Pre-login: token-gated, repeatable (F1e). First launch creates the
-  // config; afterwards the same token overwrites it (broken/changed
-  // environment escape hatch — see header). No session, no other path.
-  if (!token) {
-    return NextResponse.json({ error: 'token-required' }, { status: 403 });
-  }
-  if (!(await verifySetupToken(token))) {
-    return NextResponse.json({ error: 'invalid-token' }, { status: 403 });
+  // Pre-login: token-gated, repeatable (F1e) — unless the installer
+  // disabled the gate with DASHBOARD_SETUP_TOKEN_ENFORCE=0 (F1f3).
+  // First launch creates the config; afterwards the token overwrites it
+  // (broken/changed environment escape hatch — see header). No session,
+  // no other path.
+  if (isSetupTokenEnforced()) {
+    if (!token) {
+      return NextResponse.json({ error: 'token-required' }, { status: 403 });
+    }
+    if (!(await verifySetupToken(token))) {
+      return NextResponse.json({ error: 'invalid-token' }, { status: 403 });
+    }
   }
   const existed = await configExists();
   const result = existed ? await updateConfig(parsed.backends) : await saveConfigOneShot(parsed.backends);

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -6,14 +6,21 @@
 // instead of the login form. The embedded auto-detect probe only runs in the
 // unconfigured case so normal deployments pay zero extra latency.
 //
-// POST (two auth modes):
+// POST (three auth modes):
+//   - post-login L1: session at dashboard level 3 (admin) may create or
+//     overwrite the config at any time, no token needed.
+//   - post-login owner: session at level < 3 presenting the first-launch
+//     setup token (body.token). The standalone instance owner typically
+//     logs in via the Matrix track (level < 3); the one-time setup token
+//     shown at first launch is their owner credential for later edits.
+//     In a multi-user deployment only the owner (who ran first launch)
+//     holds it, so a peer L2 cannot shadow the deployment env config
+//     (config file > env).
 //   - pre-login one-shot: body.token must equal the setup token AND the
 //     config file must not exist yet. This is the only way a logged-out
 //     browser can write backend addresses (first launch on a standalone
 //     docker install). After the file exists, this mode is permanently
 //     rejected — no config re-do from the login screen.
-//   - post-login L1: session at dashboard level 3 (admin) may create or
-//     overwrite the config at any time.
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'node:crypto';
 import { getSessionFromRequest } from '@/lib/dashboard-session';
@@ -92,19 +99,19 @@ export async function GET(request: NextRequest) {
     healthy = Object.fromEntries(probed);
   }
 
-  // The structured file config (internal/external per backend) is only
-  // exposed to a level-3 (L1 admin) session — it feeds the settings dialog
-  // backend tab. Pre-login callers (the first-launch page) get candidates
+  // The structured file config (internal/external per backend) is exposed
+  // to any AUTHENTICATED session — the settings backend tab is visible to
+  // L1 and L2 alike (L2 = standalone instance owner who logged in via the
+  // Matrix track). Pre-login callers (the first-launch page) get candidates
   // and embedded defaults only.
   const session = getSessionFromRequest(request);
-  const l1Config =
-    session && session.level >= 3 ? { config: config?.backends ?? {} } : {};
+  const authedConfig = session ? { config: config?.backends ?? {} } : {};
 
   return NextResponse.json({
     configured,
     backends: perBackend,
     embedded: { defaults: EMBEDDED_DEFAULTS, healthy },
-    ...l1Config,
+    ...authedConfig,
   });
 }
 
@@ -123,6 +130,8 @@ export async function POST(request: NextRequest) {
   }
 
   const session = getSessionFromRequest(request);
+  const token = typeof body?.token === 'string' ? body.token : undefined;
+
   if (session && session.level >= 3) {
     // L1 admin (post-login): repeatable create/overwrite.
     const result = await updateConfig(parsed.backends);
@@ -132,16 +141,31 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true, mode: 'l1-update' });
   }
 
+  if (session && session.level < 3) {
+    // Post-login owner path: the standalone instance owner who logged in
+    // via the Matrix track (level < 3) edits the config with the
+    // first-launch setup token (their owner credential). A peer L2 in a
+    // multi-user deployment does not hold it → cannot shadow env.
+    if (!(token && (await verifySetupToken(token)))) {
+      return NextResponse.json(
+        { error: token ? 'invalid-token' : 'token-required' },
+        { status: 403 },
+      );
+    }
+    const result = await updateConfig(parsed.backends);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+    // The owner just proved these addresses — seed the failover cache.
+    seedWorkingCache(parsed.backends);
+    return NextResponse.json({ ok: true, mode: 'owner-update' });
+  }
+
   // Pre-login one-shot: token-gated, only while no config exists.
-  const token = typeof body?.token === 'string' ? body.token : undefined;
   if (!token) {
     return NextResponse.json({ error: 'token-required' }, { status: 403 });
   }
-  const expected = await getSetupToken();
-  const a = Buffer.from(token);
-  const b = Buffer.from(expected);
-  const valid = a.length === b.length && crypto.timingSafeEqual(a, b);
-  if (!valid) {
+  if (!(await verifySetupToken(token))) {
     return NextResponse.json({ error: 'invalid-token' }, { status: 403 });
   }
   if (await configExists()) {
@@ -152,9 +176,20 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
   // The user just proved these addresses — seed the failover working cache.
-  for (const [name, addrs] of Object.entries(parsed.backends)) {
+  seedWorkingCache(parsed.backends);
+  return NextResponse.json({ ok: true, mode: 'first-launch' });
+}
+
+async function verifySetupToken(token: string): Promise<boolean> {
+  const expected = await getSetupToken();
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+function seedWorkingCache(backends: Partial<Record<BackendName, BackendAddrs>>): void {
+  for (const [name, addrs] of Object.entries(backends)) {
     const first = addrs?.internal || addrs?.external;
     if (first) markWorking(name as BackendName, first);
   }
-  return NextResponse.json({ ok: true, mode: 'first-launch' });
 }

--- a/src/app/api/agentteams/setup/backends/route.ts
+++ b/src/app/api/agentteams/setup/backends/route.ts
@@ -6,12 +6,24 @@
 // instead of the login form. The embedded auto-detect probe only runs in the
 // unconfigured case so normal deployments pay zero extra latency.
 //
-// POST (two auth modes — plugin parity, F1c):
-//   - post-login (L1 or L2, any level): any logged-in user may create or
-//     overwrite the config. The deployment model is one instance per user
-//     (own docker, remote AgentTeams), so the instance's users ARE the
-//     plugin's "user of this host" — the plugin's config page is equally
-//     open to whoever is logged into the host, with no extra credential.
+// POST (auth modes — F1c + F1f shared-mode hardening):
+//   - post-login, standalone (default, one instance per user): any logged-in
+//     user (L1 or L2) may create or update the config — plugin parity, the
+//     instance's user IS the plugin's "user of this host".
+//   - post-login, shared (DASHBOARD_SHARED_MODE=1, e.g. Node1 multi-user):
+//     only level-3 (admin) sessions may save (A). An L2 overwriting the
+//     backend config on a shared instance would redirect EVERY user's data
+//     plane (config file > env, global) — that is attack surface ①.
+//     Every save is audited with actor + level + changed fields (C).
+//   - pre-login (token-gated, repeatable — F1e): body.token must equal the
+//     setup token. First launch creates the config; afterwards the same
+//     token remains the ONLY owner gate for re-configuring from a
+//     logged-out browser — the escape hatch for broken/changed
+//     environments (wrong addresses, network move), reachable from the
+//     login screen via ?setup=1. Plugin parity (config-first): the config
+//     surface stays reachable before login and login is downstream of it.
+//     Shared mode (B): the token comes ONLY from DASHBOARD_SETUP_TOKEN env
+//     and is never persisted; with no env token this path is closed.
 //     The SSRF surface of user-supplied addresses stays pinned by
 //     DASHBOARD_ALLOWED_HOSTS; config editing does not touch credentials
 //     (L1 SA token / L2 session tokens stay server-side).
@@ -42,6 +54,7 @@ import {
   effectiveUrl,
   getSetupToken,
   isHttpUrl,
+  isSharedMode,
   probeBackend,
   readConfigSync,
   refreshEffective,
@@ -50,6 +63,7 @@ import {
   type BackendAddrs,
   type BackendName,
 } from '@/lib/backend-config';
+import { appendAuditEvent } from '@/lib/audit-log';
 
 type BackendNameSet = Record<string, BackendName>;
 
@@ -149,13 +163,23 @@ export async function POST(request: NextRequest) {
 
   const session = getSessionFromRequest(request);
   const token = typeof body?.token === 'string' ? body.token : undefined;
+  const before = readConfigSync()?.backends ?? {};
 
   if (session) {
-    // Post-login (L1 or L2, plugin parity): repeatable create/overwrite.
+    // F1f-A: shared (multi-user) deployment — only an admin (level 3)
+    // session may save. Standalone keeps the F1c any-user behavior.
+    if (isSharedMode() && session.level < 3) {
+      return NextResponse.json(
+        { error: 'shared-mode: only admin (L1) may save backend config' },
+        { status: 403 },
+      );
+    }
     const result = await updateConfig(parsed.backends);
     if (!result.ok) {
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
+    // F1f-C: every config write is audited with actor + level + diff.
+    await auditConfigWrite(before, parsed.backends, session.user, session.level, request);
     // Re-probe what was just saved (plugin put_config → refresh_effective):
     // the effective address is latency-elected from real probes, not seeded
     // blindly.
@@ -177,14 +201,71 @@ export async function POST(request: NextRequest) {
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 400 });
   }
+  await auditConfigWrite(before, parsed.backends, 'pre-login', 0, request);
   // Re-probe the saved config so the effective cache is honest from the
   // first request (plugin put_config → refresh_effective).
   const { effective, switched } = await refreshEffective(Object.keys(parsed.backends) as BackendName[]);
   return NextResponse.json({ ok: true, mode: existed ? 'update' : 'first-launch', effective, switched });
 }
 
+/** F1f-C: audit a config write with actor, level and a per-backend diff.
+ * A failed audit must never break the save (log + continue). */
+async function auditConfigWrite(
+  before: Partial<Record<BackendName, BackendAddrs>>,
+  after: Partial<Record<BackendName, BackendAddrs>>,
+  actor: string,
+  level: number,
+  request: NextRequest,
+): Promise<void> {
+  try {
+    const changed = diffBackends(before, after);
+    await appendAuditEvent({
+      actor,
+      actor_level: level,
+      entity_type: 'system',
+      entity_name: 'backend-config',
+      action: 'config.write',
+      details: changed ? `changed: ${changed}` : 'no-op (identical)',
+      severity: 'warning',
+      source_ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim(),
+    });
+  } catch (err) {
+    console.warn('[dashboard] backend-config audit write failed:', err);
+  }
+}
+
+/** Per-backend merge diff: sent backends replace, unsent are preserved
+ * (F1f-E merge semantics), so the diff lists exactly what changed. */
+function diffBackends(
+  before: Partial<Record<BackendName, BackendAddrs>>,
+  after: Partial<Record<BackendName, BackendAddrs>>,
+): string {
+  const names = new Set<string>([...Object.keys(before), ...Object.keys(after)]);
+  const changed: string[] = [];
+  for (const name of [...names].sort()) {
+    const b = before[name as BackendName];
+    const a = after[name as BackendName];
+    if (!a) continue; // merge keeps unsent backends — nothing to report
+    if (!b) {
+      changed.push(`${name}+(${Object.keys(a).join(',')})`);
+      continue;
+    }
+    const slots: string[] = [];
+    for (const slot of ['internal', 'external'] as const) {
+      if (b[slot] !== a[slot]) {
+        slots.push(`${slot}:${b[slot] ? 'set' : 'unset'}→${a[slot] ? 'set' : 'unset'}`);
+      }
+    }
+    if (slots.length > 0) changed.push(`${name}(${slots.join(' ')})`);
+  }
+  return changed.join('; ');
+}
+
 async function verifySetupToken(token: string): Promise<boolean> {
   const expected = await getSetupToken();
+  // B: shared mode without a DASHBOARD_SETUP_TOKEN env — the pre-login
+  // write path is closed (fails closed, no timing comparison on empty).
+  if (!expected) return false;
   const a = Buffer.from(token);
   const b = Buffer.from(expected);
   return a.length === b.length && crypto.timingSafeEqual(a, b);

--- a/src/app/api/agentteams/setup/backends/test/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/test/route.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { NextRequest } from 'next/server';
+import { BACKEND_NAMES, effectiveUrl, forgetWorking } from '@/lib/backend-config';
+import { POST } from './route';
+
+let workDir: string;
+let server: Server;
+let goodUrl: string;
+
+const configFile = () => path.join(workDir, 'config.json');
+
+beforeAll(async () => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backends-test-'));
+  server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const a = server.address();
+  if (!a || typeof a === 'string') throw new Error('no server');
+  goodUrl = `http://127.0.0.1:${a.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv('DASHBOARD_CONFIG_FILE', configFile());
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', '');
+  vi.stubEnv('AGENTTEAMS_SGLANG_URL', '');
+  for (const name of BACKEND_NAMES) forgetWorking(name);
+});
+
+afterEach(() => {
+  if (fs.existsSync(configFile())) fs.rmSync(configFile());
+  vi.unstubAllEnvs();
+});
+
+function post(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/agentteams/setup/backends/test', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+interface TestResponse {
+  ok: boolean;
+  results: Record<string, Array<{ url: string; ok: boolean; httpOk: boolean; ms: number | null; detail: string }>>;
+  effective: Record<string, string>;
+  applied: boolean;
+  switched: Record<string, boolean>;
+}
+
+describe('POST /api/agentteams/setup/backends/test (F1c plugin config_test semantics)', () => {
+  it('a draft test returns rows but NEVER touches the effective cache (applied=false)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://127.0.0.1:1' } } }),
+    );
+    const res = await POST(post({ backends: { controller: { internal: goodUrl } } }));
+    const data = (await res.json()) as TestResponse;
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(data.results.controller[0].httpOk).toBe(true);
+    expect(data.applied).toBe(false);
+    expect(data.effective.controller).toBeUndefined();
+    expect(effectiveUrl('controller')).toBeNull();
+  });
+
+  it('testing the saved list applies the election (draft == saved)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({
+        version: 1,
+        backends: { controller: { internal: 'http://127.0.0.1:1', external: goodUrl } },
+      }),
+    );
+    const res = await POST(
+      post({ backends: { controller: { internal: 'http://127.0.0.1:1', external: goodUrl } } }),
+    );
+    const data = (await res.json()) as TestResponse;
+    expect(data.applied).toBe(true);
+    expect(data.effective.controller).toBe(goodUrl);
+    expect(effectiveUrl('controller')).toBe(goodUrl);
+  });
+
+  it('a failed test never clears the existing effective address', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: goodUrl } } }),
+    );
+    // first: test the saved list → effective cache is elected from a real probe
+    await POST(post({ backends: { controller: { internal: goodUrl } } }));
+    expect(effectiveUrl('controller')).toBe(goodUrl);
+
+    // now test a draft pointing at a dead address — applied=false, cache untouched
+    const res = await POST(post({ backends: { controller: { internal: 'http://127.0.0.1:1' } } }));
+    const data = (await res.json()) as TestResponse;
+    expect(data.results.controller[0].ok).toBe(false);
+    expect(effectiveUrl('controller')).toBe(goodUrl);
+  });
+
+  it('no body → tests the currently configured candidates', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { sglang: { internal: goodUrl } } }),
+    );
+    const res = await POST(post({}));
+    const data = (await res.json()) as TestResponse;
+    expect(res.status).toBe(200);
+    expect(data.results.sglang).toHaveLength(1);
+    expect(data.results.sglang[0].url).toBe(goodUrl);
+  });
+
+  it('rejects disallowed hosts (SSRF filter) with 403', async () => {
+    vi.stubEnv('DASHBOARD_ALLOWED_HOSTS', 'allowed.example.com');
+    const res = await POST(post({ backends: { controller: { internal: 'http://evil.example.com:8090' } } }));
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe('host-not-allowed');
+  });
+
+  it('rejects an invalid body with 400', async () => {
+    const res = await POST(
+      new NextRequest('http://localhost/api/agentteams/setup/backends/test', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{"backends":"nope"}',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/agentteams/setup/backends/test/route.test.ts
+++ b/src/app/api/agentteams/setup/backends/test/route.test.ts
@@ -17,6 +17,7 @@ const configFile = () => path.join(workDir, 'config.json');
 beforeAll(async () => {
   workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backends-test-'));
   server = createServer((_req, res) => {
+    serverHits += 1;
     res.writeHead(200, { 'content-type': 'application/json' });
     res.end('{}');
   });
@@ -31,11 +32,17 @@ afterAll(async () => {
   fs.rmSync(workDir, { recursive: true, force: true });
 });
 
+let serverHits = 0;
+
 beforeEach(() => {
   vi.unstubAllEnvs();
   vi.stubEnv('DASHBOARD_CONFIG_FILE', configFile());
+  // PR-91 review (Block 2): the probe is token-gated pre-login — these
+  // tests exercise the probe semantics, so a valid env token is available.
+  vi.stubEnv('DASHBOARD_SETUP_TOKEN', 'test-token-123');
   vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', '');
   vi.stubEnv('AGENTTEAMS_SGLANG_URL', '');
+  serverHits = 0;
   for (const name of BACKEND_NAMES) forgetWorking(name);
 });
 
@@ -45,6 +52,18 @@ afterEach(() => {
 });
 
 function post(body: unknown): NextRequest {
+  const payload =
+    body && typeof body === 'object' && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+  // PR-91 review: carry the setup token — the pre-login door to the probe.
+  return new NextRequest('http://localhost/api/agentteams/setup/backends/test', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token: 'test-token-123', ...payload }),
+  });
+}
+
+/** Raw request WITHOUT the token — for the gate tests themselves. */
+function postRaw(body: unknown): NextRequest {
   return new NextRequest('http://localhost/api/agentteams/setup/backends/test', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -137,5 +156,76 @@ describe('POST /api/agentteams/setup/backends/test (F1c plugin config_test seman
       }),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe('PR-91 review (Block 2): the probe is no longer unauthenticated', () => {
+  it('pre-login probe without a token → 403 token-required, nothing probed', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: goodUrl } } }),
+    );
+    const res = await POST(postRaw({ backends: { controller: { internal: goodUrl } } }));
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe('token-required');
+    expect(serverHits).toBe(0); // gate fires before any network I/O
+  });
+
+  it('pre-login probe with a wrong token → 403 invalid-token, nothing probed', async () => {
+    const res = await POST(
+      postRaw({ token: 'wrong-token', backends: { controller: { internal: goodUrl } } }),
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe('invalid-token');
+    expect(serverHits).toBe(0);
+  });
+
+  it('pre-login probe with the setup token works (same door as the config write)', async () => {
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: goodUrl } } }),
+    );
+    const res = await POST(
+      postRaw({ token: 'test-token-123', backends: { controller: { internal: goodUrl } } }),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+    expect(serverHits).toBeGreaterThan(0);
+  });
+
+  it('ENFORCE=0: pre-login probe without a token works (installer opt-out, trusted-LAN)', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN_ENFORCE', '0');
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: goodUrl } } }),
+    );
+    const res = await POST(postRaw({ backends: { controller: { internal: goodUrl } } }));
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+  });
+});
+
+describe('isTestTargetAllowed SSRF filter (PR-91 review)', () => {
+  it('denies the cloud metadata sentinel in all modes', async () => {
+    const { isTestTargetAllowed } = await import('@/lib/backend-config');
+    vi.unstubAllEnvs();
+    expect(isTestTargetAllowed('http://169.254.169.254/latest/meta-data/')).toBe(false);
+    vi.stubEnv('DASHBOARD_ALLOWED_HOSTS', '169.254.169.254');
+    expect(isTestTargetAllowed('http://169.254.169.254/latest/meta-data/')).toBe(false);
+  });
+
+  it('empty allowlist = allow for the (now gated) caller; loopback fine', async () => {
+    const { isTestTargetAllowed } = await import('@/lib/backend-config');
+    vi.unstubAllEnvs();
+    expect(isTestTargetAllowed('http://127.0.0.1:8090')).toBe(true);
+    expect(isTestTargetAllowed('http://192.168.54.107:8090')).toBe(true);
+  });
+
+  it('a set allowlist stays strict', async () => {
+    const { isTestTargetAllowed } = await import('@/lib/backend-config');
+    vi.unstubAllEnvs();
+    vi.stubEnv('DASHBOARD_ALLOWED_HOSTS', 'allowed.example.com');
+    expect(isTestTargetAllowed('http://allowed.example.com:8090')).toBe(true);
+    expect(isTestTargetAllowed('http://evil.example.com:8090')).toBe(false);
   });
 });

--- a/src/app/api/agentteams/setup/backends/test/route.ts
+++ b/src/app/api/agentteams/setup/backends/test/route.ts
@@ -1,0 +1,53 @@
+// POST /api/agentteams/setup/backends/test — server-side probe of a
+// user-supplied backend URL from the setup UI ("test connection" button).
+//
+// Public (pre-login) by design: this is the first-launch self-configuration
+// flow. SSRF filter = DASHBOARD_ALLOWED_HOSTS (comma-separated hosts; empty
+// = allow, which is fine for a local self-config tool — set it to pin
+// targets in hardened deployments).
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  BACKEND_NAMES,
+  forgetWorking,
+  isHttpUrl,
+  isTestTargetAllowed,
+  markWorking,
+  probeBackend,
+  type BackendName,
+} from '@/lib/backend-config';
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => null)) as {
+    backend?: unknown;
+    url?: unknown;
+  } | null;
+
+  const backend = body?.backend;
+  const url = body?.url;
+  if (
+    typeof backend !== 'string' ||
+    !BACKEND_NAMES.includes(backend as BackendName) ||
+    typeof url !== 'string' ||
+    !isHttpUrl(url)
+  ) {
+    return NextResponse.json({ error: 'invalid-request' }, { status: 400 });
+  }
+  const name = backend as BackendName;
+  const target = url.trim();
+
+  if (!isTestTargetAllowed(target)) {
+    return NextResponse.json({ error: 'host-not-allowed' }, { status: 403 });
+  }
+
+  const result = await probeBackend(name, target);
+  // A successful explicit test records the address as working (user intent);
+  // a failed test does NOT clear an existing working entry — the user may
+  // have been testing an alternative that is down while the current one is
+  // fine.
+  if (result.ok) {
+    markWorking(name, target);
+  } else if (result.error === 'timeout' || result.error === 'fetch failed') {
+    forgetWorking(name);
+  }
+  return NextResponse.json(result);
+}

--- a/src/app/api/agentteams/setup/backends/test/route.ts
+++ b/src/app/api/agentteams/setup/backends/test/route.ts
@@ -1,53 +1,112 @@
-// POST /api/agentteams/setup/backends/test — server-side probe of a
-// user-supplied backend URL from the setup UI ("test connection" button).
-//
-// Public (pre-login) by design: this is the first-launch self-configuration
-// flow. SSRF filter = DASHBOARD_ALLOWED_HOSTS (comma-separated hosts; empty
-// = allow, which is fine for a local self-config tool — set it to pin
-// targets in hardened deployments).
 import { NextRequest, NextResponse } from 'next/server';
 import {
   BACKEND_NAMES,
-  forgetWorking,
+  backendCandidatesSync,
+  effectiveUrl,
   isHttpUrl,
   isTestTargetAllowed,
-  markWorking,
+  listMatchesSaved,
   probeBackend,
+  selectAndMark,
+  toProbeRow,
   type BackendName,
+  type ProbeRow,
 } from '@/lib/backend-config';
 
+// POST /api/agentteams/setup/backends/test — server-side connectivity test.
+//
+// Plugin /config_test semantics (F1c parity):
+// - body { backends: { [name]: { internal?, external? } } } = test the DRAFT
+//   (unsaved form values) for the given backends; omit/empty = test the
+//   currently configured candidate list.
+// - A draft test NEVER touches the effective cache; only when the tested
+//   list equals the SAVED config list (applied) does selectAndMark re-elect.
+// - A failed test NEVER clears the current effective address.
+// - Rows carry the two-layer model: ok = network connected (401/403 count),
+//   httpOk = status < 400 (only these are election-eligible).
+//
+// Public (pre-login) by design — the first-launch setup page tests before
+// any session exists. SSRF surface pinned by DASHBOARD_ALLOWED_HOSTS.
+
+type DraftAddrs = { internal?: string; external?: string };
+
+function parseDrafts(body: unknown): Partial<Record<BackendName, DraftAddrs>> | null {
+  if (body == null) return {};
+  if (typeof body !== 'object') return null;
+  const raw = (body as { backends?: unknown }).backends;
+  if (raw == null) return {};
+  if (typeof raw !== 'object') return null;
+  const out: Partial<Record<BackendName, DraftAddrs>> = {};
+  for (const name of BACKEND_NAMES) {
+    const entry = (raw as Record<string, unknown>)[name];
+    if (!entry || typeof entry !== 'object') continue;
+    const addrs: DraftAddrs = {};
+    if (isHttpUrl((entry as DraftAddrs).internal)) addrs.internal = (entry as DraftAddrs).internal!.trim();
+    if (isHttpUrl((entry as DraftAddrs).external)) addrs.external = (entry as DraftAddrs).external!.trim();
+    if (addrs.internal || addrs.external) out[name] = addrs;
+  }
+  return out;
+}
+
 export async function POST(request: NextRequest) {
-  const body = (await request.json().catch(() => null)) as {
-    backend?: unknown;
-    url?: unknown;
-  } | null;
-
-  const backend = body?.backend;
-  const url = body?.url;
-  if (
-    typeof backend !== 'string' ||
-    !BACKEND_NAMES.includes(backend as BackendName) ||
-    typeof url !== 'string' ||
-    !isHttpUrl(url)
-  ) {
-    return NextResponse.json({ error: 'invalid-request' }, { status: 400 });
-  }
-  const name = backend as BackendName;
-  const target = url.trim();
-
-  if (!isTestTargetAllowed(target)) {
-    return NextResponse.json({ error: 'host-not-allowed' }, { status: 403 });
+  const body = (await request.json().catch(() => null)) as unknown;
+  const drafts = parseDrafts(body);
+  if (drafts === null) {
+    return NextResponse.json({ ok: false, error: 'invalid-request' }, { status: 400 });
   }
 
-  const result = await probeBackend(name, target);
-  // A successful explicit test records the address as working (user intent);
-  // a failed test does NOT clear an existing working entry — the user may
-  // have been testing an alternative that is down while the current one is
-  // fine.
-  if (result.ok) {
-    markWorking(name, target);
-  } else if (result.error === 'timeout' || result.error === 'fetch failed') {
-    forgetWorking(name);
+  // Targets: draft values where provided, otherwise the configured list.
+  const targets: Partial<Record<BackendName, string[]>> = {};
+  for (const name of BACKEND_NAMES) {
+    const draft = drafts[name];
+    const fromDraft = draft ? [draft.internal, draft.external].filter((v): v is string => !!v) : [];
+    const urls = fromDraft.length > 0 ? fromDraft : backendCandidatesSync(name);
+    if (urls.length > 0) targets[name] = urls;
   }
-  return NextResponse.json(result);
+  if (Object.keys(targets).length === 0) {
+    return NextResponse.json(
+      { ok: false, error: 'nothing-to-test', message: 'no addresses provided or configured' },
+      { status: 400 },
+    );
+  }
+
+  // SSRF filter: reject the whole request if any target is disallowed.
+  for (const name of Object.keys(targets) as BackendName[]) {
+    for (const url of targets[name]!) {
+      if (!isTestTargetAllowed(url)) {
+        return NextResponse.json({ ok: false, error: 'host-not-allowed', url }, { status: 403 });
+      }
+    }
+  }
+
+  const results: Partial<Record<BackendName, ProbeRow[]>> = {};
+  const switched: Partial<Record<BackendName, boolean>> = {};
+  let applied = false;
+
+  await Promise.all(
+    (Object.keys(targets) as BackendName[]).map(async (name) => {
+      const urls = targets[name]!;
+      const probeResults = await Promise.all(urls.map((url) => probeBackend(name, url, 6000)));
+      const rows = urls.map((url, i) => toProbeRow(url, probeResults[i]));
+      results[name] = rows;
+
+      // Effective-cache update is APPLIED-ONLY (plugin config_test): a draft
+      // test must never rewrite the working address; a failed probe never
+      // clears it (selectAndMark returns null when nobody is eligible).
+      if (listMatchesSaved(name, urls)) {
+        const prev = effectiveUrl(name);
+        const picked = selectAndMark(name, rows);
+        applied = true;
+        if (picked && prev && prev !== picked) switched[name] = true;
+      }
+    }),
+  );
+
+  const effective: Partial<Record<BackendName, string>> = {};
+  for (const name of Object.keys(targets) as BackendName[]) {
+    const url = effectiveUrl(name);
+    if (url) effective[name] = url;
+  }
+
+  return NextResponse.json({ ok: true, results, effective, applied, switched });
 }

--- a/src/app/api/agentteams/setup/backends/test/route.ts
+++ b/src/app/api/agentteams/setup/backends/test/route.ts
@@ -4,14 +4,17 @@ import {
   backendCandidatesSync,
   effectiveUrl,
   isHttpUrl,
+  isSetupTokenEnforced,
   isTestTargetAllowed,
   listMatchesSaved,
   probeBackend,
   selectAndMark,
   toProbeRow,
+  verifySetupToken,
   type BackendName,
   type ProbeRow,
 } from '@/lib/backend-config';
+import { getSessionFromRequest } from '@/lib/dashboard-session';
 
 // POST /api/agentteams/setup/backends/test — server-side connectivity test.
 //
@@ -25,8 +28,17 @@ import {
 // - Rows carry the two-layer model: ok = network connected (401/403 count),
 //   httpOk = status < 400 (only these are election-eligible).
 //
-// Public (pre-login) by design — the first-launch setup page tests before
-// any session exists. SSRF surface pinned by DASHBOARD_ALLOWED_HOSTS.
+// Access (PR-91 review, Block 2): the probe is NO LONGER an unauthenticated
+// fetch proxy — same door as POST /setup/backends:
+//   - any authenticated session (post-login settings tab, L1 and L2),
+//   - pre-login: the setup token in the body (token-gated, repeatable,
+//     exactly like the pre-login write); with
+//     DASHBOARD_SETUP_TOKEN_ENFORCE=0 (installer opt-out, trusted-LAN) the
+//     gate is off — the same documented posture as the unauthenticated
+//     config writes that opt-out already accepts (startup warn).
+// SSRF hardening: DASHBOARD_ALLOWED_HOSTS (empty = allow for the
+// session/token holders above, strict allowlist when set) plus an
+// unconditional deny of the cloud metadata sentinel (169.254.169.254).
 
 type DraftAddrs = { internal?: string; external?: string };
 
@@ -49,10 +61,27 @@ function parseDrafts(body: unknown): Partial<Record<BackendName, DraftAddrs>> | 
 }
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json().catch(() => null)) as unknown;
-  const drafts = parseDrafts(body);
+  const raw = (await request.json().catch(() => null)) as unknown;
+  const body = (raw ?? {}) as { token?: unknown; backends?: unknown };
+  const drafts = parseDrafts(raw);
   if (drafts === null) {
     return NextResponse.json({ ok: false, error: 'invalid-request' }, { status: 400 });
+  }
+
+  // PR-91 review: same door as POST /setup/backends — a pre-login caller
+  // must hold the setup token (when the gate is enforced). No session, no
+  // probe: the endpoint used to be an unauthenticated fetch proxy.
+  const session = getSessionFromRequest(request);
+  if (!session) {
+    if (isSetupTokenEnforced()) {
+      const token = typeof body.token === 'string' ? body.token : undefined;
+      if (!token) {
+        return NextResponse.json({ ok: false, error: 'token-required' }, { status: 403 });
+      }
+      if (!(await verifySetupToken(token))) {
+        return NextResponse.json({ ok: false, error: 'invalid-token' }, { status: 403 });
+      }
+    }
   }
 
   // Targets: draft values where provided, otherwise the configured list.

--- a/src/app/api/agentteams/storage/download/route.ts
+++ b/src/app/api/agentteams/storage/download/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { createMinioClient } from '@/lib/minio-client';
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/agentteams/storage/upload/route.ts
+++ b/src/app/api/agentteams/storage/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { createMinioClient } from '@/lib/minio-client';
 import { enforceLevelOnlyRbac } from '@/lib/server-auth';
 

--- a/src/app/api/agentteams/teams/[name]/files/download/route.ts
+++ b/src/app/api/agentteams/teams/[name]/files/download/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import type { Client } from 'minio';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
 import { isValidNameSegment } from '@/lib/skill-package';

--- a/src/app/api/agentteams/workers/[name]/files/download/route.ts
+++ b/src/app/api/agentteams/workers/[name]/files/download/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import type { Client } from 'minio';
 import { createMinioClient, getMinioBucket } from '@/lib/minio-client';
 import { isValidNameSegment } from '@/lib/skill-package';

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -58,6 +58,7 @@ function installFetchMock(opts: {
   humans?: Record<string, { status?: number; body?: Record<string, unknown> }>;
   matrixLogin?: { status?: number; body?: Record<string, unknown> };
   teams?: { status?: number; body?: Record<string, unknown> };
+  status?: { status?: number; body?: Record<string, unknown> };
 }) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -66,6 +67,15 @@ function installFetchMock(opts: {
     if (humanMatch) {
       const spec = opts.humans?.[decodeURIComponent(humanMatch[1])] ?? { status: 404 };
       return new Response(spec.status ? null : JSON.stringify(spec.body ?? {}), {
+        status: spec.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/v1/status')) {
+      // Own-matrix-token identity probe — default 401 (token rejected =
+      // not an L2 team user); L2 tests pass `status` explicitly.
+      const spec = opts.status ?? { status: 401 };
+      return new Response(spec.status ? null : JSON.stringify(spec.body ?? { ok: true }), {
         status: spec.status ?? 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -204,11 +214,14 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(data.mode).toBe('matrix');
   });
 
-  // ── SA-less (one-person-per-instance) level-lookup fallback ────────────
-  // The Controller denies L2 matrix tokens on human reads
-  // (authorizeHuman has no "human" case), so without a server-side SA
-  // credential the level lookup needs a Controller admin token pasted at
-  // login. L2-without-token needs the upstream GET /api/v1/me (pending).
+  // ── SA-less (one-person-per-instance) identity resolution ──────────────
+  // The Controller denies matrix tokens on human reads (authorizeHuman
+  // has no "human" case), so without a server-side SA credential:
+  // admin token pasted at login → CR read (L1 self-service), otherwise
+  // the user's OWN matrix token probes /status — a 200 proves L2 (the
+  // controller only accepts level-2 matrix tokens) and /teams returns
+  // the user's own accessibleTeams. Plugin model: own token = default
+  // identity, no admin credential needed.
 
   it('SA-less instance: L1 + valid pasted controller token performs the level lookup', async () => {
     mockGetAuthToken.mockResolvedValue(undefined);
@@ -244,18 +257,37 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(data.error).toBe('Controller 管理员 token 无效');
   });
 
-  it('SA-less instance: L2 without any admin token → generic 401 (upstream /me pending)', async () => {
+  it('SA-less instance: L2 with NO admin token → 200 level 2 via own matrix token (plugin model)', async () => {
     mockGetAuthToken.mockResolvedValue(undefined);
     installFetchMock({
+      status: { body: { ok: true } }, // own matrix token accepted → L2 proven
+      teams: { body: { teams: [{ name: 'biz-team' }], total: 1 } },
       matrixLogin: {
         body: { access_token: 'syt_l2_token', user_id: '@sunzong:sat.example', device_id: 'D1' },
       },
     });
 
     const response = await POST(request({ username: 'sunzong', password: 'matrix-password' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.success).toBe(true);
+    expect(data.user).toEqual({ username: 'sunzong', level: 2 });
+    expect(data.mode).toBe('matrix');
+  });
+
+  it('SA-less instance: controller rejects the matrix token (L1/L3) + no admin token → specific 401', async () => {
+    mockGetAuthToken.mockResolvedValue(undefined);
+    installFetchMock({
+      // no `status` key → probe defaults to 401 (token rejected)
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'luo', password: 'matrix-password' }));
     expect(response.status).toBe(401);
     const data = await responseJson(response);
-    expect(data.error).toBe('Invalid username or password');
+    expect(data.error).toBe('无法确认该账号的权限级别：请展开「管理员账号验证」提供 Controller 管理员 token，或联系部署管理员检查 Human CR');
   });
 
   it('SA-less instance: L2 + valid pasted controller token → level 2 (admin bootstrap)', async () => {

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST } from './route';
-import { callHigressConsole, forwardCookies } from '../../higress/proxy-helper';
+import { callHigressConsole, forwardCookies, getHigressConsoleURL } from '../../higress/proxy-helper';
 import { getAuthToken, getControllerUrl } from '../../agentteams/proxy-helper';
 import { __resetSessionStoreForTests, SESSION_COOKIE_NAME } from '@/lib/dashboard-session';
 
@@ -28,6 +28,7 @@ const mockCallHigressConsole = vi.mocked(callHigressConsole);
 const mockForwardCookies = vi.mocked(forwardCookies);
 const mockGetAuthToken = vi.mocked(getAuthToken);
 const mockGetControllerUrl = vi.mocked(getControllerUrl);
+const mockGetHigressConsoleURL = vi.mocked(getHigressConsoleURL);
 
 const SECRET = 'c'.repeat(64);
 
@@ -92,6 +93,8 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     vi.stubEnv('AGENTTEAMS_HIGRESS_ADAPTER_MODE', 'direct');
     vi.stubEnv('DASHBOARD_COOKIE_SECURE', '');
     mockCallHigressConsole.mockReset();
+    mockGetHigressConsoleURL.mockReset();
+    mockGetHigressConsoleURL.mockReturnValue('http://higress-console:8080');
     mockForwardCookies.mockReset();
     mockGetAuthToken.mockReset();
     mockGetAuthToken.mockResolvedValue('sa-token');
@@ -166,6 +169,29 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(cookies.some((c) => c.startsWith('_hi_sess='))).toBe(false);
     // The Matrix token must never appear in a cookie value.
     expect(cookies.every((c) => !c.includes('syt_l2_token'))).toBe(true);
+  });
+
+  it('Console deployment config error (host not allowed) → falls through to the Matrix track instead of 502 (one-person-per-instance LAN deployment)', async () => {
+    const cfgError = new Error(
+      'Higress Console deployment configuration error: Console host "192.168.54.107" is not allowed',
+    );
+    cfgError.name = 'HigressConsoleConfigurationError';
+    mockGetHigressConsoleURL.mockImplementation(() => {
+      throw cfgError;
+    });
+    installFetchMock({
+      humans: { sunzong: { body: { name: 'sunzong', permissionLevel: 2, accessibleTeams: ['biz-team'] } } },
+      matrixLogin: {
+        body: { access_token: 'syt_l2_token', user_id: '@sunzong:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'sunzong', password: 'matrix-password' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.success).toBe(true);
+    expect(data.user).toEqual({ username: 'sunzong', level: 2 });
+    expect(data.mode).toBe('matrix');
   });
 
   it('Matrix: CR level 1 + valid admin account credentials → level-3 session, SA data credential, matrix chat token kept', async () => {

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -80,7 +80,7 @@ function installFetchMock(opts: {
         headers: { 'content-type': 'application/json' },
       });
     }
-    if (url.includes('/api/v1/teams/')) {
+    if (url.includes('/api/v1/teams')) {
       // verifyControllerToken endpoint — default 401 (invalid token);
       // tests asserting a VALID pasted token pass `teams` explicitly.
       const spec = opts.teams ?? { status: 401 };

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -57,6 +57,7 @@ function failedConsoleLogin() {
 function installFetchMock(opts: {
   humans?: Record<string, { status?: number; body?: Record<string, unknown> }>;
   matrixLogin?: { status?: number; body?: Record<string, unknown> };
+  teams?: { status?: number; body?: Record<string, unknown> };
 }) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -65,6 +66,15 @@ function installFetchMock(opts: {
     if (humanMatch) {
       const spec = opts.humans?.[decodeURIComponent(humanMatch[1])] ?? { status: 404 };
       return new Response(spec.status ? null : JSON.stringify(spec.body ?? {}), {
+        status: spec.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/v1/teams/')) {
+      // verifyControllerToken endpoint — default 401 (invalid token);
+      // tests asserting a VALID pasted token pass `teams` explicitly.
+      const spec = opts.teams ?? { status: 401 };
+      return new Response(spec.status ? null : JSON.stringify(spec.body ?? { items: [] }), {
         status: spec.status ?? 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -192,6 +202,76 @@ describe('POST /api/auth/login (dual track, M19)', () => {
     expect(data.success).toBe(true);
     expect(data.user).toEqual({ username: 'sunzong', level: 2 });
     expect(data.mode).toBe('matrix');
+  });
+
+  // ── SA-less (one-person-per-instance) level-lookup fallback ────────────
+  // The Controller denies L2 matrix tokens on human reads
+  // (authorizeHuman has no "human" case), so without a server-side SA
+  // credential the level lookup needs a Controller admin token pasted at
+  // login. L2-without-token needs the upstream GET /api/v1/me (pending).
+
+  it('SA-less instance: L1 + valid pasted controller token performs the level lookup', async () => {
+    mockGetAuthToken.mockResolvedValue(undefined);
+    installFetchMock({
+      humans: { luo: { body: { name: 'luo', permissionLevel: 1, accessibleTeams: [] } } },
+      teams: { body: { items: [] } },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'luo', password: 'matrix-password', controllerToken: 'admin-token-1' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.success).toBe(true);
+    expect(data.user).toEqual({ username: 'luo', level: 3 });
+    expect(data.mode).toBe('matrix');
+  });
+
+  it('SA-less instance: invalid pasted controller token → specific 401, not generic', async () => {
+    mockGetAuthToken.mockResolvedValue(undefined);
+    installFetchMock({
+      humans: { luo: { status: 401 } },
+      teams: { status: 401 },
+      matrixLogin: {
+        body: { access_token: 'syt_l1_token', user_id: '@luo:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'luo', password: 'matrix-password', controllerToken: 'bad-token' }));
+    expect(response.status).toBe(401);
+    const data = await responseJson(response);
+    expect(data.error).toBe('Controller 管理员 token 无效');
+  });
+
+  it('SA-less instance: L2 without any admin token → generic 401 (upstream /me pending)', async () => {
+    mockGetAuthToken.mockResolvedValue(undefined);
+    installFetchMock({
+      matrixLogin: {
+        body: { access_token: 'syt_l2_token', user_id: '@sunzong:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'sunzong', password: 'matrix-password' }));
+    expect(response.status).toBe(401);
+    const data = await responseJson(response);
+    expect(data.error).toBe('Invalid username or password');
+  });
+
+  it('SA-less instance: L2 + valid pasted controller token → level 2 (admin bootstrap)', async () => {
+    mockGetAuthToken.mockResolvedValue(undefined);
+    installFetchMock({
+      humans: { sunzong: { body: { name: 'sunzong', permissionLevel: 2, accessibleTeams: ['biz-team'] } } },
+      teams: { body: { items: [] } },
+      matrixLogin: {
+        body: { access_token: 'syt_l2_token', user_id: '@sunzong:sat.example', device_id: 'D1' },
+      },
+    });
+
+    const response = await POST(request({ username: 'sunzong', password: 'matrix-password', controllerToken: 'admin-token-1' }));
+    expect(response.status).toBe(200);
+    const data = await responseJson(response);
+    expect(data.user).toEqual({ username: 'sunzong', level: 2 });
   });
 
   it('Matrix: CR level 1 + valid admin account credentials → level-3 session, SA data credential, matrix chat token kept', async () => {

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST } from './route';

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -56,6 +56,41 @@ async function fetchHumanViaSa(request: NextRequest, name: string): Promise<Huma
   return fetchHumanWithToken(request, name, token);
 }
 
+/** Identity probe with the user's OWN Matrix token. The Controller's
+ * Matrix auth only accepts permissionLevel=2 tokens, so a 200 on the
+ * status endpoint proves team-user identity WITHOUT reading the Human CR
+ * (the plugin's model: the user's own access token is the default
+ * identity, admin tokens are an optional channel — agentteams_connector/
+ * config.py `controller_token` = "Optional admin token for L1 full view"). */
+async function probeMatrixToken(request: NextRequest, matrixToken: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/status`, {
+      headers: { Authorization: `Bearer ${matrixToken}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Teams visible to the caller's own Matrix token — the Controller
+ * filters the list by accessibleTeams server-side (ListTeams), so this is
+ * the user's own team scope, not an admin read. */
+async function fetchTeamsWithToken(request: NextRequest, matrixToken: string): Promise<string[]> {
+  try {
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams/`, {
+      headers: { Authorization: `Bearer ${matrixToken}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { teams?: { name?: string }[] };
+    return (data.teams ?? []).map((t) => t.name ?? '').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 /** CR lookup with an explicit admin-grade token (SA env or a validated
  * Controller admin token pasted at login — one-person-per-instance
  * deployments may hold no server-side SA credential at all). */
@@ -334,6 +369,29 @@ async function attemptMatrixLogin(
     } else {
       return NextResponse.json(
         { success: false, error: 'Controller 管理员 token 无效' },
+        { status: 401 },
+      );
+    }
+  }
+  if (!human) {
+    // No admin-grade credential available (SA-less one-person-per-instance):
+    // identify with the user's OWN Matrix token instead of an admin read.
+    // A 200 proves team-user (L2) identity — the Controller's Matrix auth
+    // rejects every other level — and the teams list carries the user's
+    // own accessibleTeams (server-side filtered). Plugin-aligned: own
+    // token = default identity, no admin credential needed for L2.
+    if (await probeMatrixToken(request, String(matrix.accessToken))) {
+      human = {
+        name: localpart,
+        permissionLevel: 2,
+        accessibleTeams: await fetchTeamsWithToken(request, String(matrix.accessToken)),
+      };
+    } else {
+      return NextResponse.json(
+        {
+          success: false,
+          error: '无法确认该账号的权限级别：请展开「管理员账号验证」提供 Controller 管理员 token，或联系部署管理员检查 Human CR',
+        },
         { status: 401 },
       );
     }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -79,7 +79,7 @@ async function probeMatrixToken(request: NextRequest, matrixToken: string): Prom
  * the user's own team scope, not an admin read. */
 async function fetchTeamsWithToken(request: NextRequest, matrixToken: string): Promise<string[]> {
   try {
-    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams/`, {
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams`, {
       headers: { Authorization: `Bearer ${matrixToken}` },
       signal: AbortSignal.timeout(5000),
     });
@@ -310,7 +310,7 @@ async function verifyAdminConsoleCredentials(username: string, password: string)
  */
 async function verifyControllerToken(request: NextRequest, token: string): Promise<boolean> {
   try {
-    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams/`, {
+    const res = await fetch(`${getControllerUrl(request)}/api/v1/teams`, {
       headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(5000),
     });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -53,6 +53,13 @@ interface HumanRecord {
 async function fetchHumanViaSa(request: NextRequest, name: string): Promise<HumanRecord | null> {
   const token = await getAuthToken();
   if (!token) return null;
+  return fetchHumanWithToken(request, name, token);
+}
+
+/** CR lookup with an explicit admin-grade token (SA env or a validated
+ * Controller admin token pasted at login — one-person-per-instance
+ * deployments may hold no server-side SA credential at all). */
+async function fetchHumanWithToken(request: NextRequest, name: string, token: string): Promise<HumanRecord | null> {
   try {
     const res = await fetch(`${getControllerUrl(request)}/api/v1/humans/${encodeURIComponent(name)}`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -312,7 +319,25 @@ async function attemptMatrixLogin(
 
   const userId = typeof matrix.userId === 'string' ? matrix.userId : '';
   const localpart = userId.startsWith('@') ? userId.slice(1).split(':')[0] : username;
-  const human = await fetchHumanViaSa(request, localpart);
+  let human = await fetchHumanViaSa(request, localpart);
+  if (!human && controllerToken) {
+    // One-person-per-instance deployment: the server may hold no admin
+    // credential (no AGENTTEAMS_AUTH_TOKEN). The Controller admin token
+    // pasted at login (existing L1 field) can perform the same level
+    // lookup — validated against the Controller before use. The L2-only
+    // matrix token itself is denied on human reads (controller
+    // authorizeHuman has no "human" case), so without an admin-grade
+    // token here the lookup is impossible; the upstream GET /api/v1/me
+    // (self-scope) would close that gap for L2.
+    if (await verifyControllerToken(request, controllerToken)) {
+      human = await fetchHumanWithToken(request, localpart, controllerToken);
+    } else {
+      return NextResponse.json(
+        { success: false, error: 'Controller 管理员 token 无效' },
+        { status: 401 },
+      );
+    }
+  }
   const crLevel = human && typeof human.permissionLevel === 'number' ? human.permissionLevel : -1;
   const dashLevel = MATRIX_CR_LEVEL_TO_DASH_LEVEL[crLevel];
   if (!human || !dashLevel) {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -227,10 +227,18 @@ async function attemptConsoleLogin(
       consoleUrl,
     });
     consoleRes = result.response;
-  } catch {
+  } catch (err) {
+    // F1g: surface the failure in docker logs. A silently-failing Console
+    // track sends admin-password users down the Matrix track into the
+    // confusing "paste a Controller token" error with no trace of WHY the
+    // password path died (Luo-zong 9/9: only the token worked).
+    console.error(
+      `Console track fetch failed (${consoleUrl}): ${err instanceof Error ? err.message : String(err)}`,
+    );
     return { kind: 'failed' };
   }
   if (!consoleRes.ok) {
+    console.error(`Console track rejected: HTTP ${consoleRes.status} for user "${username}" (${consoleUrl})`);
     return { kind: 'failed' };
   }
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -155,7 +155,19 @@ async function attemptConsoleLogin(
   password: string,
   opts: { allowMatrix: boolean },
 ): Promise<ConsoleAttempt> {
-  const consoleUrl = getHigressConsoleURL();
+  let consoleUrl: string;
+  try {
+    consoleUrl = getHigressConsoleURL();
+  } catch (err) {
+    // Console deployment config invalid (e.g. host not on the allowlist in a
+    // one-person-per-instance LAN deployment): the Console track is
+    // unavailable, but the Matrix track does not depend on it — fall through
+    // so one track's misconfiguration never blocks the whole login endpoint.
+    console.error(
+      `Console track unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { kind: 'failed' };
+  }
 
   // NOTE: the upstream auto-initializer (/system/init, "first login auto-
   // registers a Console admin") was intentionally REMOVED. It is a privilege

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,9 @@ export default function Home() {
   const [auth, setAuth] = useState<AuthState>({ status: 'loading' });
   const [setup, setSetup] = useState<SetupState>({ status: 'loading' });
   const [preSetup, setPreSetup] = useState<PreSetupState>({ status: 'loading' });
+  // F1e: the login screen can deep-link here (?setup=1) to re-configure
+  // backends when an existing deployment is broken or moved.
+  const [forceSetup, setForceSetup] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,18 +45,23 @@ export default function Home() {
         if (cancelled) return;
         if (!data.authenticated) {
           setAuth({ status: 'unauthenticated' });
+          // F1e: ?setup=1 forces the pre-login backend setup page from the
+          // login screen (escape hatch — broken/changed environments).
+          const forceSetup = new URLSearchParams(window.location.search).get('setup') === '1';
+          setForceSetup(forceSetup);
           // F1: before offering the login form, check whether the dashboard
           // has any usable backend addresses. Standalone installs without
-          // env config must configure backends FIRST (token-gated one-shot),
+          // env config must configure backends FIRST (token-gated),
           // so unconfigured -> setup page instead of login.
           fetch(apiUrl('/api/agentteams/setup/backends'), { credentials: 'same-origin' })
             .then((res) => res.json().catch(() => null))
             .then((sdata) => {
               if (cancelled) return;
-              setPreSetup({ status: sdata && sdata.configured === false ? 'required' : 'complete' });
+              const required = forceSetup || (sdata && sdata.configured === false);
+              setPreSetup({ status: required ? 'required' : 'complete' });
             })
             .catch(() => {
-              if (!cancelled) setPreSetup({ status: 'complete' });
+              if (!cancelled) setPreSetup({ status: forceSetup ? 'required' : 'complete' });
             });
           return;
         }
@@ -98,7 +106,7 @@ export default function Home() {
     return (
       <ThemeProvider>
         {preSetup.status === 'required' ? (
-          <BackendSetupPage onDone={handleLoginSuccess} />
+          <BackendSetupPage onDone={handleLoginSuccess} reconfigure={forceSetup} />
         ) : (
           <LoginPage onLoginSuccess={handleLoginSuccess} />
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { AgentTeamsDashboard } from '@/components/dashboard/agent-teams-dashboard';
 import { LoginPage } from '@/components/auth/login-page';
+import { BackendSetupPage } from '@/components/setup/backend-setup-page';
 import { SetupWizard } from '@/components/setup/setup-wizard';
 import { QueryProvider } from '@/lib/query-provider';
 import { useAgentTeamsStore } from '@/lib/agentteams-store';
@@ -21,9 +22,14 @@ type SetupState =
   | { status: 'required' }
   | { status: 'complete' };
 
+// F1 pre-login backend setup gate: independent of the (post-login)
+// controller-side setup wizard above.
+type PreSetupState = { status: 'loading' } | { status: 'required' } | { status: 'complete' };
+
 export default function Home() {
   const [auth, setAuth] = useState<AuthState>({ status: 'loading' });
   const [setup, setSetup] = useState<SetupState>({ status: 'loading' });
+  const [preSetup, setPreSetup] = useState<PreSetupState>({ status: 'loading' });
 
   useEffect(() => {
     let cancelled = false;
@@ -36,6 +42,19 @@ export default function Home() {
         if (cancelled) return;
         if (!data.authenticated) {
           setAuth({ status: 'unauthenticated' });
+          // F1: before offering the login form, check whether the dashboard
+          // has any usable backend addresses. Standalone installs without
+          // env config must configure backends FIRST (token-gated one-shot),
+          // so unconfigured -> setup page instead of login.
+          fetch(apiUrl('/api/agentteams/setup/backends'), { credentials: 'same-origin' })
+            .then((res) => res.json().catch(() => null))
+            .then((sdata) => {
+              if (cancelled) return;
+              setPreSetup({ status: sdata && sdata.configured === false ? 'required' : 'complete' });
+            })
+            .catch(() => {
+              if (!cancelled) setPreSetup({ status: 'complete' });
+            });
           return;
         }
         setAuth({ status: 'authenticated', username: data.username });
@@ -75,9 +94,14 @@ export default function Home() {
   }
 
   if (auth.status === 'unauthenticated') {
+    if (preSetup.status === 'loading') return null;
     return (
       <ThemeProvider>
-        <LoginPage onLoginSuccess={handleLoginSuccess} />
+        {preSetup.status === 'required' ? (
+          <BackendSetupPage onDone={handleLoginSuccess} />
+        ) : (
+          <LoginPage onLoginSuccess={handleLoginSuccess} />
+        )}
         <Toaster position="top-right" richColors />
       </ThemeProvider>
     );

--- a/src/components/auth/login-page.tsx
+++ b/src/components/auth/login-page.tsx
@@ -170,6 +170,19 @@ export function LoginPage({ onLoginSuccess, defaultUsername = '' }: LoginPagePro
               </>
             )}
           </Button>
+          {/* F1e (plugin parity: the config surface is always one click away,
+              not a first-launch easter egg) — re-configure backends from a
+              logged-out browser when the environment changed or addresses
+              are wrong. Pre-login writes stay token-gated server-side. */}
+          <div className="pt-1 text-center">
+            <button
+              type="button"
+              onClick={() => window.location.assign('?setup=1')}
+              className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              无法登录？后端配置（地址 / 首启）
+            </button>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/dashboard/sections/overview-section.tsx
+++ b/src/components/dashboard/sections/overview-section.tsx
@@ -690,6 +690,16 @@ export function OverviewSection() {
                     icon={GitBranch}
                     detail={infrastructure.controller?.version}
                   />
+                  {/* SGLang: optional inference backend — only shown once an
+                      address is configured (F1). */}
+                  {infrastructure.sglang && infrastructure.sglang.endpoint !== '' && (
+                    <HealthCard
+                      name="SGLang"
+                      healthy={infrastructure.sglang.healthy}
+                      icon={Bot}
+                      detail={infrastructure.sglang.endpoint}
+                    />
+                  )}
                 </div>
               ) : (
                 <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">

--- a/src/components/dashboard/settings-dialog.tsx
+++ b/src/components/dashboard/settings-dialog.tsx
@@ -147,14 +147,12 @@ export function SettingsDialog() {
         </DialogHeader>
 
         <Tabs defaultValue="connection" className="w-full">
-          <TabsList className={isL1 ? 'grid w-full grid-cols-5' : 'grid w-full grid-cols-4'}>
+          <TabsList className="grid w-full grid-cols-5">
             <TabsTrigger value="connection">连接</TabsTrigger>
-            {isL1 && (
-              <TabsTrigger value="backends">
-                <Server className="w-3.5 h-3.5 mr-1" />
-                后端
-              </TabsTrigger>
-            )}
+            <TabsTrigger value="backends">
+              <Server className="w-3.5 h-3.5 mr-1" />
+              后端
+            </TabsTrigger>
             <TabsTrigger value="theme">
               <Palette className="w-3.5 h-3.5 mr-1" />
               外观
@@ -398,11 +396,9 @@ export function SettingsDialog() {
             </div>
           </TabsContent>
 
-          {isL1 && (
-            <TabsContent value="backends" className="py-4">
-              <BackendTab />
-            </TabsContent>
-          )}
+          <TabsContent value="backends" className="py-4">
+            <BackendTab />
+          </TabsContent>
 
           <TabsContent value="theme" className="py-4">
             <ThemeTab />

--- a/src/components/dashboard/settings-dialog.tsx
+++ b/src/components/dashboard/settings-dialog.tsx
@@ -38,6 +38,7 @@ import {
 import { useInfrastructure } from '@/hooks/use-agentteams-infrastructure';
 import { ThemeTab } from './settings/theme-tab';
 import { PluginsTab } from './settings/plugins-tab';
+import { BackendTab } from './settings/backend-tab';
 
 // Empty default means "use the server-side AGENTTEAMS_CONTROLLER_URL" so the same
 // image works in embedded (localhost) and Kubernetes (in-cluster) modes.
@@ -65,7 +66,14 @@ export function SettingsDialog() {
     setTaskBoardVisible,
     projectsVisible,
     setProjectsVisible,
+    userLevel,
   } = useAgentTeamsStore();
+
+  // F1b: backend address config (settings tab + the per-request controllerUrl
+  // override in the connection test) is an L1 (level 3) capability. Non-admins
+  // always hit the deployment-configured controller — the server enforces the
+  // same rule in proxy-helper.getControllerUrl (the UI gate is cosmetic only).
+  const isL1 = userLevel >= 3;
 
   const { data: infrastructure } = useInfrastructure();
 
@@ -100,7 +108,9 @@ export function SettingsDialog() {
     setTestResult(null);
     const start = performance.now();
     try {
-      const testPath = tempUrl.trim()
+      // Non-admins test the server-configured controller only (their override
+      // would be dropped by the server anyway — see proxy-helper.getControllerUrl).
+      const testPath = isL1 && tempUrl.trim()
         ? `/api/agentteams/healthz/?controllerUrl=${encodeURIComponent(tempUrl)}`
         : '/api/agentteams/healthz/';
       const res = await fetch(apiUrl(testPath));
@@ -137,8 +147,14 @@ export function SettingsDialog() {
         </DialogHeader>
 
         <Tabs defaultValue="connection" className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
+          <TabsList className={isL1 ? 'grid w-full grid-cols-5' : 'grid w-full grid-cols-4'}>
             <TabsTrigger value="connection">连接</TabsTrigger>
+            {isL1 && (
+              <TabsTrigger value="backends">
+                <Server className="w-3.5 h-3.5 mr-1" />
+                后端
+              </TabsTrigger>
+            )}
             <TabsTrigger value="theme">
               <Palette className="w-3.5 h-3.5 mr-1" />
               外观
@@ -154,22 +170,30 @@ export function SettingsDialog() {
           </TabsList>
 
           <TabsContent value="connection" className="space-y-5 py-4">
-            {/* Controller URL */}
-            <div className="space-y-2">
-              <Label htmlFor="controller-url">Controller 地址</Label>
-              <div className="flex gap-2">
-                <Input
-                  id="controller-url"
-                  value={tempUrl}
-                  onChange={(e) => { setTempUrl(e.target.value); setTestResult(null); }}
-                  placeholder="留空以使用服务端配置 (AGENTTEAMS_CONTROLLER_URL)"
-                  className="flex-1"
-                />
-                <Button variant="outline" size="icon" onClick={handleReset} title="重置为默认">
-                  <RotateCcw className="w-4 h-4" />
-                </Button>
+            {/* Controller URL — L1 only (F1b): the per-request ?controllerUrl=
+                override is ignored server-side for non-admin sessions, so the
+                field is hidden for them instead of silently mis-tested. */}
+            {isL1 ? (
+              <div className="space-y-2">
+                <Label htmlFor="controller-url">Controller 地址</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="controller-url"
+                    value={tempUrl}
+                    onChange={(e) => { setTempUrl(e.target.value); setTestResult(null); }}
+                    placeholder="留空以使用服务端配置 (AGENTTEAMS_CONTROLLER_URL)"
+                    className="flex-1"
+                  />
+                  <Button variant="outline" size="icon" onClick={handleReset} title="重置为默认">
+                    <RotateCcw className="w-4 h-4" />
+                  </Button>
+                </div>
               </div>
-            </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                后端地址由管理员（L1）在「后端」页统一配置；当前身份不支持按请求覆盖 Controller 地址。
+              </p>
+            )}
 
             {/* Connection Status */}
             <div className="flex items-center gap-2">
@@ -373,6 +397,12 @@ export function SettingsDialog() {
               />
             </div>
           </TabsContent>
+
+          {isL1 && (
+            <TabsContent value="backends" className="py-4">
+              <BackendTab />
+            </TabsContent>
+          )}
 
           <TabsContent value="theme" className="py-4">
             <ThemeTab />

--- a/src/components/dashboard/settings/backend-tab.tsx
+++ b/src/components/dashboard/settings/backend-tab.tsx
@@ -1,34 +1,40 @@
 'use client';
 
-// Settings > 后端 tab (F1b): the server-side backend address config that
-// the first-launch setup page writes (F1a), editable after login.
+// Settings > 后端 tab (F1b + F1c): the server-side backend address config.
 //
-// Visible to ALL logged-in users; save permissions follow the server:
-//   - L1 (level 3, admin): save directly, no token.
-//   - L2 (level < 3): save requires the first-launch setup token — the
-//     standalone instance owner (who typically logs in via the Matrix
-//     track) keeps editing rights via that owner credential, while a peer
-//     L2 in a multi-user deployment cannot shadow the env config.
-//     The token is shown once at first launch (docker logs) and persists
-//     in the .setup-token file next to the config. It is never stored
-//     client-side — cleared from the input after each save.
+// Plugin parity (F1c, decided 9/9 — deployment model is one instance per
+// user, no shared instances): ANY logged-in user (L1 or L2) can view, test
+// and SAVE the backend config — exactly like the plugin's config page, which
+// is open to whoever uses the host. There is no owner token for saving; the
+// first-launch token only gates the PRE-LOGIN setup page (the dashboard's
+// install-method difference). SSRF surface of user-supplied addresses stays
+// pinned server-side by DASHBOARD_ALLOWED_HOSTS.
 //
-// - Reads GET /api/agentteams/setup/backends — the `config` field
-//   (structured internal/external per backend) is returned to any
-//   authenticated session.
-// - Per-field "测试" button → POST /api/agentteams/setup/backends/test
-//   (server-side probe; a pass also seeds the failover working cache).
-// - 保存 → POST /api/agentteams/setup/backends (L1 path, or owner path
-//   with token). Empty fields are omitted; the server rejects a payload
-//   with no address at all ("at least one address is required").
+// - GET /api/agentteams/setup/backends → config (internal/external per
+//   backend) + effective (working cache) for the "在生效" badge.
+// - Per-backend "测试" → POST .../backends/test with the FORM values (draft):
+//   the server probes each address (parallel, one retry) and returns rows in
+//   the plugin's two-layer model — ✅ connected & usable (ms) / ⚠️ connected
+//   but needs auth (401/403) / ❌ classified error (DNS / refused / timeout /
+//   TLS 握手 / TLS 证书 / 连接失败). Draft tests never touch the effective
+//   cache; a failed test never clears it.
+// - 保存 → POST .../backends (no token). The server re-probes what was saved
+//   and returns effective/switched; the tab then auto-runs a test on the
+//   saved list (plugin "保存后自动测一次") and shows the switch banner.
 //
 // Resolution priority (documented for the user): config file > env vars >
-// embedded defaults; the last-known-working candidate (probe TTL) wins.
+// embedded defaults. The background re-rank loop re-probes backends with
+// >= 2 addresses every 30s/120s/300s (adaptive) and latency-elected the
+// fastest reachable one (debounce: must be > 100ms AND > 30% faster); the
+// request layer additionally walks the candidates with a same-address retry,
+// so switching between internal/external networks is automatic.
 import { useCallback, useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
+  AlertTriangle,
   CheckCircle2,
   Loader2,
+  RefreshCw,
   Save,
   Server,
   XCircle,
@@ -39,7 +45,6 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { apiUrl } from '@/lib/api-base';
 import { BACKEND_LABELS, BACKEND_NAMES, REQUIRED_BACKENDS } from '@/lib/backend-names';
-import { useAgentTeamsStore } from '@/lib/agentteams-store';
 
 interface BackendAddrs {
   internal?: string;
@@ -50,16 +55,16 @@ interface BackendsState {
   configured: boolean;
   backends: Record<string, { configured: boolean; candidates: string[] }>;
   config?: Record<string, BackendAddrs>;
+  effective?: Record<string, string>;
 }
 
-interface TestOutcome {
+interface TestRow {
+  url: string;
   ok: boolean;
-  latencyMs?: number;
-  status?: number;
-  error?: string;
+  httpOk: boolean;
+  ms: number | null;
+  detail: string;
 }
-
-type TestKey = string; // `${backend}:${slot}`
 
 function initialFields(config: Record<string, BackendAddrs> | undefined) {
   const out: Record<string, { internal: string; external: string }> = {};
@@ -72,20 +77,23 @@ function initialFields(config: Record<string, BackendAddrs> | undefined) {
   return out;
 }
 
+function RowIcon({ row }: { row: TestRow }) {
+  if (row.ok && row.httpOk) return <CheckCircle2 className="w-3 h-3 text-emerald-600 shrink-0" />;
+  if (row.ok) return <AlertTriangle className="w-3 h-3 text-amber-500 shrink-0" />;
+  return <XCircle className="w-3 h-3 text-red-600 shrink-0" />;
+}
+
 export function BackendTab() {
   const queryClient = useQueryClient();
-  const { userLevel } = useAgentTeamsStore();
-  const isL1 = userLevel >= 3;
   const [state, setState] = useState<BackendsState | null>(null);
   const [loading, setLoading] = useState(true);
   const [fields, setFields] = useState<Record<string, { internal: string; external: string }>>({});
-  const [tests, setTests] = useState<Record<TestKey, TestOutcome | 'running'>>({});
+  const [rows, setRows] = useState<Record<string, TestRow[]>>({});
+  const [testing, setTesting] = useState<Record<string, boolean>>({});
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  // L2-only: first-launch setup token (owner credential). Never persisted
-  // client-side; cleared after each save.
-  const [setupToken, setSetupToken] = useState('');
+  const [banner, setBanner] = useState<{ switched: string[]; unchanged: string[] } | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -93,7 +101,7 @@ export function BackendTab() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = (await res.json()) as BackendsState;
       setState(data);
-      setFields(initialFields(data.config));
+      setFields((prev) => (Object.keys(prev).length > 0 ? prev : initialFields(data.config)));
     } finally {
       setLoading(false);
     }
@@ -107,62 +115,96 @@ export function BackendTab() {
     setFields((prev) => ({ ...prev, [backend]: { ...prev[backend], [slot]: value } }));
     setSaved(false);
     setSaveError(null);
+    setBanner(null);
+    setRows((prev) => {
+      const rest = { ...prev };
+      delete rest[backend];
+      return rest;
+    });
   };
 
-  const handleTest = async (backend: string, slot: 'internal' | 'external') => {
-    const url = (fields[backend]?.[slot] ?? '').trim();
-    const key: TestKey = `${backend}:${slot}`;
-    if (!url) {
-      setTests((prev) => ({ ...prev, [key]: { ok: false, error: '请先填写地址' } }));
-      return;
-    }
-    setTests((prev) => ({ ...prev, [key]: 'running' }));
-    try {
-      const res = await fetch(apiUrl('/api/agentteams/setup/backends/test/'), {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ backend, url }),
-      });
-      const data = (await res.json()) as TestOutcome & { error?: string };
-      setTests((prev) => ({ ...prev, [key]: { ok: res.ok && data.ok, latencyMs: data.latencyMs, status: data.status, error: res.ok ? data.error : `HTTP ${res.status}` } }));
-    } catch {
-      setTests((prev) => ({ ...prev, [key]: { ok: false, error: '测试请求失败' } }));
-    }
+  const runTest = useCallback(
+    async (backends: Record<string, { internal: string; external: string }>) => {
+      const payload: Record<string, BackendAddrs> = {};
+      for (const [name, addrs] of Object.entries(backends)) {
+        const internal = addrs.internal?.trim() ?? '';
+        const external = addrs.external?.trim() ?? '';
+        if (internal || external) {
+          payload[name] = { ...(internal ? { internal } : {}), ...(external ? { external } : {}) };
+        }
+      }
+      if (Object.keys(payload).length === 0) return;
+      setTesting(Object.fromEntries(Object.keys(payload).map((n) => [n, true])));
+      try {
+        const res = await fetch(apiUrl('/api/agentteams/setup/backends/test/'), {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ backends: payload }),
+        });
+        const data = (await res.json().catch(() => null)) as {
+          results?: Record<string, TestRow[]>;
+        } | null;
+        if (data?.results) {
+          setRows((prev) => ({ ...prev, ...data.results }));
+          setSaved(true);
+          setSaveError(null);
+        }
+      } finally {
+        setTesting((prev) => {
+          const next = { ...prev };
+          for (const n of Object.keys(payload)) next[n] = false;
+          return next;
+        });
+      }
+    },
+    [],
+  );
+
+  const handleTestBackend = (name: string) => {
+    if (!fields[name]) return;
+    void runTest({ [name]: fields[name] });
   };
 
   const handleSave = async () => {
-    const tokenValue = isL1 ? '' : setupToken.trim();
-    if (!isL1 && !tokenValue) {
-      setSaveError('非管理员保存需填写首次配置 token（首启时 docker logs 打印，或 .setup-token 文件）');
-      return;
-    }
     setSaving(true);
     setSaved(false);
     setSaveError(null);
+    setBanner(null);
     try {
-      const backends: Record<string, BackendAddrs> = {};
+      const backends: Record<string, { internal: string; external: string }> = {};
       for (const name of BACKEND_NAMES) {
         const internal = (fields[name]?.internal ?? '').trim();
         const external = (fields[name]?.external ?? '').trim();
-        if (internal || external) {
-          backends[name] = { ...(internal ? { internal } : {}), ...(external ? { external } : {}) };
-        }
+        if (internal || external) backends[name] = { internal, external };
       }
       const res = await fetch(apiUrl('/api/agentteams/setup/backends/'), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(isL1 ? { backends } : { backends, token: tokenValue }),
+        body: JSON.stringify({ backends }),
       });
-      const data = (await res.json()) as { ok?: boolean; error?: string };
-      if (res.ok && data.ok) {
+      const data = (await res.json().catch(() => null)) as {
+        ok?: boolean;
+        error?: string;
+        effective?: Record<string, string>;
+        switched?: Record<string, boolean>;
+      } | null;
+      if (res.ok && data?.ok) {
         setSaved(true);
-        if (!isL1) setSetupToken(''); // never keep the token in the input
         await load();
-        // The overview infrastructure panel re-resolves per request; just
-        // nudge it so the health tiles reflect the new addresses promptly.
+        // The overview infrastructure panel re-resolves per request; nudge it
+        // so the health tiles reflect the new addresses promptly.
         void queryClient.invalidateQueries({ queryKey: ['agentteams-infrastructure'] });
+        // Plugin parity: auto-test the saved list once after saving.
+        void runTest(backends);
+        const switchedNames: string[] = [];
+        const unchangedNames: string[] = [];
+        for (const name of Object.keys(backends)) {
+          if (data.switched?.[name]) switchedNames.push(BACKEND_LABELS[name]);
+          else if (data.effective?.[name]) unchangedNames.push(BACKEND_LABELS[name]);
+        }
+        setBanner({ switched: switchedNames, unchanged: unchangedNames });
       } else {
-        setSaveError(data.error === 'invalid-token' ? 'token 不正确' : data.error ?? `HTTP ${res.status}`);
+        setSaveError(data?.error ?? `保存失败（HTTP ${res.status}）`);
       }
     } catch {
       setSaveError('保存请求失败');
@@ -180,22 +222,42 @@ export function BackendTab() {
     );
   }
 
+  const effective = state.effective ?? {};
+
   return (
     <div className="space-y-5">
       <p className="text-xs text-muted-foreground leading-relaxed">
         地址保存在服务端配置文件（<code className="font-mono">DASHBOARD_CONFIG_FILE</code>，数据卷上），保存后立即生效。
-        解析优先级：本配置 &gt; 环境变量 &gt; 内置默认；某地址探活失败后 60 秒内自动切到另一可用候选（内网/外网 failover）。
-        {!isL1 && (
-          <span className="block mt-1">
-            当前身份非管理员：查看/测试可用，<b>保存需首次配置 token</b>（首启时 <code className="font-mono">docker logs</code> 打印一次，或配置同目录 <code className="font-mono">.setup-token</code> 文件）。
-          </span>
-        )}
+        解析优先级：本配置 &gt; 环境变量 &gt; 内置默认。
+        <span className="block mt-1">
+          有 ≥2 个地址的后端每 2 分钟自动重测、切到最快可达的（防抖：需快 100ms 且快 30% 以上才切）；
+          切换内/外网期间请求自动逐候选重试，不会掉。测试未保存的草稿不影响生效地址，测试失败也不会清掉当前生效地址。
+        </span>
       </p>
+
+      {banner && (
+        <div className="space-y-1 rounded-lg border px-3 py-2 text-xs">
+          {banner.switched.map((label) => (
+            <div key={`s-${label}`} className="flex items-center gap-1.5 text-emerald-600">
+              <RefreshCw className="w-3 h-3" />
+              {label}：已切换到最快可达地址
+            </div>
+          ))}
+          {banner.unchanged.map((label) => (
+            <div key={`u-${label}`} className="flex items-center gap-1.5 text-muted-foreground">
+              <CheckCircle2 className="w-3 h-3" />
+              {label}：当前生效地址已是最快，保持不变
+            </div>
+          ))}
+        </div>
+      )}
 
       {BACKEND_NAMES.map((name) => {
         const candidates = state.backends[name]?.candidates ?? [];
         const required = REQUIRED_BACKENDS.includes(name);
         const missingRequired = required && candidates.length === 0;
+        const isTesting = !!testing[name];
+        const hasAny = !!(fields[name]?.internal?.trim() || fields[name]?.external?.trim());
         return (
           <div key={name} className="space-y-1.5 rounded-lg border p-3">
             <div className="flex items-center gap-2">
@@ -206,75 +268,56 @@ export function BackendTab() {
                   无可用地址（影响登录/数据面）
                 </Badge>
               )}
+              <Button
+                variant="outline"
+                size="sm"
+                className="ml-auto h-7 text-xs"
+                onClick={() => handleTestBackend(name)}
+                disabled={isTesting || !hasAny}
+              >
+                {isTesting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : '测试'}
+              </Button>
             </div>
-            {(['internal', 'external'] as const).map((slot) => {
-              const key: TestKey = `${name}:${slot}`;
-              const test = tests[key];
-              return (
-                <div key={slot} className="flex items-center gap-2 pl-5">
-                  <span className="w-14 text-xs text-muted-foreground shrink-0">
-                    {slot === 'internal' ? '内网' : '外网'}
-                  </span>
-                  <Input
-                    value={fields[name]?.[slot] ?? ''}
-                    onChange={(e) => setField(name, slot, e.target.value)}
-                    placeholder="http://host:port（可选，留空=用 env/内置）"
-                    className="h-8 text-xs flex-1"
-                  />
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8 shrink-0"
-                    onClick={() => handleTest(name, slot)}
-                    disabled={test === 'running'}
-                  >
-                    {test === 'running' ? (
-                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                    ) : (
-                      '测试'
-                    )}
-                  </Button>
-                  {test && test !== 'running' && (
-                    <span className="shrink-0">
-                      {test.ok ? (
-                        <Badge variant="outline" className="text-[10px] h-4 px-1.5 gap-1 border-emerald-500/50 text-emerald-600">
-                          <CheckCircle2 className="w-3 h-3" />
-                          {test.latencyMs !== undefined ? `${test.latencyMs}ms` : 'OK'}
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="text-[10px] h-4 px-1.5 gap-1 border-red-500/50 text-red-600 max-w-44" title={test.error}>
-                          <XCircle className="w-3 h-3 shrink-0" />
-                          <span className="truncate">{test.error ?? '失败'}</span>
-                        </Badge>
-                      )}
-                    </span>
-                  )}
-                </div>
-              );
-            })}
+            {(['internal', 'external'] as const).map((slot) => (
+              <div key={slot} className="flex items-center gap-2 pl-5">
+                <span className="w-14 text-xs text-muted-foreground shrink-0">
+                  {slot === 'internal' ? '内网' : '外网'}
+                </span>
+                <Input
+                  value={fields[name]?.[slot] ?? ''}
+                  onChange={(e) => setField(name, slot, e.target.value)}
+                  placeholder="http://host:port（可选，留空=用 env/内置）"
+                  className="h-8 text-xs flex-1"
+                  spellCheck={false}
+                />
+              </div>
+            ))}
+            {rows[name]?.map((row) => (
+              <div key={row.url} className="flex items-center gap-1.5 pl-5 text-[11px]">
+                <RowIcon row={row} />
+                <span className="text-muted-foreground shrink-0">
+                  {row.ok && row.httpOk && row.ms != null ? `${row.ms}ms · ` : ''}
+                  {row.detail}
+                </span>
+                <span className="truncate text-muted-foreground/70 max-w-52" title={row.url}>
+                  {row.url}
+                </span>
+                {effective[name] === row.url && (
+                  <Badge variant="secondary" className="text-[9px] h-4 px-1 shrink-0">
+                    在生效
+                  </Badge>
+                )}
+              </div>
+            ))}
             {candidates.length > 0 && (
               <p className="pl-5 text-[10px] text-muted-foreground truncate">
                 当前候选顺序：{candidates.join(' → ')}
+                {effective[name] ? ` · 生效：${effective[name]}` : ''}
               </p>
             )}
           </div>
         );
       })}
-
-      {!isL1 && (
-        <div className="space-y-1">
-          <Label htmlFor="setup-token" className="text-xs">首次配置 token（保存用）</Label>
-          <Input
-            id="setup-token"
-            type="password"
-            value={setupToken}
-            onChange={(e) => { setSetupToken(e.target.value); setSaved(false); setSaveError(null); }}
-            placeholder="首启 setup 页用的那个 token"
-            className="h-8 text-xs max-w-sm"
-            autoComplete="off"
-          />
-        </div>
-      )}
 
       <div className="flex items-center gap-3">
         <Button onClick={handleSave} disabled={saving}>

--- a/src/components/dashboard/settings/backend-tab.tsx
+++ b/src/components/dashboard/settings/backend-tab.tsx
@@ -1,15 +1,26 @@
 'use client';
 
-// Settings > 后端 tab (F1b): L1-only (level 3) editing of the server-side
-// backend address config that the first-launch setup page writes (F1a).
+// Settings > 后端 tab (F1b): the server-side backend address config that
+// the first-launch setup page writes (F1a), editable after login.
 //
-// - Reads GET /api/agentteams/setup/backends — the `config` field (structured
-//   internal/external per backend) is only returned to level-3 sessions.
+// Visible to ALL logged-in users; save permissions follow the server:
+//   - L1 (level 3, admin): save directly, no token.
+//   - L2 (level < 3): save requires the first-launch setup token — the
+//     standalone instance owner (who typically logs in via the Matrix
+//     track) keeps editing rights via that owner credential, while a peer
+//     L2 in a multi-user deployment cannot shadow the env config.
+//     The token is shown once at first launch (docker logs) and persists
+//     in the .setup-token file next to the config. It is never stored
+//     client-side — cleared from the input after each save.
+//
+// - Reads GET /api/agentteams/setup/backends — the `config` field
+//   (structured internal/external per backend) is returned to any
+//   authenticated session.
 // - Per-field "测试" button → POST /api/agentteams/setup/backends/test
 //   (server-side probe; a pass also seeds the failover working cache).
-// - 保存 → POST /api/agentteams/setup/backends (L1 session path; no token).
-//   Empty fields are omitted; the server rejects a payload with no address
-//   at all ("at least one address is required").
+// - 保存 → POST /api/agentteams/setup/backends (L1 path, or owner path
+//   with token). Empty fields are omitted; the server rejects a payload
+//   with no address at all ("at least one address is required").
 //
 // Resolution priority (documented for the user): config file > env vars >
 // embedded defaults; the last-known-working candidate (probe TTL) wins.
@@ -28,6 +39,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { apiUrl } from '@/lib/api-base';
 import { BACKEND_LABELS, BACKEND_NAMES, REQUIRED_BACKENDS } from '@/lib/backend-names';
+import { useAgentTeamsStore } from '@/lib/agentteams-store';
 
 interface BackendAddrs {
   internal?: string;
@@ -62,6 +74,8 @@ function initialFields(config: Record<string, BackendAddrs> | undefined) {
 
 export function BackendTab() {
   const queryClient = useQueryClient();
+  const { userLevel } = useAgentTeamsStore();
+  const isL1 = userLevel >= 3;
   const [state, setState] = useState<BackendsState | null>(null);
   const [loading, setLoading] = useState(true);
   const [fields, setFields] = useState<Record<string, { internal: string; external: string }>>({});
@@ -69,6 +83,9 @@ export function BackendTab() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // L2-only: first-launch setup token (owner credential). Never persisted
+  // client-side; cleared after each save.
+  const [setupToken, setSetupToken] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -114,6 +131,11 @@ export function BackendTab() {
   };
 
   const handleSave = async () => {
+    const tokenValue = isL1 ? '' : setupToken.trim();
+    if (!isL1 && !tokenValue) {
+      setSaveError('非管理员保存需填写首次配置 token（首启时 docker logs 打印，或 .setup-token 文件）');
+      return;
+    }
     setSaving(true);
     setSaved(false);
     setSaveError(null);
@@ -129,17 +151,18 @@ export function BackendTab() {
       const res = await fetch(apiUrl('/api/agentteams/setup/backends/'), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ backends }),
+        body: JSON.stringify(isL1 ? { backends } : { backends, token: tokenValue }),
       });
       const data = (await res.json()) as { ok?: boolean; error?: string };
       if (res.ok && data.ok) {
         setSaved(true);
+        if (!isL1) setSetupToken(''); // never keep the token in the input
         await load();
         // The overview infrastructure panel re-resolves per request; just
         // nudge it so the health tiles reflect the new addresses promptly.
         void queryClient.invalidateQueries({ queryKey: ['agentteams-infrastructure'] });
       } else {
-        setSaveError(data.error ?? `HTTP ${res.status}`);
+        setSaveError(data.error === 'invalid-token' ? 'token 不正确' : data.error ?? `HTTP ${res.status}`);
       }
     } catch {
       setSaveError('保存请求失败');
@@ -162,6 +185,11 @@ export function BackendTab() {
       <p className="text-xs text-muted-foreground leading-relaxed">
         地址保存在服务端配置文件（<code className="font-mono">DASHBOARD_CONFIG_FILE</code>，数据卷上），保存后立即生效。
         解析优先级：本配置 &gt; 环境变量 &gt; 内置默认；某地址探活失败后 60 秒内自动切到另一可用候选（内网/外网 failover）。
+        {!isL1 && (
+          <span className="block mt-1">
+            当前身份非管理员：查看/测试可用，<b>保存需首次配置 token</b>（首启时 <code className="font-mono">docker logs</code> 打印一次，或配置同目录 <code className="font-mono">.setup-token</code> 文件）。
+          </span>
+        )}
       </p>
 
       {BACKEND_NAMES.map((name) => {
@@ -232,6 +260,21 @@ export function BackendTab() {
           </div>
         );
       })}
+
+      {!isL1 && (
+        <div className="space-y-1">
+          <Label htmlFor="setup-token" className="text-xs">首次配置 token（保存用）</Label>
+          <Input
+            id="setup-token"
+            type="password"
+            value={setupToken}
+            onChange={(e) => { setSetupToken(e.target.value); setSaved(false); setSaveError(null); }}
+            placeholder="首启 setup 页用的那个 token"
+            className="h-8 text-xs max-w-sm"
+            autoComplete="off"
+          />
+        </div>
+      )}
 
       <div className="flex items-center gap-3">
         <Button onClick={handleSave} disabled={saving}>

--- a/src/components/dashboard/settings/backend-tab.tsx
+++ b/src/components/dashboard/settings/backend-tab.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+// Settings > 后端 tab (F1b): L1-only (level 3) editing of the server-side
+// backend address config that the first-launch setup page writes (F1a).
+//
+// - Reads GET /api/agentteams/setup/backends — the `config` field (structured
+//   internal/external per backend) is only returned to level-3 sessions.
+// - Per-field "测试" button → POST /api/agentteams/setup/backends/test
+//   (server-side probe; a pass also seeds the failover working cache).
+// - 保存 → POST /api/agentteams/setup/backends (L1 session path; no token).
+//   Empty fields are omitted; the server rejects a payload with no address
+//   at all ("at least one address is required").
+//
+// Resolution priority (documented for the user): config file > env vars >
+// embedded defaults; the last-known-working candidate (probe TTL) wins.
+import { useCallback, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  CheckCircle2,
+  Loader2,
+  Save,
+  Server,
+  XCircle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { apiUrl } from '@/lib/api-base';
+import { BACKEND_LABELS, BACKEND_NAMES, REQUIRED_BACKENDS } from '@/lib/backend-names';
+
+interface BackendAddrs {
+  internal?: string;
+  external?: string;
+}
+
+interface BackendsState {
+  configured: boolean;
+  backends: Record<string, { configured: boolean; candidates: string[] }>;
+  config?: Record<string, BackendAddrs>;
+}
+
+interface TestOutcome {
+  ok: boolean;
+  latencyMs?: number;
+  status?: number;
+  error?: string;
+}
+
+type TestKey = string; // `${backend}:${slot}`
+
+function initialFields(config: Record<string, BackendAddrs> | undefined) {
+  const out: Record<string, { internal: string; external: string }> = {};
+  for (const name of BACKEND_NAMES) {
+    out[name] = {
+      internal: config?.[name]?.internal ?? '',
+      external: config?.[name]?.external ?? '',
+    };
+  }
+  return out;
+}
+
+export function BackendTab() {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<BackendsState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fields, setFields] = useState<Record<string, { internal: string; external: string }>>({});
+  const [tests, setTests] = useState<Record<TestKey, TestOutcome | 'running'>>({});
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl('/api/agentteams/setup/backends/'), { cache: 'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as BackendsState;
+      setState(data);
+      setFields(initialFields(data.config));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const setField = (backend: string, slot: 'internal' | 'external', value: string) => {
+    setFields((prev) => ({ ...prev, [backend]: { ...prev[backend], [slot]: value } }));
+    setSaved(false);
+    setSaveError(null);
+  };
+
+  const handleTest = async (backend: string, slot: 'internal' | 'external') => {
+    const url = (fields[backend]?.[slot] ?? '').trim();
+    const key: TestKey = `${backend}:${slot}`;
+    if (!url) {
+      setTests((prev) => ({ ...prev, [key]: { ok: false, error: '请先填写地址' } }));
+      return;
+    }
+    setTests((prev) => ({ ...prev, [key]: 'running' }));
+    try {
+      const res = await fetch(apiUrl('/api/agentteams/setup/backends/test/'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ backend, url }),
+      });
+      const data = (await res.json()) as TestOutcome & { error?: string };
+      setTests((prev) => ({ ...prev, [key]: { ok: res.ok && data.ok, latencyMs: data.latencyMs, status: data.status, error: res.ok ? data.error : `HTTP ${res.status}` } }));
+    } catch {
+      setTests((prev) => ({ ...prev, [key]: { ok: false, error: '测试请求失败' } }));
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    setSaveError(null);
+    try {
+      const backends: Record<string, BackendAddrs> = {};
+      for (const name of BACKEND_NAMES) {
+        const internal = (fields[name]?.internal ?? '').trim();
+        const external = (fields[name]?.external ?? '').trim();
+        if (internal || external) {
+          backends[name] = { ...(internal ? { internal } : {}), ...(external ? { external } : {}) };
+        }
+      }
+      const res = await fetch(apiUrl('/api/agentteams/setup/backends/'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ backends }),
+      });
+      const data = (await res.json()) as { ok?: boolean; error?: string };
+      if (res.ok && data.ok) {
+        setSaved(true);
+        await load();
+        // The overview infrastructure panel re-resolves per request; just
+        // nudge it so the health tiles reflect the new addresses promptly.
+        void queryClient.invalidateQueries({ queryKey: ['agentteams-infrastructure'] });
+      } else {
+        setSaveError(data.error ?? `HTTP ${res.status}`);
+      }
+    } catch {
+      setSaveError('保存请求失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading || !state) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" />
+        加载后端配置…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <p className="text-xs text-muted-foreground leading-relaxed">
+        地址保存在服务端配置文件（<code className="font-mono">DASHBOARD_CONFIG_FILE</code>，数据卷上），保存后立即生效。
+        解析优先级：本配置 &gt; 环境变量 &gt; 内置默认；某地址探活失败后 60 秒内自动切到另一可用候选（内网/外网 failover）。
+      </p>
+
+      {BACKEND_NAMES.map((name) => {
+        const candidates = state.backends[name]?.candidates ?? [];
+        const required = REQUIRED_BACKENDS.includes(name);
+        const missingRequired = required && candidates.length === 0;
+        return (
+          <div key={name} className="space-y-1.5 rounded-lg border p-3">
+            <div className="flex items-center gap-2">
+              <Server className="w-3.5 h-3.5 text-muted-foreground" />
+              <Label className="text-sm">{BACKEND_LABELS[name]}</Label>
+              {missingRequired && (
+                <Badge variant="destructive" className="text-[10px] h-4 px-1.5">
+                  无可用地址（影响登录/数据面）
+                </Badge>
+              )}
+            </div>
+            {(['internal', 'external'] as const).map((slot) => {
+              const key: TestKey = `${name}:${slot}`;
+              const test = tests[key];
+              return (
+                <div key={slot} className="flex items-center gap-2 pl-5">
+                  <span className="w-14 text-xs text-muted-foreground shrink-0">
+                    {slot === 'internal' ? '内网' : '外网'}
+                  </span>
+                  <Input
+                    value={fields[name]?.[slot] ?? ''}
+                    onChange={(e) => setField(name, slot, e.target.value)}
+                    placeholder="http://host:port（可选，留空=用 env/内置）"
+                    className="h-8 text-xs flex-1"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 shrink-0"
+                    onClick={() => handleTest(name, slot)}
+                    disabled={test === 'running'}
+                  >
+                    {test === 'running' ? (
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    ) : (
+                      '测试'
+                    )}
+                  </Button>
+                  {test && test !== 'running' && (
+                    <span className="shrink-0">
+                      {test.ok ? (
+                        <Badge variant="outline" className="text-[10px] h-4 px-1.5 gap-1 border-emerald-500/50 text-emerald-600">
+                          <CheckCircle2 className="w-3 h-3" />
+                          {test.latencyMs !== undefined ? `${test.latencyMs}ms` : 'OK'}
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-[10px] h-4 px-1.5 gap-1 border-red-500/50 text-red-600 max-w-44" title={test.error}>
+                          <XCircle className="w-3 h-3 shrink-0" />
+                          <span className="truncate">{test.error ?? '失败'}</span>
+                        </Badge>
+                      )}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+            {candidates.length > 0 && (
+              <p className="pl-5 text-[10px] text-muted-foreground truncate">
+                当前候选顺序：{candidates.join(' → ')}
+              </p>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="flex items-center gap-3">
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? (
+            <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+          ) : (
+            <Save className="w-4 h-4 mr-1" />
+          )}
+          保存配置
+        </Button>
+        {saved && (
+          <span className="text-xs text-emerald-600 flex items-center gap-1">
+            <CheckCircle2 className="w-3.5 h-3.5" /> 已保存，立即生效
+          </span>
+        )}
+        {saveError && <span className="text-xs text-destructive">{saveError}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/setup/backend-setup-page.tsx
+++ b/src/components/setup/backend-setup-page.tsx
@@ -10,7 +10,7 @@
 // can never be reached again from a logged-out browser (level-3 session
 // updates go through the settings dialog, F1b).
 import { useCallback, useEffect, useState } from 'react';
-import { CheckCircle2, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, XCircle } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -41,6 +41,7 @@ type TestState =
   | { status: 'idle' }
   | { status: 'testing' }
   | { status: 'ok'; detail: string }
+  | { status: 'auth'; detail: string }
   | { status: 'fail'; detail: string };
 
 const EMPTY_TEST: TestState = { status: 'idle' };
@@ -101,37 +102,65 @@ export function BackendSetupPage({ onDone }: { onDone: () => void }) {
     setTests((prev) => ({ ...prev, [`${name}:${slot}`]: EMPTY_TEST }));
   };
 
-  const runTest = useCallback(async (name: BackendName, slot: 'internal' | 'external') => {
-    const url = addrs[name][slot].trim();
-    if (!url) return;
-    const key = `${name}:${slot}`;
-    setTests((prev) => ({ ...prev, [key]: { status: 'testing' } }));
-    try {
-      const res = await fetch(apiUrl('/api/agentteams/setup/backends/test'), {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ backend: name, url }),
-      });
-      const data = (await res.json().catch(() => ({}))) as {
-        ok?: boolean;
-        status?: number;
-        latencyMs?: number;
-        error?: string;
-      };
+  // F1c: one test per backend — probes the filled slots together (plugin
+  // config_test parity): per-address rows in the two-layer model (✅ usable /
+  // ⚠️ connected but needs auth / ❌ classified error).
+  const runTest = useCallback(
+    async (name: BackendName) => {
+      const internal = addrs[name].internal.trim();
+      const external = addrs[name].external.trim();
+      if (!internal && !external) return;
+      const filled = [
+        { slot: 'internal' as const, url: internal },
+        { slot: 'external' as const, url: external },
+      ].filter((e) => e.url !== '');
       setTests((prev) => ({
         ...prev,
-        [key]: data.ok
-          ? { status: 'ok', detail: `HTTP ${data.status} · ${data.latencyMs}ms` }
-          : { status: 'fail', detail: data.error || `HTTP ${data.status}` },
+        ...Object.fromEntries(filled.map((e) => [`${name}:${e.slot}`, { status: 'testing' as const }])),
       }));
-    } catch (err) {
-      setTests((prev) => ({
-        ...prev,
-        [key]: { status: 'fail', detail: err instanceof Error ? err.message : '测试请求失败' },
-      }));
-    }
-  }, [addrs]);
+      try {
+        const res = await fetch(apiUrl('/api/agentteams/setup/backends/test'), {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            backends: { [name]: { internal: internal || undefined, external: external || undefined } },
+          }),
+        });
+        const data = (await res.json().catch(() => null)) as {
+          results?: Record<string, Array<{ url: string; ok: boolean; httpOk: boolean; ms: number | null; detail: string }>>;
+        } | null;
+        const rows = data?.results?.[name] ?? [];
+        setTests((prev) => {
+          const next = { ...prev };
+          for (const { slot, url } of filled) {
+            const row = rows.find((r) => r.url === url);
+            if (!row) {
+              next[`${name}:${slot}`] = { status: 'fail', detail: '无测试结果' };
+              continue;
+            }
+            if (row.ok && row.httpOk) {
+              next[`${name}:${slot}`] = { status: 'ok', detail: `${row.ms ?? '-'}ms · ${row.detail}` };
+            } else if (row.ok) {
+              next[`${name}:${slot}`] = {
+                status: row.detail.includes('需鉴权') ? 'auth' : 'fail',
+                detail: row.detail,
+              };
+            } else {
+              next[`${name}:${slot}`] = { status: 'fail', detail: row.detail };
+            }
+          }
+          return next;
+        });
+      } catch (err) {
+        setTests((prev) => ({
+          ...prev,
+          ...Object.fromEntries(filled.map((e) => [`${name}:${e.slot}`, { status: 'fail' as const, detail: err instanceof Error ? err.message : '测试请求失败' }])),
+        }));
+      }
+    },
+    [addrs],
+  );
 
   const applyEmbeddedDefaults = () => {
     setAddrs(
@@ -214,6 +243,7 @@ export function BackendSetupPage({ onDone }: { onDone: () => void }) {
           <CardDescription>
             Dashboard 还没有可用的后端地址。填写后保存即可登录；配置保存在挂载卷中，重启不丢失。
             每个后端可只填一个地址；「内网」= 容器/集群网络，「外网」= 跨网段备用（自动切换）。
+            「测试」一次验证该后端填写的全部地址（✅ 可用 / ⚠️ 已连通需鉴权 / ❌ 不可达，含原因分类）。
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -227,65 +257,74 @@ export function BackendSetupPage({ onDone }: { onDone: () => void }) {
           )}
 
           <div className="space-y-4">
-            {BACKEND_NAMES.map((name) => (
-              <div key={name} className="rounded-md border p-3">
-                <div className="mb-2 flex items-center gap-2 text-sm font-medium">
-                  {BACKEND_LABELS[name]}
-                  {REQUIRED_BACKENDS.includes(name) && (
-                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-                      必需
-                    </span>
-                  )}
-                </div>
-                <div className="grid gap-3 md:grid-cols-2">
-                  {(['internal', 'external'] as const).map((slot) => {
-                    const key = `${name}:${slot}`;
-                    const test = tests[key] ?? EMPTY_TEST;
-                    return (
-                      <div key={slot} className="space-y-1">
-                        <div className="flex items-center justify-between text-xs text-muted-foreground">
-                          <span>{slot === 'internal' ? '内网地址' : '外网地址（备用）'}</span>
-                          <span className="inline-flex items-center gap-1">
-                            {test.status === 'ok' && (
-                              <>
-                                <CheckCircle2 className="size-3.5 text-green-600" />
-                                {test.detail}
-                              </>
-                            )}
-                            {test.status === 'fail' && (
-                              <>
-                                <XCircle className="size-3.5 text-red-600" />
-                                {test.detail}
-                              </>
-                            )}
-                          </span>
-                        </div>
-                        <div className="flex gap-2">
+            {BACKEND_NAMES.map((name) => {
+              const hasAny = !!(addrs[name].internal.trim() || addrs[name].external.trim());
+              const isTesting = ['internal', 'external'].some(
+                (slot) => (tests[`${name}:${slot}`] ?? EMPTY_TEST).status === 'testing',
+              );
+              return (
+                <div key={name} className="rounded-md border p-3">
+                  <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                    {BACKEND_LABELS[name]}
+                    {REQUIRED_BACKENDS.includes(name) && (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                        必需
+                      </span>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="ml-auto h-7 text-xs"
+                      disabled={!hasAny || isTesting}
+                      onClick={() => runTest(name)}
+                    >
+                      {isTesting ? <Loader2 className="size-3.5 animate-spin" /> : '测试'}
+                    </Button>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {(['internal', 'external'] as const).map((slot) => {
+                      const key = `${name}:${slot}`;
+                      const test = tests[key] ?? EMPTY_TEST;
+                      return (
+                        <div key={slot} className="space-y-1">
+                          <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                            <span className="shrink-0">{slot === 'internal' ? '内网地址' : '外网地址（备用）'}</span>
+                            <span className="inline-flex items-center gap-1 min-w-0">
+                              {test.status === 'ok' && (
+                                <>
+                                  <CheckCircle2 className="size-3.5 text-green-600 shrink-0" />
+                                  <span className="truncate">{test.detail}</span>
+                                </>
+                              )}
+                              {test.status === 'auth' && (
+                                <>
+                                  <AlertTriangle className="size-3.5 text-amber-500 shrink-0" />
+                                  <span className="truncate">{test.detail}</span>
+                                </>
+                              )}
+                              {test.status === 'fail' && (
+                                <>
+                                  <XCircle className="size-3.5 text-red-600 shrink-0" />
+                                  <span className="truncate max-w-56" title={test.detail}>
+                                    {test.detail}
+                                  </span>
+                                </>
+                              )}
+                            </span>
+                          </div>
                           <Input
                             value={addrs[name][slot]}
                             onChange={(e) => setSlot(name, slot, e.target.value)}
                             placeholder="http://host:port"
                             spellCheck={false}
                           />
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={!addrs[name][slot].trim() || test.status === 'testing'}
-                            onClick={() => runTest(name, slot)}
-                          >
-                            {test.status === 'testing' ? (
-                              <Loader2 className="size-4 animate-spin" />
-                            ) : (
-                              '测试'
-                            )}
-                          </Button>
                         </div>
-                      </div>
-                    );
-                  })}
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           <div className="space-y-1">

--- a/src/components/setup/backend-setup-page.tsx
+++ b/src/components/setup/backend-setup-page.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+// First-launch backend setup (F1). Rendered INSTEAD OF the login form when
+// the dashboard has no usable backend addresses yet (standalone docker
+// install without env configuration).
+//
+// Pre-login writes are one-shot and token-gated: the token comes from the
+// server log ("one-time backend setup token") or the DASHBOARD_SETUP_TOKEN
+// env var. After the config is saved the login page appears and this screen
+// can never be reached again from a logged-out browser (level-3 session
+// updates go through the settings dialog, F1b).
+import { useCallback, useEffect, useState } from 'react';
+import { CheckCircle2, Loader2, RefreshCw, XCircle } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { apiUrl } from '@/lib/api-base';
+import {
+  BACKEND_LABELS,
+  BACKEND_NAMES,
+  EMBEDDED_DEFAULTS,
+  REQUIRED_BACKENDS,
+  type BackendName,
+} from '@/lib/backend-names';
+
+interface BackendStatus {
+  configured: boolean;
+  candidates: string[];
+}
+
+interface SetupStatusResponse {
+  configured: boolean;
+  backends: Record<BackendName, BackendStatus>;
+  embedded: {
+    defaults: Record<BackendName, string | undefined>;
+    healthy: Record<BackendName, boolean> | null;
+  };
+}
+
+type TestState =
+  | { status: 'idle' }
+  | { status: 'testing' }
+  | { status: 'ok'; detail: string }
+  | { status: 'fail'; detail: string };
+
+const EMPTY_TEST: TestState = { status: 'idle' };
+
+export function BackendSetupPage({ onDone }: { onDone: () => void }) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [addrs, setAddrs] = useState<Record<BackendName, { internal: string; external: string }>>(
+    () =>
+      Object.fromEntries(
+        BACKEND_NAMES.map((name) => [name, { internal: '', external: '' }]),
+      ) as Record<BackendName, { internal: string; external: string }>,
+  );
+  const [embeddedHealthy, setEmbeddedHealthy] = useState(false);
+  const [token, setToken] = useState('');
+  const [tests, setTests] = useState<Record<string, TestState>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(apiUrl('/api/agentteams/setup/backends'), { credentials: 'same-origin' })
+      .then((res) => res.json().catch(() => null))
+      .then((data: SetupStatusResponse | null) => {
+        if (cancelled || !data) {
+          if (!cancelled) {
+            setLoading(false);
+            setLoadError('读取后端配置状态失败，请刷新重试');
+          }
+          return;
+        }
+        const next = Object.fromEntries(
+          BACKEND_NAMES.map((name) => {
+            const candidates = data.backends?.[name]?.candidates ?? [];
+            return [name, { internal: candidates[0] ?? '', external: candidates[1] ?? '' }];
+          }),
+        ) as Record<BackendName, { internal: string; external: string }>;
+        setAddrs(next);
+        setEmbeddedHealthy(
+          !!data.embedded?.healthy &&
+            REQUIRED_BACKENDS.every((name) => data.embedded.healthy?.[name] === true),
+        );
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoading(false);
+          setLoadError('读取后端配置状态失败，请刷新重试');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setSlot = (name: BackendName, slot: 'internal' | 'external', value: string) => {
+    setAddrs((prev) => ({ ...prev, [name]: { ...prev[name], [slot]: value } }));
+    setTests((prev) => ({ ...prev, [`${name}:${slot}`]: EMPTY_TEST }));
+  };
+
+  const runTest = useCallback(async (name: BackendName, slot: 'internal' | 'external') => {
+    const url = addrs[name][slot].trim();
+    if (!url) return;
+    const key = `${name}:${slot}`;
+    setTests((prev) => ({ ...prev, [key]: { status: 'testing' } }));
+    try {
+      const res = await fetch(apiUrl('/api/agentteams/setup/backends/test'), {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ backend: name, url }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        status?: number;
+        latencyMs?: number;
+        error?: string;
+      };
+      setTests((prev) => ({
+        ...prev,
+        [key]: data.ok
+          ? { status: 'ok', detail: `HTTP ${data.status} · ${data.latencyMs}ms` }
+          : { status: 'fail', detail: data.error || `HTTP ${data.status}` },
+      }));
+    } catch (err) {
+      setTests((prev) => ({
+        ...prev,
+        [key]: { status: 'fail', detail: err instanceof Error ? err.message : '测试请求失败' },
+      }));
+    }
+  }, [addrs]);
+
+  const applyEmbeddedDefaults = () => {
+    setAddrs(
+      Object.fromEntries(
+        BACKEND_NAMES.map((name) => [
+          name,
+          { internal: EMBEDDED_DEFAULTS[name] ?? '', external: '' },
+        ]),
+      ) as Record<BackendName, { internal: string; external: string }>,
+    );
+    setTests({});
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setSaveError(null);
+    const backends: Record<string, { internal?: string; external?: string }> = {};
+    for (const name of BACKEND_NAMES) {
+      const internal = addrs[name].internal.trim();
+      const external = addrs[name].external.trim();
+      if (internal || external) backends[name] = { internal: internal || undefined, external: external || undefined };
+    }
+    try {
+      const res = await fetch(apiUrl('/api/agentteams/setup/backends'), {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ token: token.trim(), backends }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (res.ok && data.ok) {
+        onDone();
+        return;
+      }
+      const messages: Record<string, string> = {
+        'token-required': '缺少首次启动 token',
+        'invalid-token': '首次启动 token 不正确（见服务器日志 docker logs <容器>，或 env DASHBOARD_SETUP_TOKEN）',
+        'already-configured': '后端已配置过；请刷新页面（或让管理员在设置里修改）',
+      };
+      setSaveError(messages[data.error ?? ''] || data.error || `保存失败（HTTP ${res.status}）`);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : '保存失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <Card className="max-w-md">
+          <CardHeader>
+            <CardTitle>后端配置</CardTitle>
+            <CardDescription>{loadError}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="outline" onClick={() => window.location.reload()}>
+              <RefreshCw className="mr-2 size-4" />
+              刷新
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-muted/30 p-4 md:p-8">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle className="text-lg">后端配置（首次启动）</CardTitle>
+          <CardDescription>
+            Dashboard 还没有可用的后端地址。填写后保存即可登录；配置保存在挂载卷中，重启不丢失。
+            每个后端可只填一个地址；「内网」= 容器/集群网络，「外网」= 跨网段备用（自动切换）。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {embeddedHealthy && (
+            <div className="flex items-center justify-between rounded-md border bg-muted/50 px-3 py-2">
+              <span className="text-sm">检测到嵌入式部署（内置地址可用）</span>
+              <Button size="sm" variant="outline" onClick={applyEmbeddedDefaults}>
+                使用内置默认地址
+              </Button>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            {BACKEND_NAMES.map((name) => (
+              <div key={name} className="rounded-md border p-3">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                  {BACKEND_LABELS[name]}
+                  {REQUIRED_BACKENDS.includes(name) && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      必需
+                    </span>
+                  )}
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {(['internal', 'external'] as const).map((slot) => {
+                    const key = `${name}:${slot}`;
+                    const test = tests[key] ?? EMPTY_TEST;
+                    return (
+                      <div key={slot} className="space-y-1">
+                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                          <span>{slot === 'internal' ? '内网地址' : '外网地址（备用）'}</span>
+                          <span className="inline-flex items-center gap-1">
+                            {test.status === 'ok' && (
+                              <>
+                                <CheckCircle2 className="size-3.5 text-green-600" />
+                                {test.detail}
+                              </>
+                            )}
+                            {test.status === 'fail' && (
+                              <>
+                                <XCircle className="size-3.5 text-red-600" />
+                                {test.detail}
+                              </>
+                            )}
+                          </span>
+                        </div>
+                        <div className="flex gap-2">
+                          <Input
+                            value={addrs[name][slot]}
+                            onChange={(e) => setSlot(name, slot, e.target.value)}
+                            placeholder="http://host:port"
+                            spellCheck={false}
+                          />
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={!addrs[name][slot].trim() || test.status === 'testing'}
+                            onClick={() => runTest(name, slot)}
+                          >
+                            {test.status === 'testing' ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              '测试'
+                            )}
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-1">
+            <div className="text-sm font-medium">首次启动 token</div>
+            <Input
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="见服务器日志或 DASHBOARD_SETUP_TOKEN"
+              spellCheck={false}
+            />
+            <p className="text-xs text-muted-foreground">
+              仅首次保存需要。token 在服务器日志里（docker logs &lt;容器&gt;，搜
+              setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定；保存成功后不再需要。
+            </p>
+          </div>
+
+          {saveError && <p className="text-sm text-red-600">{saveError}</p>}
+
+          <div className="flex justify-end gap-2">
+            <Button onClick={save} disabled={saving}>
+              {saving && <Loader2 className="mr-2 size-4 animate-spin" />}
+              保存并进入登录
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/setup/backend-setup-page.tsx
+++ b/src/components/setup/backend-setup-page.tsx
@@ -46,7 +46,7 @@ type TestState =
 
 const EMPTY_TEST: TestState = { status: 'idle' };
 
-export function BackendSetupPage({ onDone }: { onDone: () => void }) {
+export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () => void; reconfigure?: boolean }) {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [addrs, setAddrs] = useState<Record<BackendName, { internal: string; external: string }>>(
@@ -239,12 +239,23 @@ export function BackendSetupPage({ onDone }: { onDone: () => void }) {
     <div className="flex min-h-screen items-start justify-center bg-muted/30 p-4 md:p-8">
       <Card className="w-full max-w-2xl">
         <CardHeader>
-          <CardTitle className="text-lg">后端配置（首次启动）</CardTitle>
+          <CardTitle className="text-lg">{reconfigure ? '后端配置' : '后端配置（首次启动）'}</CardTitle>
           <CardDescription>
-            Dashboard 还没有可用的后端地址。填写后保存即可登录；配置保存在挂载卷中，重启不丢失。
+            {reconfigure
+              ? '覆盖现有后端配置（登录前保存需要 setup token）。保存后回到登录页；配置在挂载卷中，重启不丢失。登录前看不到已保存的具体值，直接填写正确地址即可。'
+              : 'Dashboard 还没有可用的后端地址。填写后保存即可登录；配置保存在挂载卷中，重启不丢失。'}
             每个后端可只填一个地址；「内网」= 容器/集群网络，「外网」= 跨网段备用（自动切换）。
             「测试」一次验证该后端填写的全部地址（✅ 可用 / ⚠️ 已连通需鉴权 / ❌ 不可达，含原因分类）。
           </CardDescription>
+          {reconfigure && (
+            <button
+              type="button"
+              onClick={() => window.location.assign('/')}
+              className="self-start text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              ← 返回登录页
+            </button>
+          )}
         </CardHeader>
         <CardContent className="space-y-6">
           {embeddedHealthy && (
@@ -328,7 +339,7 @@ export function BackendSetupPage({ onDone }: { onDone: () => void }) {
           </div>
 
           <div className="space-y-1">
-            <div className="text-sm font-medium">首次启动 token</div>
+            <div className="text-sm font-medium">{reconfigure ? 'Setup token' : '首次启动 token'}</div>
             <Input
               value={token}
               onChange={(e) => setToken(e.target.value)}
@@ -336,8 +347,9 @@ export function BackendSetupPage({ onDone }: { onDone: () => void }) {
               spellCheck={false}
             />
             <p className="text-xs text-muted-foreground">
-              仅首次保存需要。token 在服务器日志里（docker logs &lt;容器&gt;，搜
-              setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定；保存成功后不再需要。
+              {reconfigure
+                ? '登录前修改配置需要 setup token（与首启同一个）：docker logs &lt;容器&gt; 搜 setup token，或 env DASHBOARD_SETUP_TOKEN。找不到 token = docker volume rm 数据卷 出厂重置（配置与 token 一并重建）。'
+                : '仅首次保存需要。token 在服务器日志里（docker logs &lt;容器&gt;，搜 setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定；保存成功后不再需要。'}
             </p>
           </div>
 

--- a/src/components/setup/backend-setup-page.tsx
+++ b/src/components/setup/backend-setup-page.tsx
@@ -4,11 +4,13 @@
 // the dashboard has no usable backend addresses yet (standalone docker
 // install without env configuration).
 //
-// Pre-login writes are one-shot and token-gated: the token comes from the
-// server log ("one-time backend setup token") or the DASHBOARD_SETUP_TOKEN
-// env var. After the config is saved the login page appears and this screen
-// can never be reached again from a logged-out browser (level-3 session
-// updates go through the settings dialog, F1b).
+// Pre-login writes are token-gated and repeatable (F1e): the token comes
+// from the server log ("one-time backend setup token") or the
+// DASHBOARD_SETUP_TOKEN env var — unless the installer disabled the gate
+// (DASHBOARD_SETUP_TOKEN_ENFORCE=0, F1f3), in which case the token field
+// is hidden and saving is plain. After the config is saved the login page
+// appears and this screen can never be reached again from a logged-out
+// browser (level-3 session updates go through the settings dialog, F1b).
 import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, XCircle } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -30,6 +32,9 @@ interface BackendStatus {
 
 interface SetupStatusResponse {
   configured: boolean;
+  /** F1f3: false when the installer disabled the pre-login token gate
+   * (DASHBOARD_SETUP_TOKEN_ENFORCE=0) — the token field is hidden. */
+  setupTokenRequired?: boolean;
   backends: Record<BackendName, BackendStatus>;
   embedded: {
     defaults: Record<BackendName, string | undefined>;
@@ -57,6 +62,7 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
   );
   const [embeddedHealthy, setEmbeddedHealthy] = useState(false);
   const [token, setToken] = useState('');
+  const [tokenRequired, setTokenRequired] = useState(true);
   const [tests, setTests] = useState<Record<string, TestState>>({});
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -84,6 +90,7 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
           !!data.embedded?.healthy &&
             REQUIRED_BACKENDS.every((name) => data.embedded.healthy?.[name] === true),
         );
+        setTokenRequired(data.setupTokenRequired ?? true);
         setLoading(false);
       })
       .catch(() => {
@@ -242,7 +249,7 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
           <CardTitle className="text-lg">{reconfigure ? '后端配置' : '后端配置（首次启动）'}</CardTitle>
           <CardDescription>
             {reconfigure
-              ? '覆盖现有后端配置（登录前保存需要 setup token）。保存后回到登录页；配置在挂载卷中，重启不丢失。登录前看不到已保存的具体值，直接填写正确地址即可。'
+              ? `覆盖现有后端配置${tokenRequired ? '（登录前保存需要 setup token）' : '（本实例已关闭登录前 token 验证，直接保存即可）'}。保存后回到登录页；配置在挂载卷中，重启不丢失。登录前看不到已保存的具体值，直接填写正确地址即可。`
               : 'Dashboard 还没有可用的后端地址。填写后保存即可登录；配置保存在挂载卷中，重启不丢失。'}
             每个后端可只填一个地址；「内网」= 容器/集群网络，「外网」= 跨网段备用（自动切换）。
             「测试」一次验证该后端填写的全部地址（✅ 可用 / ⚠️ 已连通需鉴权 / ❌ 不可达，含原因分类）。
@@ -338,20 +345,22 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
             })}
           </div>
 
-          <div className="space-y-1">
-            <div className="text-sm font-medium">{reconfigure ? 'Setup token' : '首次启动 token'}</div>
-            <Input
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              placeholder="见服务器日志或 DASHBOARD_SETUP_TOKEN"
-              spellCheck={false}
-            />
-            <p className="text-xs text-muted-foreground">
-              {reconfigure
-                ? '登录前修改配置需要 setup token（与首启同一个）：docker logs &lt;容器&gt; 搜 setup token，或 env DASHBOARD_SETUP_TOKEN。找不到 token = docker volume rm 数据卷 出厂重置（配置与 token 一并重建）。'
-                : '仅首次保存需要。token 在服务器日志里（docker logs &lt;容器&gt;，搜 setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定；保存成功后不再需要。'}
-            </p>
-          </div>
+          {tokenRequired && (
+            <div className="space-y-1">
+              <div className="text-sm font-medium">{reconfigure ? 'Setup token' : '首次启动 token'}</div>
+              <Input
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="见服务器日志或 DASHBOARD_SETUP_TOKEN"
+                spellCheck={false}
+              />
+              <p className="text-xs text-muted-foreground">
+                {reconfigure
+                  ? '登录前修改配置需要 setup token（与首启同一个）：docker logs &lt;容器&gt; 搜 setup token，或 env DASHBOARD_SETUP_TOKEN。找不到 token = docker volume rm 数据卷 出厂重置（配置与 token 一并重建）。'
+                  : '仅首次保存需要。token 在服务器日志里（docker logs &lt;容器&gt;，搜 setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定；保存成功后不再需要。'}
+              </p>
+            </div>
+          )}
 
           {saveError && <p className="text-sm text-red-600">{saveError}</p>}
 

--- a/src/components/setup/backend-setup-page.tsx
+++ b/src/components/setup/backend-setup-page.tsx
@@ -35,7 +35,9 @@ interface SetupStatusResponse {
   /** F1f3: false when the installer disabled the pre-login token gate
    * (DASHBOARD_SETUP_TOKEN_ENFORCE=0) — the token field is hidden. */
   setupTokenRequired?: boolean;
-  backends: Record<BackendName, BackendStatus>;
+  /** PR-91 review: absent in the anonymous (pre-login, no token) response —
+   * the saved topology is only served to a session or ?token= holder. */
+  backends?: Record<BackendName, BackendStatus>;
   embedded: {
     defaults: Record<BackendName, string | undefined>;
     healthy: Record<BackendName, boolean> | null;
@@ -104,6 +106,49 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
     };
   }, []);
 
+  // PR-91 review: the saved topology is no longer served pre-login. Once
+  // the operator enters the setup token (reconfigure mode), refetch with
+  // it — same owner gate as the pre-login write — and prefill the saved
+  // addresses (only empty slots: never overwrite what the user typed).
+  useEffect(() => {
+    if (!reconfigure || !tokenRequired) return;
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      fetch(
+        apiUrl(`/api/agentteams/setup/backends?token=${encodeURIComponent(trimmed)}`),
+        { credentials: 'same-origin' },
+      )
+        .then((res) => res.json().catch(() => null))
+        .then((data: SetupStatusResponse | null) => {
+          if (cancelled || !data?.backends) return;
+          setAddrs((prev) =>
+            Object.fromEntries(
+              BACKEND_NAMES.map((name) => {
+                const candidates = data.backends?.[name]?.candidates ?? [];
+                const cur = prev[name];
+                return [
+                  name,
+                  {
+                    internal: cur.internal.trim() || (candidates[0] ?? ''),
+                    external: cur.external.trim() || (candidates[1] ?? ''),
+                  },
+                ];
+              }),
+            ) as Record<BackendName, { internal: string; external: string }>,
+          );
+        })
+        .catch(() => {
+          /* wrong token / transient — the user keeps typing manually */
+        });
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [token, reconfigure, tokenRequired]);
+
   const setSlot = (name: BackendName, slot: 'internal' | 'external', value: string) => {
     setAddrs((prev) => ({ ...prev, [name]: { ...prev[name], [slot]: value } }));
     setTests((prev) => ({ ...prev, [`${name}:${slot}`]: EMPTY_TEST }));
@@ -131,6 +176,10 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
           credentials: 'same-origin',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({
+            // PR-91 review: the probe is token-gated pre-login (same door as
+            // the save) — the endpoint is no longer an unauthenticated
+            // fetch proxy.
+            token: token.trim() || undefined,
             backends: { [name]: { internal: internal || undefined, external: external || undefined } },
           }),
         });
@@ -256,7 +305,7 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
           <CardTitle className="text-lg">{reconfigure ? '后端配置' : '后端配置（首次启动）'}</CardTitle>
           <CardDescription>
             {reconfigure
-              ? `覆盖现有后端配置${tokenRequired ? '（登录前保存需要 setup token）' : '（本实例已关闭登录前 token 验证，直接保存即可）'}。保存后回到登录页；配置在挂载卷中，重启不丢失。登录前看不到已保存的具体值，直接填写正确地址即可。`
+              ? `覆盖现有后端配置${tokenRequired ? '（登录前保存需要 setup token）' : '（本实例已关闭登录前 token 验证，直接保存即可）'}。保存后回到登录页；配置在挂载卷中，重启不丢失。登录前默认看不到已保存的具体值，直接填写正确地址即可；填入 setup token 后已存值会自动回填空槽。`
               : 'Dashboard 还没有可用的后端地址。填写后保存即可登录；配置保存在挂载卷中，重启不丢失。'}
             每个后端可只填一个地址；「内网」= 容器/集群网络，「外网」= 跨网段备用（自动切换）。
             「测试」一次验证该后端填写的全部地址（✅ 可用 / ⚠️ 已连通需鉴权 / ❌ 不可达，含原因分类）。
@@ -364,7 +413,7 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
               <p className="text-xs text-muted-foreground">
                 {reconfigure
                   ? '登录前修改配置需要 setup token（与首启同一个）：docker logs &lt;容器&gt; 搜 setup token，或 env DASHBOARD_SETUP_TOKEN。找不到 token = docker volume rm 数据卷 出厂重置（配置与 token 一并重建）。'
-                  : '仅首次保存需要。token 在服务器日志里（docker logs &lt;容器&gt;，搜 setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定；保存成功后不再需要。'}
+                  : '首启保存需要；之后登录前修改配置（?setup=1）仍是同一个 token（可重复使用，直到数据卷出厂重置）。token 在服务器日志里（docker logs &lt;容器&gt;，搜 setup token），也可用 env DASHBOARD_SETUP_TOKEN 预先指定。'}
               </p>
             </div>
           )}

--- a/src/components/setup/backend-setup-page.tsx
+++ b/src/components/setup/backend-setup-page.tsx
@@ -199,6 +199,13 @@ export function BackendSetupPage({ onDone, reconfigure = false }: { onDone: () =
       });
       const data = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
       if (res.ok && data.ok) {
+        // F1g: clear the ?setup=1 deep link before onDone() (a reload) —
+        // otherwise the reloaded page re-reads ?setup=1, forceSetup stays
+        // true, and the user is stuck on this page and must hunt for the
+        // "返回登录页" escape hatch (Luo-zong 9/9 acceptance).
+        if (window.location.search) {
+          window.history.replaceState(null, '', window.location.pathname + window.location.hash);
+        }
         onDone();
         return;
       }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,6 +8,18 @@ export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
   if (process.env.NEXT_PHASE) return;
   if (process.env.VITEST) return;
+  const { isSharedMode } = await import('./lib/backend-config');
+  // F1f-D: a shared (multi-user) deployment should NOT carry the cluster
+  // super-credential in the env. L1 logs in via the per-login
+  // controller-token paste (C2); L2 via pure Matrix (C3). The env token
+  // stays readable at /proc/<pid>/env for every process in the container.
+  if (isSharedMode() && (process.env.AGENTTEAMS_AUTH_TOKEN || '').trim()) {
+    console.warn(
+      '[dashboard] DASHBOARD_SHARED_MODE=1 but AGENTTEAMS_AUTH_TOKEN is set — ' +
+        'a cluster-level super credential in the env. Drop it; L1 should use ' +
+        'the controller-token paste at login instead.',
+    );
+  }
   const { startAddressProbe } = await import('./lib/address-probe');
   startAddressProbe();
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,13 @@
+// Next.js instrumentation hook (nodejs runtime): starts the background
+// address auto-rerank loop when the standalone server boots — the dashboard
+// equivalent of the plugin's register_startup_hook (address_probe.py).
+//
+// Skipped during `next build` (NEXT_PHASE set in the build worker) and in
+// unit tests (VITEST), so the loop only runs in a live server process.
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (process.env.NEXT_PHASE) return;
+  if (process.env.VITEST) return;
+  const { startAddressProbe } = await import('./lib/address-probe');
+  startAddressProbe();
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,7 +8,7 @@ export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
   if (process.env.NEXT_PHASE) return;
   if (process.env.VITEST) return;
-  const { isSharedMode } = await import('./lib/backend-config');
+  const { isSharedMode, isSetupTokenEnforced } = await import('./lib/backend-config');
   // F1f-D: a shared (multi-user) deployment should NOT carry the cluster
   // super-credential in the env. L1 logs in via the per-login
   // controller-token paste (C2); L2 via pure Matrix (C3). The env token
@@ -18,6 +18,14 @@ export async function register(): Promise<void> {
       '[dashboard] DASHBOARD_SHARED_MODE=1 but AGENTTEAMS_AUTH_TOKEN is set — ' +
         'a cluster-level super credential in the env. Drop it; L1 should use ' +
         'the controller-token paste at login instead.',
+    );
+  }
+  // F1f3: the installer disabled the pre-login setup token gate — record
+  // the open state in the startup log (docker logs).
+  if (!isSetupTokenEnforced()) {
+    console.warn(
+      '[dashboard] DASHBOARD_SETUP_TOKEN_ENFORCE=0 — pre-login backend-config saves are OPEN (no token). ' +
+        'Anyone who can reach this dashboard can rewrite the backend addresses. Trusted-LAN deployments only.',
     );
   }
   const { startAddressProbe } = await import('./lib/address-probe');

--- a/src/lib/address-probe.test.ts
+++ b/src/lib/address-probe.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { nextIntervalMs, probeKinds } from './address-probe';
+
+describe('probeKinds (plugin: single-address backends pay zero cost)', () => {
+  it('only backends with >= 2 candidates are probed', () => {
+    const kinds = probeKinds({
+      controller: ['http://a', 'http://b'],
+      matrix: ['http://a'],
+      minio: ['http://a', 'http://b', 'http://c'],
+      sglang: [],
+      'higress-gateway': ['http://a'],
+      'higress-console': [],
+    });
+    expect(kinds).toEqual(['controller', 'minio']);
+  });
+
+  it('no candidates at all → nothing to probe', () => {
+    expect(probeKinds({})).toEqual([]);
+  });
+});
+
+describe('nextIntervalMs (adaptive period, plugin 30/120/300s model)', () => {
+  it('unsettled topology → fast (30s)', () => {
+    expect(nextIntervalMs(false, 0)).toBe(30_000);
+    expect(nextIntervalMs(false, 5)).toBe(30_000);
+  });
+
+  it('stable but not yet converged → base (120s)', () => {
+    expect(nextIntervalMs(true, 0)).toBe(120_000);
+    expect(nextIntervalMs(true, 1)).toBe(120_000);
+  });
+
+  it('two consecutive stable rounds → slow (300s)', () => {
+    expect(nextIntervalMs(true, 2)).toBe(300_000);
+    expect(nextIntervalMs(true, 5)).toBe(300_000);
+  });
+});

--- a/src/lib/address-probe.ts
+++ b/src/lib/address-probe.ts
@@ -1,0 +1,122 @@
+// Background address auto-rerank loop (port of the plugin's address_probe.py)
+// — the "内外网自动探测" half of F1. The plugin probes on a QwenPaw host
+// process; here it runs in the standalone dashboard server, started from the
+// Next.js instrumentation hook (src/instrumentation.ts).
+//
+// - Only backends with >= 2 candidate addresses are probed — single-address
+//   deployments pay zero cost (plugin rule, kept).
+// - Adaptive period: 30s while the topology is unsettled (a switch just
+//   happened, or some backend has no effective address), 120s normally, 300s
+//   after 2 consecutive stable rounds (resource saver for steady networks).
+// - 15s startup delay: don't fight the startup network window.
+// - Reentrancy guard: a slow round never starts a second round.
+// - Request-layer failover (proxy-helper) handles instant fallback; this loop
+//   only optimizes the "slow but connected" case (latency fastest + hysteresis
+//   via selectAndMark), so a network switch converges within one period.
+
+import {
+  BACKEND_NAMES,
+  backendCandidatesSync,
+  effectiveUrl,
+  refreshEffective,
+} from './backend-config';
+import type { BackendName } from './backend-names';
+
+const INTERVAL_FAST_MS = 30_000;
+const INTERVAL_BASE_MS = 120_000;
+const INTERVAL_STABLE_MS = 300_000;
+const STABLE_ROUNDS = 2;
+const STARTUP_DELAY_MS = 15_000;
+
+/** Backends worth probing: >= 2 candidates (plugin: single-address users pay zero). */
+export function probeKinds(candidates: Record<string, string[]>): BackendName[] {
+  return BACKEND_NAMES.filter((n) => (candidates[n]?.length ?? 0) >= 2);
+}
+
+/** Adaptive period decision (plugin _probe_loop, extracted for unit tests). */
+export function nextIntervalMs(stable: boolean, stableRounds: number): number {
+  if (!stable) return INTERVAL_FAST_MS;
+  if (stableRounds >= STABLE_ROUNDS) return INTERVAL_STABLE_MS;
+  return INTERVAL_BASE_MS;
+}
+
+interface ProbeState {
+  started: boolean;
+  running: boolean;
+  stableRounds: number;
+  intervalMs: number;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+// globalThis-scoped on purpose (same lesson as the session store / working
+// cache, 87cb478): Next may instantiate a server module more than once per
+// process; a plain module-level flag would start one loop per instance.
+function state(): ProbeState {
+  const g = globalThis as unknown as { __dashboardAddressProbe?: ProbeState };
+  if (!g.__dashboardAddressProbe) {
+    g.__dashboardAddressProbe = {
+      started: false,
+      running: false,
+      stableRounds: 0,
+      intervalMs: INTERVAL_BASE_MS,
+    };
+  }
+  return g.__dashboardAddressProbe;
+}
+
+export function stopAddressProbe(): void {
+  const s = state();
+  if (!s.started) return;
+  s.started = false;
+  if (s.timer) clearTimeout(s.timer);
+  s.timer = undefined;
+}
+
+async function round(s: ProbeState): Promise<void> {
+  if (s.running) return; // reentrancy guard (plugin _probe_loop)
+  s.running = true;
+  try {
+    const candidates = Object.fromEntries(BACKEND_NAMES.map((n) => [n, backendCandidatesSync(n)]));
+    const kinds = probeKinds(candidates);
+    let stable = true;
+    if (kinds.length > 0) {
+      const { effective, switched } = await refreshEffective(kinds);
+      const changed = kinds.filter((k) => switched[k]);
+      if (changed.length > 0) {
+        console.warn(
+          `[dashboard] address auto-rerank: ${changed.map((k) => `${k} -> ${effectiveUrl(k)}`).join(', ')}`,
+        );
+      }
+      // Round quality: every probed kind got an effective address this round.
+      stable = kinds.every((k) => !!effective[k]);
+    }
+    s.stableRounds = stable ? s.stableRounds + 1 : 0;
+    const next = nextIntervalMs(stable, s.stableRounds);
+    if (next !== s.intervalMs) {
+      console.warn(`[dashboard] address probe interval -> ${next / 1000}s (stable_rounds=${s.stableRounds})`);
+      s.intervalMs = next;
+    }
+    s.timer = setTimeout(() => void round(s), next);
+  } catch (err) {
+    // A broken round must never kill the loop.
+    console.warn('[dashboard] address probe round failed', err instanceof Error ? err.message : err);
+    s.timer = setTimeout(() => void round(s), INTERVAL_FAST_MS);
+  } finally {
+    s.running = false;
+  }
+}
+
+export function startAddressProbe(): void {
+  const s = state();
+  if (s.started) return;
+  s.started = true;
+  console.warn('[dashboard] address auto-rerank started (adaptive 30/120/300s; single-address backends skipped)');
+  s.timer = setTimeout(() => void round(s), STARTUP_DELAY_MS);
+}
+
+/** Test hook: reset the globalThis singleton (tests only). */
+export function __resetAddressProbeForTests(): void {
+  const g = globalThis as unknown as { __dashboardAddressProbe?: ProbeState };
+  if (g.__dashboardAddressProbe?.timer) clearTimeout(g.__dashboardAddressProbe.timer);
+  delete g.__dashboardAddressProbe;
+}

--- a/src/lib/agentteams-api.ts
+++ b/src/lib/agentteams-api.ts
@@ -295,6 +295,8 @@ export interface InfrastructureInfo {
   matrix?: { healthy: boolean; homeserver: string };
   kubernetes?: { healthy: boolean; version: string };
   controller?: { healthy: boolean; version: string };
+  /** Optional SGLang inference backend (F1). endpoint is empty when not configured. */
+  sglang?: { healthy: boolean; endpoint: string };
 }
 
 export interface BucketResponse {

--- a/src/lib/backend-config.test.ts
+++ b/src/lib/backend-config.test.ts
@@ -140,11 +140,13 @@ describe('saveConfigOneShot / updateConfig', () => {
     expect(await configExists()).toBe(false);
   });
 
-  it('updateConfig creates and overwrites', async () => {
+  it('updateConfig creates and merges per-backend (F1f-E)', async () => {
     expect(await updateConfig({ controller: { internal: 'http://a:8090' } })).toEqual({ ok: true });
     expect(await updateConfig({ matrix: { internal: 'http://b:6167' } })).toEqual({ ok: true });
     const config = readConfigSync();
-    expect(config?.backends.controller).toBeUndefined(); // overwritten
+    // F1f-E merge semantics: the sent backend replaces its entry; unsent
+    // backends are preserved — a partial save must never wipe the config.
+    expect(config?.backends.controller).toEqual({ internal: 'http://a:8090' });
     expect(config?.backends.matrix).toEqual({ internal: 'http://b:6167' });
   });
 });
@@ -160,6 +162,15 @@ describe('getSetupToken', () => {
     expect(first).toMatch(/^[0-9a-f]{32}$/);
     expect(await getSetupToken()).toBe(first);
     expect(fs.existsSync(path.join(workDir, '.setup-token'))).toBe(true);
+  });
+
+  it('shared mode: env is the only source, empty when unset, never persisted (F1f-B)', async () => {
+    vi.stubEnv('DASHBOARD_SHARED_MODE', '1');
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN', 'shared-env-token');
+    expect(await getSetupToken()).toBe('shared-env-token');
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN', '');
+    expect(await getSetupToken()).toBe('');
+    expect(fs.existsSync(path.join(workDir, '.setup-token'))).toBe(false);
   });
 });
 

--- a/src/lib/backend-config.test.ts
+++ b/src/lib/backend-config.test.ts
@@ -381,6 +381,12 @@ describe('classifyProbeError (port of plugin _classify_error)', () => {
     );
   });
 
+  it('ECONNRESET → 提示语含中间盒/DPI 嫌疑（sat 外网归因 2026-09-09）', () => {
+    const out = classifyProbeError(wrapped(withCode('ECONNRESET', 'socket hang up')), false);
+    expect(out).toContain('连接被重置');
+    expect(out).toContain('中间盒/DPI');
+  });
+
   it('certificate verification failure stays a certificate error', () => {
     expect(classifyProbeError(wrapped(new Error('unable to verify the first certificate')), false)).toContain('证书');
   });

--- a/src/lib/backend-config.test.ts
+++ b/src/lib/backend-config.test.ts
@@ -9,18 +9,26 @@ import {
   EMBEDDED_DEFAULTS,
   backendCandidates,
   backendCandidatesSync,
+  classifyProbeError,
   configExists,
   configFilePath,
+  effectiveUrl,
   forgetWorking,
   getSetupToken,
   isHttpUrl,
   isTestTargetAllowed,
+  listMatchesSaved,
   markWorking,
+  orderedCandidates,
   pickBackendUrl,
   probeBackend,
   readConfigSync,
+  refreshEffective,
   saveConfigOneShot,
+  selectAndMark,
+  toProbeRow,
   updateConfig,
+  type ProbeRow,
 } from './backend-config';
 
 let workDir: string;
@@ -188,7 +196,7 @@ describe('pickBackendUrl + working cache', () => {
       // candidates = [in:8000 (file), env:8000]; mark the second as working.
       markWorking('sglang', 'http://env:8000');
       expect(pickBackendUrl('sglang')).toBe('http://env:8000');
-      vi.advanceTimersByTime(70_000);
+      vi.advanceTimersByTime(700_000);
       // expired → fall back to the first candidate.
       expect(pickBackendUrl('sglang')).toBe('http://in:8000');
     } finally {
@@ -246,12 +254,27 @@ describe('probeBackend', () => {
     expect(paths[paths.length - 1]).toBe('GET /healthz');
   });
 
-  it('treats a higress 404 as "gateway up, route missing"', async () => {
+  it('treats a higress 404 as "gateway up, route missing" (connected, not httpOk)', async () => {
     const result = await probeBackend('higress-gateway', base);
-    expect(result.ok).toBe(false);
+    expect(result.ok).toBe(true); // the gateway answered → network connected
+    expect(result.httpOk).toBe(false);
     expect(result.status).toBe(404);
-    expect(result.error).toContain('route');
+    expect(result.error).toContain('路由');
     expect(paths[paths.length - 1]).toBe('POST /v1/chat/completions');
+  });
+
+  it('401 is connected but not usable (two-layer model)', async () => {
+    server.removeAllListeners('request');
+    server.on('request', (_req, res) => {
+      res.writeHead(401, { 'www-authenticate': 'Basic' });
+      res.end('nope');
+    });
+    const result = await probeBackend('matrix', base);
+    expect(result.ok).toBe(true);
+    expect(result.httpOk).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.error).toBeUndefined();
+    expect(toProbeRow(base, result).detail).toContain('需鉴权');
   });
 
   it('reports unreachable targets with an error', async () => {
@@ -263,5 +286,223 @@ describe('probeBackend', () => {
   it('embedded defaults are the documented embedded topology (no sglang)', () => {
     expect(EMBEDDED_DEFAULTS.controller).toBe('http://agentteams-controller:8090');
     expect(EMBEDDED_DEFAULTS.sglang).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F1c: plugin parity — election, error classification, candidate order,
+// applied-only cache updates, refresh_effective
+// ---------------------------------------------------------------------------
+
+const row = (url: string, ms: number | null, ok = true, httpOk = true): ProbeRow => ({
+  url,
+  ok,
+  httpOk,
+  ms,
+  detail: '',
+});
+
+describe('selectAndMark (port of plugin _select_and_mark)', () => {
+  it('no current working → elects the fastest reachable', () => {
+    const picked = selectAndMark('controller', [row('http://slow:8090', 208), row('http://fast:8090', 100)]);
+    expect(picked).toBe('http://fast:8090');
+    expect(effectiveUrl('controller')).toBe('http://fast:8090');
+  });
+
+  it('challenger 108ms faster (> max(100ms, 30%)) → switches', () => {
+    markWorking('controller', 'http://slow:8090', 208);
+    const picked = selectAndMark('controller', [row('http://slow:8090', 208), row('http://fast:8090', 100)]);
+    expect(picked).toBe('http://fast:8090');
+  });
+
+  it('challenger 50ms faster (< 100ms floor) → hysteresis holds the current', () => {
+    markWorking('controller', 'http://slow:8090', 208);
+    const picked = selectAndMark('controller', [row('http://slow:8090', 208), row('http://fast:8090', 158)]);
+    expect(picked).toBe('http://slow:8090');
+    expect(effectiveUrl('controller')).toBe('http://slow:8090');
+  });
+
+  it('current unreachable → switches to the fastest immediately', () => {
+    markWorking('controller', 'http://dead:8090', 120);
+    const picked = selectAndMark('controller', [
+      row('http://dead:8090', null, false, false),
+      row('http://ok:8090', 300),
+      row('http://ok2:8090', 180),
+    ]);
+    expect(picked).toBe('http://ok2:8090');
+  });
+
+  it('nobody reachable → working cache untouched', () => {
+    markWorking('controller', 'http://keep:8090', 90);
+    const picked = selectAndMark('controller', [
+      row('http://a:8090', null, false, false),
+      row('http://b:8090', null, false, false),
+    ]);
+    expect(picked).toBeNull();
+    expect(effectiveUrl('controller')).toBe('http://keep:8090');
+  });
+
+  it('a connected-but-401 address is never elected', () => {
+    const picked = selectAndMark('controller', [
+      row('http://auth:8090', 10, true, false),
+      row('http://plain:8090', 200),
+    ]);
+    expect(picked).toBe('http://plain:8090');
+  });
+});
+
+describe('classifyProbeError (port of plugin _classify_error)', () => {
+  const withCode = (code: string, message?: string) => {
+    const err = new Error(message ?? `failed (${code})`);
+    (err as { code?: string }).code = code;
+    return err;
+  };
+  const wrapped = (cause: unknown) => {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = cause;
+    return err;
+  };
+
+  it('timeout (AbortError) → 连接超时', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    expect(classifyProbeError(err, true)).toContain('连接超时');
+  });
+
+  it('DNS failure (ENOTFOUND, undici-wrapped)', () => {
+    expect(
+      classifyProbeError(wrapped(withCode('ENOTFOUND', 'getaddrinfo ENOTFOUND badhost')), false),
+    ).toContain('DNS 解析失败');
+  });
+
+  it('ECONNREFUSED → 连接被拒绝', () => {
+    expect(classifyProbeError(wrapped(withCode('ECONNREFUSED', 'connect ECONNREFUSED 127.0.0.1:1')), false)).toContain(
+      '连接被拒绝',
+    );
+  });
+
+  it('certificate verification failure stays a certificate error', () => {
+    expect(classifyProbeError(wrapped(new Error('unable to verify the first certificate')), false)).toContain('证书');
+  });
+
+  it('handshake interruption is a handshake error (NOT a certificate error)', () => {
+    const out = classifyProbeError(wrapped(new Error('TLS handshake failed: wrong version number')), false);
+    expect(out).toContain('握手');
+    expect(out).not.toContain('证书校验失败');
+  });
+
+  it('unknown error → 连接失败 with the message preserved', () => {
+    const out = classifyProbeError(wrapped(withCode('EACCES', 'permission denied')), false);
+    expect(out).toContain('连接失败');
+    expect(out).toContain('permission denied');
+  });
+});
+
+describe('orderedCandidates (request-layer failover order)', () => {
+  it('fresh working address first, then config internal → external → env, deduped', () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } } }),
+    );
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
+    markWorking('controller', 'http://out:8090');
+    expect(orderedCandidates('controller')).toEqual(['http://out:8090', 'http://in:8090', 'http://env:8090']);
+  });
+
+  it('no working entry → plain candidate order', () => {
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
+    expect(orderedCandidates('controller')).toEqual(['http://env:8090']);
+  });
+
+  it('a working address that is no longer a candidate is excluded (ghost guard, same as pickBackendUrl)', () => {
+    markWorking('controller', 'http://ghost:8090');
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
+    expect(orderedCandidates('controller')).toEqual(['http://env:8090']);
+  });
+});
+
+describe('listMatchesSaved (plugin config_test "applied" semantics)', () => {
+  it('tested list equal to the saved config list (any slot order) → applies', () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } } }),
+    );
+    expect(listMatchesSaved('controller', ['http://out:8090', 'http://in:8090'])).toBe(true);
+  });
+
+  it('draft differs from the saved list → does not apply', () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({ version: 1, backends: { controller: { internal: 'http://in:8090' } } }),
+    );
+    expect(listMatchesSaved('controller', ['http://other:8090'])).toBe(false);
+    expect(listMatchesSaved('controller', ['http://in:8090', 'http://extra:8090'])).toBe(false);
+  });
+
+  it('no saved config (env-only deployment) → never applies', () => {
+    expect(listMatchesSaved('controller', ['http://env:8090'])).toBe(false);
+  });
+});
+
+describe('refreshEffective (port of plugin refresh_effective)', () => {
+  let fast: Server;
+  let slow: Server;
+  let fastUrl: string;
+  let slowUrl: string;
+
+  beforeAll(async () => {
+    fast = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+    slow = createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      }, 150);
+    });
+    await new Promise<void>((resolve) => fast.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>((resolve) => slow.listen(0, '127.0.0.1', resolve));
+    const fa = fast.address();
+    const sa = slow.address();
+    if (!fa || typeof fa === 'string' || !sa || typeof sa === 'string') throw new Error('no server');
+    fastUrl = `http://127.0.0.1:${fa.port}`;
+    slowUrl = `http://127.0.0.1:${sa.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => fast.close(() => resolve()));
+    await new Promise<void>((resolve) => slow.close(() => resolve()));
+  });
+
+  it('elects the fastest reachable candidate; re-runs switch across the hysteresis gap', async () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({ version: 1, backends: { sglang: { internal: fastUrl, external: slowUrl } } }),
+    );
+    const first = await refreshEffective(['sglang']);
+    expect(first.effective.sglang).toBe(fastUrl);
+    expect(first.switched.sglang).toBeUndefined(); // no previous working address
+
+    // Simulate a previous effective = the slow address; the ~150ms gap clears
+    // max(100ms, 30%) → the re-probe switches back to the fast one.
+    markWorking('sglang', slowUrl, 150);
+    const second = await refreshEffective(['sglang']);
+    expect(second.effective.sglang).toBe(fastUrl);
+    expect(second.switched.sglang).toBe(true);
+  });
+
+  it('a failed round never clears the existing effective address', async () => {
+    markWorking('sglang', fastUrl, 10);
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({
+        version: 1,
+        backends: { sglang: { internal: 'http://127.0.0.1:1', external: 'http://127.0.0.1:2' } },
+      }),
+    );
+    const result = await refreshEffective(['sglang'], 1500);
+    expect(result.effective.sglang).toBeUndefined();
+    expect(effectiveUrl('sglang')).toBe(fastUrl);
   });
 });

--- a/src/lib/backend-config.test.ts
+++ b/src/lib/backend-config.test.ts
@@ -1,0 +1,267 @@
+// @vitest-environment node
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import {
+  BACKEND_NAMES,
+  EMBEDDED_DEFAULTS,
+  backendCandidates,
+  backendCandidatesSync,
+  configExists,
+  configFilePath,
+  forgetWorking,
+  getSetupToken,
+  isHttpUrl,
+  isTestTargetAllowed,
+  markWorking,
+  pickBackendUrl,
+  probeBackend,
+  readConfigSync,
+  saveConfigOneShot,
+  updateConfig,
+} from './backend-config';
+
+let workDir: string;
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backend-config-'));
+});
+
+afterAll(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv('DASHBOARD_CONFIG_FILE', path.join(workDir, 'config.json'));
+  vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', '');
+  vi.stubEnv('DASHBOARD_SETUP_TOKEN', '');
+  for (const name of BACKEND_NAMES) forgetWorking(name);
+});
+
+afterEach(() => {
+  const file = path.join(workDir, 'config.json');
+  if (fs.existsSync(file)) fs.rmSync(file);
+  const token = path.join(workDir, '.setup-token');
+  if (fs.existsSync(token)) fs.rmSync(token);
+  vi.unstubAllEnvs();
+});
+
+describe('isHttpUrl', () => {
+  it('accepts http/https only', () => {
+    expect(isHttpUrl('http://a:8090')).toBe(true);
+    expect(isHttpUrl('https://a.example.com')).toBe(true);
+    expect(isHttpUrl('ftp://a')).toBe(false);
+    expect(isHttpUrl('not a url')).toBe(false);
+    expect(isHttpUrl('')).toBe(false);
+    expect(isHttpUrl(undefined)).toBe(false);
+  });
+});
+
+describe('readConfigSync / normalization', () => {
+  it('returns null when the file is missing or corrupt', () => {
+    expect(readConfigSync()).toBeNull();
+    fs.writeFileSync(configFilePath(), '{not json');
+    expect(readConfigSync()).toBeNull();
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({
+        version: 1,
+        backends: {
+          controller: { internal: 'http://ctl:8090', external: 'ftp://bad' },
+          matrix: { internal: 42 },
+          sglang: { external: 'http://s:8000' },
+        },
+      }),
+    );
+    const config = readConfigSync();
+    expect(config?.backends.controller).toEqual({ internal: 'http://ctl:8090' });
+    expect(config?.backends.matrix).toBeUndefined();
+    expect(config?.backends.sglang).toEqual({ external: 'http://s:8000' });
+  });
+});
+
+describe('backendCandidates (order: config internal > config external > env)', () => {
+  it('orders and dedupes', () => {
+    vi.stubEnv('AGENTTEAMS_CONTROLLER_URL', 'http://env:8090');
+    const config = readConfigSync();
+    const from = backendCandidates('controller', {
+      version: 1,
+      backends: { controller: { internal: 'http://in:8090', external: 'http://out:8090' } },
+    });
+    expect(from).toEqual(['http://in:8090', 'http://out:8090', 'http://env:8090']);
+    // duplicate between file and env collapses
+    const dup = backendCandidates('controller', {
+      version: 1,
+      backends: { controller: { internal: 'http://env:8090' } },
+    });
+    expect(dup).toEqual(['http://env:8090']);
+    expect(config).toBeNull();
+  });
+
+  it('backendCandidatesSync reads the file', () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({ version: 1, backends: { sglang: { internal: 'http://file:8000' } } }),
+    );
+    vi.stubEnv('AGENTTEAMS_SGLANG_URL', 'http://env:8000');
+    expect(backendCandidatesSync('sglang')).toEqual(['http://file:8000', 'http://env:8000']);
+  });
+});
+
+describe('saveConfigOneShot / updateConfig', () => {
+  it('one-shot: first write succeeds, second is rejected', async () => {
+    expect(await saveConfigOneShot({ controller: { internal: 'http://a:8090' } })).toEqual({ ok: true });
+    expect(await configExists()).toBe(true);
+    expect(await saveConfigOneShot({ matrix: { internal: 'http://b:6167' } })).toEqual({
+      ok: false,
+      error: 'already-configured',
+    });
+    // file unchanged
+    expect(readConfigSync()?.backends.matrix).toBeUndefined();
+  });
+
+  it('one-shot rejects an all-invalid payload', async () => {
+    const result = await saveConfigOneShot({ controller: { external: 'ftp://nope' } });
+    expect(result.ok).toBe(false);
+    expect(await configExists()).toBe(false);
+  });
+
+  it('updateConfig creates and overwrites', async () => {
+    expect(await updateConfig({ controller: { internal: 'http://a:8090' } })).toEqual({ ok: true });
+    expect(await updateConfig({ matrix: { internal: 'http://b:6167' } })).toEqual({ ok: true });
+    const config = readConfigSync();
+    expect(config?.backends.controller).toBeUndefined(); // overwritten
+    expect(config?.backends.matrix).toEqual({ internal: 'http://b:6167' });
+  });
+});
+
+describe('getSetupToken', () => {
+  it('env token wins', async () => {
+    vi.stubEnv('DASHBOARD_SETUP_TOKEN', 'env-token');
+    expect(await getSetupToken()).toBe('env-token');
+  });
+
+  it('auto-generates, persists, and is stable across calls', async () => {
+    const first = await getSetupToken();
+    expect(first).toMatch(/^[0-9a-f]{32}$/);
+    expect(await getSetupToken()).toBe(first);
+    expect(fs.existsSync(path.join(workDir, '.setup-token'))).toBe(true);
+  });
+});
+
+describe('pickBackendUrl + working cache', () => {
+  it('falls back through the candidate list', () => {
+    expect(pickBackendUrl('sglang')).toBeUndefined();
+    vi.stubEnv('AGENTTEAMS_SGLANG_URL', 'http://env:8000');
+    expect(pickBackendUrl('sglang')).toBe('http://env:8000');
+  });
+
+  it('recently probed working address wins over the candidate order', () => {
+    fs.writeFileSync(
+      configFilePath(),
+      JSON.stringify({
+        version: 1,
+        backends: { sglang: { internal: 'http://in:8000', external: 'http://out:8000' } },
+      }),
+    );
+    markWorking('sglang', 'http://out:8000');
+    expect(pickBackendUrl('sglang')).toBe('http://out:8000');
+    // a working address that is no longer a candidate is ignored
+    markWorking('sglang', 'http://ghost:8000');
+    expect(pickBackendUrl('sglang')).toBe('http://in:8000');
+  });
+
+  it('working entry wins while fresh, expires after the TTL', () => {
+    vi.useFakeTimers();
+    try {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({ version: 1, backends: { sglang: { internal: 'http://in:8000' } } }),
+      );
+      vi.stubEnv('AGENTTEAMS_SGLANG_URL', 'http://env:8000');
+      // candidates = [in:8000 (file), env:8000]; mark the second as working.
+      markWorking('sglang', 'http://env:8000');
+      expect(pickBackendUrl('sglang')).toBe('http://env:8000');
+      vi.advanceTimersByTime(70_000);
+      // expired → fall back to the first candidate.
+      expect(pickBackendUrl('sglang')).toBe('http://in:8000');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('isTestTargetAllowed', () => {
+  it('empty filter allows everything; configured filter is exclusive (exact or subdomain)', () => {
+    vi.stubEnv('DASHBOARD_ALLOWED_HOSTS', '');
+    expect(isTestTargetAllowed('http://anything.example.com:1234/x')).toBe(true);
+    vi.stubEnv('DASHBOARD_ALLOWED_HOSTS', 'a.example.com');
+    expect(isTestTargetAllowed('http://a.example.com/')).toBe(true);
+    expect(isTestTargetAllowed('http://sub.a.example.com/')).toBe(true);
+    expect(isTestTargetAllowed('http://evil-a.example.com/')).toBe(false);
+    expect(isTestTargetAllowed('not-a-url')).toBe(false);
+  });
+});
+
+describe('probeBackend', () => {
+  let server: Server;
+  let base: string;
+  const paths: string[] = [];
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      paths.push(`${req.method} ${req.url}`);
+      if (req.url === '/ok' || req.url === '/healthz') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      } else if (req.url === '/missing' || req.url === '/v1/chat/completions') {
+        res.writeHead(404);
+        res.end('nf');
+      } else {
+        res.writeHead(500);
+        res.end('boom');
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('no server address');
+    base = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('maps health paths per backend kind and records latency', async () => {
+    const result = await probeBackend('controller', base);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(paths[paths.length - 1]).toBe('GET /healthz');
+  });
+
+  it('treats a higress 404 as "gateway up, route missing"', async () => {
+    const result = await probeBackend('higress-gateway', base);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.error).toContain('route');
+    expect(paths[paths.length - 1]).toBe('POST /v1/chat/completions');
+  });
+
+  it('reports unreachable targets with an error', async () => {
+    const result = await probeBackend('sglang', 'http://127.0.0.1:1');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('embedded defaults are the documented embedded topology (no sglang)', () => {
+    expect(EMBEDDED_DEFAULTS.controller).toBe('http://agentteams-controller:8090');
+    expect(EMBEDDED_DEFAULTS.sglang).toBeUndefined();
+  });
+});

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -319,6 +319,8 @@ export function orderedCandidates(name: BackendName): string[] {
 //   B: the setup token comes ONLY from DASHBOARD_SETUP_TOKEN env and is
 //      NEVER generated or persisted to the volume (no owner credential on
 //      disk); with no env token the pre-login write path stays closed;
+//      F1f3: DASHBOARD_SETUP_TOKEN_ENFORCE=0 disables the whole gate
+//      (installer opt-out — pre-login writes open, no token at all);
 //   C: every config write is audited with actor + level + changed fields;
 //   D: startup warns if AGENTTEAMS_AUTH_TOKEN (a cluster-level super
 //      credential) is in the env — shared deployments should drop it and
@@ -331,11 +333,25 @@ export function isSharedMode(): boolean {
   return process.env.DASHBOARD_SHARED_MODE === '1';
 }
 
+/** F1f3: the installer (deployer) chooses whether the pre-login setup
+ * token gate is enforced. `DASHBOARD_SETUP_TOKEN_ENFORCE=0` disables the
+ * gate entirely — pre-login config saves need no token, and no token is
+ * generated, printed or persisted (authoritative over DASHBOARD_SETUP_TOKEN).
+ * Default (unset or '1') = enforced: all F1e/F1f behavior. Documented risk
+ * of opting out: anyone who can reach the dashboard can rewrite the
+ * backend addresses — trusted-LAN deployments only (the startup log
+ * records the open state, instrumentation.ts). */
+export function isSetupTokenEnforced(): boolean {
+  return (process.env.DASHBOARD_SETUP_TOKEN_ENFORCE || '').trim() !== '0';
+}
+
 // ---------------------------------------------------------------------------
 // First-launch setup token (gates the pre-auth write; repeatable — F1e)
 // ---------------------------------------------------------------------------
 
 export async function getSetupToken(): Promise<string> {
+  // F1f3: the installer disabled the gate — no token exists at all.
+  if (!isSetupTokenEnforced()) return '';
   const fromEnv = (process.env.DASHBOARD_SETUP_TOKEN || '').trim();
   if (fromEnv) return fromEnv;
   // B: shared mode — env is the ONLY token source. Nothing is generated,

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -35,14 +35,14 @@ import {
 
 export { BACKEND_NAMES, EMBEDDED_DEFAULTS, REQUIRED_BACKENDS, type BackendName };
 
-type FsModule = typeof import('fs');
+type FsModule = typeof import('node:fs');
 
 let fsPromise: Promise<FsModule> | null = null;
 let fsResolved: FsModule | null = null;
 
 function loadFs(): Promise<FsModule> {
   if (!fsPromise) {
-    fsPromise = import('fs')
+    fsPromise = import('node:fs')
       .then((mod) => {
         fsResolved = mod;
         return mod;
@@ -75,7 +75,7 @@ export function configFilePath(): string {
 }
 
 async function tokenFilePath(): Promise<string> {
-  const path = await import('path');
+  const path = await import('node:path');
   return path.join(path.dirname(configFilePath()), '.setup-token');
 }
 
@@ -158,7 +158,7 @@ export async function configExists(): Promise<boolean> {
 
 async function writeConfigAtomic(config: DashboardConfig): Promise<void> {
   const fsp = (await loadFs()).promises;
-  const path = await import('path');
+  const path = await import('node:path');
   const file = configFilePath();
   await fsp.mkdir(path.dirname(file), { recursive: true });
   const tmp = `${file}.tmp`;
@@ -359,7 +359,7 @@ export async function getSetupToken(): Promise<string> {
   // is closed (verifySetupToken fails closed on it).
   if (isSharedMode()) return '';
   const fsp = (await loadFs()).promises;
-  const path = await import('path');
+  const path = await import('node:path');
   const tokenFile = await tokenFilePath();
   try {
     const persisted = (await fsp.readFile(tokenFile, 'utf-8')).trim();
@@ -367,7 +367,7 @@ export async function getSetupToken(): Promise<string> {
   } catch {
     // fall through to generation
   }
-  const crypto = await import('crypto');
+  const crypto = await import('node:crypto');
   const token = crypto.randomBytes(16).toString('hex');
   try {
     await fsp.mkdir(path.dirname(tokenFile), { recursive: true });

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -185,7 +185,16 @@ export async function saveConfigOneShot(
 export async function updateConfig(
   backends: DashboardConfig['backends'],
 ): Promise<{ ok: boolean; error?: string }> {
-  const config = normalizeConfig({ version: 1, backends });
+  // F1f-E: per-backend MERGE, not full replacement. Sent backends replace
+  // their entry; unsent backends are preserved. A partial save (e.g. the
+  // admin fixing only the controller address on a shared instance) must
+  // never wipe the other backends — under the old replace semantics that
+  // one save made the whole instance unusable until re-configured.
+  // Explicit removal of a backend = `docker volume rm` factory reset
+  // (the UI form always sends all six, so merge === replace from the UI).
+  const existing = readConfigSync()?.backends ?? {};
+  const merged: DashboardConfig['backends'] = { ...existing, ...backends };
+  const config = normalizeConfig({ version: 1, backends: merged });
   if (!config) return { ok: false, error: 'invalid-config' };
   await writeConfigAtomic(config);
   return { ok: true };
@@ -298,12 +307,41 @@ export function orderedCandidates(name: BackendName): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// First-launch setup token (gates the pre-auth one-shot write)
+// Shared (multi-user) deployment mode — F1f
+//
+// DASHBOARD_SHARED_MODE=1 marks an instance that MULTIPLE humans share
+// (e.g. Node1: admin L1 + team L2 on one container). The plugin's
+// "whoever uses this host edits this config" model assumes one instance per
+// human; on a shared instance that model is an attack surface (an L2
+// overwriting the backend config redirects EVERY user's data plane). In
+// shared mode the dashboard therefore:
+//   A: only level-3 (admin) sessions may save the backend config;
+//   B: the setup token comes ONLY from DASHBOARD_SETUP_TOKEN env and is
+//      NEVER generated or persisted to the volume (no owner credential on
+//      disk); with no env token the pre-login write path stays closed;
+//   C: every config write is audited with actor + level + changed fields;
+//   D: startup warns if AGENTTEAMS_AUTH_TOKEN (a cluster-level super
+//      credential) is in the env — shared deployments should drop it and
+//      use the per-login controller-token paste (C2) instead.
+// Standalone (one instance per user) deployments keep the F1c behavior:
+// any logged-in user saves, token auto-generated + persisted.
+// ---------------------------------------------------------------------------
+
+export function isSharedMode(): boolean {
+  return process.env.DASHBOARD_SHARED_MODE === '1';
+}
+
+// ---------------------------------------------------------------------------
+// First-launch setup token (gates the pre-auth write; repeatable — F1e)
 // ---------------------------------------------------------------------------
 
 export async function getSetupToken(): Promise<string> {
   const fromEnv = (process.env.DASHBOARD_SETUP_TOKEN || '').trim();
   if (fromEnv) return fromEnv;
+  // B: shared mode — env is the ONLY token source. Nothing is generated,
+  // printed or persisted; an empty result means the pre-login write path
+  // is closed (verifySetupToken fails closed on it).
+  if (isSharedMode()) return '';
   const fsp = (await loadFs()).promises;
   const path = await import('path');
   const tokenFile = await tokenFilePath();

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -97,14 +97,24 @@ export function isHttpUrl(value: string | undefined | null): value is string {
 // Empty (default) = allow any http(s) target — this is a local
 // self-configuration tool; operators can pin exact hosts if they want.
 export function isTestTargetAllowed(url: string): boolean {
-  const fromEnv = (process.env.DASHBOARD_ALLOWED_HOSTS || '').trim();
-  if (!fromEnv) return true;
   let hostname: string;
   try {
     hostname = new URL(url.trim()).hostname.toLowerCase().replace(/^\[|\]$/g, '');
   } catch {
     return false;
   }
+  // Cloud instance-metadata sentinel: never a legitimate dashboard backend
+  // in any mode (the setup probe is an authenticated owner tool since the
+  // PR-91 security review — this is belt, not the suspenders).
+  if (hostname === '169.254.169.254') return false;
+  const fromEnv = (process.env.DASHBOARD_ALLOWED_HOSTS || '').trim();
+  // Empty = allow (local self-config posture — plugin config_test parity).
+  // Since the PR-91 review the probe endpoint is no longer reachable
+  // unauthenticated: pre-login callers must hold the setup token (or the
+  // installer opted out with DASHBOARD_SETUP_TOKEN_ENFORCE=0, trusted-LAN),
+  // and post-login callers hold a session. Set DASHBOARD_ALLOWED_HOSTS for
+  // a strict allowlist regardless of caller.
+  if (!fromEnv) return true;
   const allowed = fromEnv
     .split(',')
     .map((h) => h.trim().toLowerCase())
@@ -331,6 +341,21 @@ export function orderedCandidates(name: BackendName): string[] {
 
 export function isSharedMode(): boolean {
   return process.env.DASHBOARD_SHARED_MODE === '1';
+}
+
+/** PR-91 review: the setup-token check shared by the pre-login write paths
+ * (POST /setup/backends, POST /setup/backends/test, GET /setup/backends
+ * prefill) — one implementation, timing-safe, fails closed on a missing
+ * token source (shared mode without env token). */
+export async function verifySetupToken(token: string): Promise<boolean> {
+  const expected = await getSetupToken();
+  // B: shared mode without a DASHBOARD_SETUP_TOKEN env — the pre-login
+  // write path is closed (fails closed, no timing comparison on empty).
+  if (!expected) return false;
+  const crypto = await import('node:crypto');
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
 }
 
 /** F1f3: the installer (deployer) chooses whether the pre-login setup

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -1,0 +1,362 @@
+// Dashboard backend configuration (F1: first-launch backend setup).
+//
+// Every backend the dashboard talks to (controller, matrix, minio,
+// higress gateway/console, sglang) supports two addresses — internal /
+// external — mirroring the workbench plugin's dual-address model. The
+// dashboard server resolves which address to use at request time:
+//
+//   resolution:  config file > env vars
+//   failover:    last-known-working address (probed, TTL-cached) wins,
+//                then config internal, config external, env — in that order.
+//
+// Persistence: a small JSON file (DASHBOARD_CONFIG_FILE) on a mounted
+// volume. It is written ONCE at first launch by the pre-login setup page
+// (token-gated, one-shot) and may be updated afterwards only by a level-3
+// (L1 admin) session. Read access is a plain synchronous file read per
+// request (tiny file, local disk) — same pattern as the per-call token
+// re-read in proxy-helper, which deliberately avoids stale caches.
+
+// Node builtins are loaded LAZILY (dynamic import) so this module can be
+// imported from non-Node environments (jsdom unit tests) without crashing —
+// same convention as proxy-helper's token-file read. In Node the fs module
+// is warmed at module init; the sync read path (readConfigSync) uses the
+// warmed cache and degrades to "no config file" until it is available,
+// which is the correct behavior in test environments.
+import {
+  BACKEND_NAMES,
+  EMBEDDED_DEFAULTS,
+  REQUIRED_BACKENDS,
+  type BackendName,
+} from './backend-names';
+
+export { BACKEND_NAMES, EMBEDDED_DEFAULTS, REQUIRED_BACKENDS, type BackendName };
+
+type FsModule = typeof import('fs');
+
+let fsPromise: Promise<FsModule> | null = null;
+let fsResolved: FsModule | null = null;
+
+function loadFs(): Promise<FsModule> {
+  if (!fsPromise) {
+    fsPromise = import('fs')
+      .then((mod) => {
+        fsResolved = mod;
+        return mod;
+      })
+      .catch((err) => {
+        fsPromise = null; // non-Node environment: stay degraded, don't poison retries
+        throw err;
+      });
+  }
+  return fsPromise;
+}
+
+// Warm the fs cache at module init (Node server + node-env tests).
+loadFs().catch(() => {
+  /* jsdom etc.: readConfigSync returns null, async writers throw at call time */
+});
+
+export interface BackendAddrs {
+  internal?: string;
+  external?: string;
+}
+
+export interface DashboardConfig {
+  version: number;
+  backends: Partial<Record<BackendName, BackendAddrs>>;
+}
+
+export function configFilePath(): string {
+  return (process.env.DASHBOARD_CONFIG_FILE || '/data/agentteams-dashboard/config.json').trim();
+}
+
+async function tokenFilePath(): Promise<string> {
+  const path = await import('path');
+  return path.join(path.dirname(configFilePath()), '.setup-token');
+}
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+export function isHttpUrl(value: string | undefined | null): value is string {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+// Optional SSRF filter for the pre-login "test connection" endpoint.
+// Empty (default) = allow any http(s) target — this is a local
+// self-configuration tool; operators can pin exact hosts if they want.
+export function isTestTargetAllowed(url: string): boolean {
+  const fromEnv = (process.env.DASHBOARD_ALLOWED_HOSTS || '').trim();
+  if (!fromEnv) return true;
+  let hostname: string;
+  try {
+    hostname = new URL(url.trim()).hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  } catch {
+    return false;
+  }
+  const allowed = fromEnv
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+  return allowed.some((h) => hostname === h || hostname.endsWith(`.${h}`));
+}
+
+// ---------------------------------------------------------------------------
+// Config file access (sync read — see header; async writes)
+// ---------------------------------------------------------------------------
+
+function normalizeConfig(parsed: unknown): DashboardConfig | null {
+  if (!parsed || typeof parsed !== 'object') return null;
+  const candidate = parsed as Partial<DashboardConfig>;
+  if (!candidate.backends || typeof candidate.backends !== 'object') return null;
+  // Keep only valid entries; silently drop malformed ones so a partially
+  // edited file cannot take the dashboard down.
+  const backends: DashboardConfig['backends'] = {};
+  for (const name of BACKEND_NAMES) {
+    const entry = candidate.backends[name];
+    if (!entry || typeof entry !== 'object') continue;
+    const out: BackendAddrs = {};
+    if (isHttpUrl(entry.internal)) out.internal = entry.internal.trim();
+    if (isHttpUrl(entry.external)) out.external = entry.external.trim();
+    if (out.internal || out.external) backends[name] = out;
+  }
+  return { version: 1, backends };
+}
+
+export function readConfigSync(): DashboardConfig | null {
+  // Sync contract (called from sync URL resolution in proxy-helper). Uses the
+  // module-init-warmed fs cache; null until warm or in non-Node environments.
+  if (!fsResolved) return null;
+  try {
+    const raw = fsResolved.readFileSync(configFilePath(), 'utf-8');
+    return normalizeConfig(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export async function configExists(): Promise<boolean> {
+  const fsp = (await loadFs()).promises;
+  try {
+    await fsp.access(configFilePath());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeConfigAtomic(config: DashboardConfig): Promise<void> {
+  const fsp = (await loadFs()).promises;
+  const path = await import('path');
+  const file = configFilePath();
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  await fsp.writeFile(tmp, JSON.stringify(config, null, 2), { mode: 0o644 });
+  await fsp.rename(tmp, file);
+}
+
+/** Pre-login one-shot write: only succeeds while no config file exists.
+ * Unlike updateConfig it rejects a payload with no valid address at all —
+ * a first-launch save that ends up configuring nothing is a user error, not
+ * a meaningful state. */
+export async function saveConfigOneShot(
+  backends: DashboardConfig['backends'],
+): Promise<{ ok: boolean; error?: string }> {
+  if (await configExists()) return { ok: false, error: 'already-configured' };
+  const config = normalizeConfig({ version: 1, backends });
+  if (!config) return { ok: false, error: 'invalid-config' };
+  if (Object.keys(config.backends).length === 0) return { ok: false, error: 'invalid-config' };
+  await writeConfigAtomic(config);
+  return { ok: true };
+}
+
+/** Level-3 (L1 admin) update: creates or overwrites the config file. */
+export async function updateConfig(
+  backends: DashboardConfig['backends'],
+): Promise<{ ok: boolean; error?: string }> {
+  const config = normalizeConfig({ version: 1, backends });
+  if (!config) return { ok: false, error: 'invalid-config' };
+  await writeConfigAtomic(config);
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Address resolution (config file > env) + failover working cache
+// ---------------------------------------------------------------------------
+
+function envAddr(name: BackendName): string | undefined {
+  const env = process.env;
+  switch (name) {
+    case 'controller':
+      return env.AGENTTEAMS_CONTROLLER_URL || env.AGENTTEAMS_API_URL;
+    case 'matrix':
+      return env.AGENTTEAMS_MATRIX_URL || env.NEXT_PUBLIC_MATRIX_API_URL;
+    case 'minio':
+      return env.AGENTTEAMS_FS_ENDPOINT || env.AGENTTEAMS_MINIO_ENDPOINT || env.AGENTTEAMS_MINIO_URL;
+    case 'higress-gateway':
+      return env.AGENTTEAMS_AI_GATEWAY_URL;
+    case 'higress-console':
+      return env.AGENTTEAMS_AI_GATEWAY_ADMIN_URL;
+    case 'sglang':
+      return env.AGENTTEAMS_SGLANG_URL;
+  }
+}
+
+/** Candidate order for one backend: config internal, config external, env.
+ * Deduped; invalid URLs dropped. */
+export function backendCandidates(name: BackendName, config: DashboardConfig | null): string[] {
+  const out: string[] = [];
+  const add = (value: string | undefined) => {
+    if (value && isHttpUrl(value) && !out.includes(value.trim())) out.push(value.trim());
+  };
+  add(config?.backends[name]?.internal);
+  add(config?.backends[name]?.external);
+  add(envAddr(name));
+  return out;
+}
+
+export function backendCandidatesSync(name: BackendName): string[] {
+  return backendCandidates(name, readConfigSync());
+}
+
+const WORKING_TTL_MS = 60_000;
+interface WorkingEntry {
+  url: string;
+  at: number;
+}
+
+// globalThis-scoped on purpose (same lesson as the session store, 87cb478):
+// Next may instantiate a server module more than once per process; a plain
+// module-level Map would then fragment the working cache.
+function workingMap(): Map<BackendName, WorkingEntry> {
+  const g = globalThis as unknown as { __dashboardBackendWorking?: Map<BackendName, WorkingEntry> };
+  if (!g.__dashboardBackendWorking) g.__dashboardBackendWorking = new Map();
+  return g.__dashboardBackendWorking;
+}
+
+export function markWorking(name: BackendName, url: string): void {
+  workingMap().set(name, { url: url.trim(), at: Date.now() });
+}
+
+export function forgetWorking(name: BackendName): void {
+  workingMap().delete(name);
+}
+
+/** Best address for a backend right now: the recently-probed working one if
+ * it is still a candidate, else the first candidate. */
+export function pickBackendUrl(name: BackendName): string | undefined {
+  const candidates = backendCandidatesSync(name);
+  const entry = workingMap().get(name);
+  if (entry && Date.now() - entry.at < WORKING_TTL_MS && candidates.includes(entry.url)) {
+    return entry.url;
+  }
+  return candidates[0];
+}
+
+// ---------------------------------------------------------------------------
+// First-launch setup token (gates the pre-auth one-shot write)
+// ---------------------------------------------------------------------------
+
+export async function getSetupToken(): Promise<string> {
+  const fromEnv = (process.env.DASHBOARD_SETUP_TOKEN || '').trim();
+  if (fromEnv) return fromEnv;
+  const fsp = (await loadFs()).promises;
+  const path = await import('path');
+  const tokenFile = await tokenFilePath();
+  try {
+    const persisted = (await fsp.readFile(tokenFile, 'utf-8')).trim();
+    if (persisted) return persisted;
+  } catch {
+    // fall through to generation
+  }
+  const crypto = await import('crypto');
+  const token = crypto.randomBytes(16).toString('hex');
+  try {
+    await fsp.mkdir(path.dirname(tokenFile), { recursive: true });
+    await fsp.writeFile(tokenFile, token, { mode: 0o600 });
+  } catch {
+    // Read-only fs (tests): the token is still usable in this process.
+  }
+  // The pre-login setup page tells the user where to find it. console.error
+  // (not log): the no-console lint rule only permits warn/error, and the
+  // token must land in the plain `docker logs` stream either way.
+  console.error(`[dashboard] one-time backend setup token: ${token}`);
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Health probes (per-kind path; also used by the infrastructure panel)
+// ---------------------------------------------------------------------------
+
+const PROBE_PATHS: Record<BackendName, { path: string; method?: 'POST'; body?: string }> = {
+  controller: { path: '/healthz' },
+  matrix: { path: '/_matrix/client/versions' },
+  minio: { path: '/minio/health/live' },
+  // POST /v1/chat/completions with an unauthenticated probe: 404 = route
+  // missing (unreachable), any other status = gateway is up.
+  'higress-gateway': {
+    path: '/v1/chat/completions',
+    method: 'POST',
+    body: JSON.stringify({ model: 'probe', messages: [{ role: 'user', content: 'ping' }], max_tokens: 1 }),
+  },
+  // Console (Next.js): any HTTP response means it is up.
+  'higress-console': { path: '/' },
+  sglang: { path: '/v1/models' },
+};
+
+export interface ProbeResult {
+  ok: boolean;
+  status?: number;
+  latencyMs: number;
+  error?: string;
+}
+
+export async function probeBackend(
+  name: BackendName,
+  url: string,
+  timeoutMs = 5000,
+): Promise<ProbeResult> {
+  const spec = PROBE_PATHS[name];
+  const target = new URL(spec.path, url.replace(/\/+$/, '')).toString();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = Date.now();
+  try {
+    const res = await fetch(target, {
+      method: spec.method ?? 'GET',
+      signal: controller.signal,
+      headers: spec.body ? { 'content-type': 'application/json' } : undefined,
+      body: spec.body,
+    });
+    const latencyMs = Date.now() - startedAt;
+    if (name === 'higress-gateway') {
+      // 404 means the AI route is missing, not that the gateway is down.
+      if (res.status === 404) {
+        return { ok: false, status: 404, latencyMs, error: 'AI route not found (gateway up, route missing)' };
+      }
+      return { ok: true, status: res.status, latencyMs };
+    }
+    if (name === 'higress-console') {
+      return { ok: true, status: res.status, latencyMs };
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status, latencyMs, error: `HTTP ${res.status}` };
+    }
+    return { ok: true, status: res.status, latencyMs };
+  } catch (err) {
+    return {
+      ok: false,
+      latencyMs: Date.now() - startedAt,
+      error: err instanceof Error && err.name === 'AbortError' ? 'timeout' : err instanceof Error ? err.message : 'Unknown error',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -6,8 +6,12 @@
 // dashboard server resolves which address to use at request time:
 //
 //   resolution:  config file > env vars
-//   failover:    last-known-working address (probed, TTL-cached) wins,
-//                then config internal, config external, env — in that order.
+//   failover:    last-known-working address (latency-probed; kept fresh by the
+//                background re-rank loop and the post-save re-probe) wins, then
+//                config internal, config external, env — in that order. The
+//                request layer (proxy-helper) additionally walks the remaining
+//                candidates with a same-address retry, so a dead first candidate
+//                never 502s the data plane (plugin catch-all parity).
 //
 // Persistence: a small JSON file (DASHBOARD_CONFIG_FILE) on a mounted
 // volume. It is written ONCE at first launch by the pre-login setup page
@@ -226,10 +230,15 @@ export function backendCandidatesSync(name: BackendName): string[] {
   return backendCandidates(name, readConfigSync());
 }
 
-const WORKING_TTL_MS = 60_000;
+// TTL safety valve: the plugin's working cache has no TTL (only the background
+// re-rank loop and the save re-probe update it). We keep a cap so a hand-edited
+// config file cannot pin a stale address forever; 10 min covers the 30/120/300s
+// loop intervals with margin.
+const WORKING_TTL_MS = 600_000;
 interface WorkingEntry {
   url: string;
   at: number;
+  ms?: number;
 }
 
 // globalThis-scoped on purpose (same lesson as the session store, 87cb478):
@@ -241,23 +250,51 @@ function workingMap(): Map<BackendName, WorkingEntry> {
   return g.__dashboardBackendWorking;
 }
 
-export function markWorking(name: BackendName, url: string): void {
-  workingMap().set(name, { url: url.trim(), at: Date.now() });
+export function markWorking(name: BackendName, url: string, ms?: number): void {
+  const entry = workingMap().get(name);
+  workingMap().set(name, { url: url.trim(), at: Date.now(), ms: ms ?? entry?.ms });
 }
 
 export function forgetWorking(name: BackendName): void {
   workingMap().delete(name);
 }
 
+/** Fresh (within TTL) working entry, or undefined. */
+export function workingEntry(name: BackendName): WorkingEntry | undefined {
+  const entry = workingMap().get(name);
+  if (entry && Date.now() - entry.at < WORKING_TTL_MS) return entry;
+  return undefined;
+}
+
+/** Currently effective address (working cache), or null. */
+export function effectiveUrl(name: BackendName): string | null {
+  return workingEntry(name)?.url ?? null;
+}
+
 /** Best address for a backend right now: the recently-probed working one if
  * it is still a candidate, else the first candidate. */
 export function pickBackendUrl(name: BackendName): string | undefined {
   const candidates = backendCandidatesSync(name);
-  const entry = workingMap().get(name);
-  if (entry && Date.now() - entry.at < WORKING_TTL_MS && candidates.includes(entry.url)) {
+  const entry = workingEntry(name);
+  if (entry && candidates.includes(entry.url)) {
     return entry.url;
   }
   return candidates[0];
+}
+
+/** Candidate order used by request-layer failover: fresh working address
+ * first (only while it is still a candidate — same guard as pickBackendUrl),
+ * then config internal → external → env (deduped). */
+export function orderedCandidates(name: BackendName): string[] {
+  const candidates = backendCandidatesSync(name);
+  const out: string[] = [];
+  const add = (v: string | undefined) => {
+    if (v && !out.includes(v)) out.push(v);
+  };
+  const working = workingEntry(name)?.url;
+  if (working && candidates.includes(working)) add(working);
+  for (const c of candidates) add(c);
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -312,17 +349,119 @@ const PROBE_PATHS: Record<BackendName, { path: string; method?: 'POST'; body?: s
 };
 
 export interface ProbeResult {
+  /** Network-layer connectivity: any HTTP response received (401/403/5xx
+   * count as connected too) — plugin v0.4.93 two-layer model. */
   ok: boolean;
+  /** Status code < 400 — only httpOk results are eligible for the effective
+   * election (401/403 = "connected but needs auth"). */
+  httpOk: boolean;
   status?: number;
   latencyMs: number;
+  /** Classified error (only when !ok); network-layer failures may carry a
+   * DNS segment diagnostic appended. */
   error?: string;
 }
 
-export async function probeBackend(
-  name: BackendName,
-  url: string,
-  timeoutMs = 5000,
-): Promise<ProbeResult> {
+/** Per-address probe row for the UI / test endpoints (plugin config_test rows). */
+export interface ProbeRow {
+  url: string;
+  ok: boolean;
+  httpOk: boolean;
+  ms: number | null;
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification (port of plugin selfcheck._classify_error)
+//
+// Three-layer semantics: "TLS 证书错误" is reserved for certificate
+// verification failures; a handshake interruption is NOT a certificate error
+// (often a middlebox / fake-ip).
+// ---------------------------------------------------------------------------
+
+export function classifyProbeError(err: unknown, timedOut: boolean): string {
+  if (timedOut) return '连接超时（网络慢或地址不可达）';
+  // undici wraps the real error in `TypeError: fetch failed` — walk the cause
+  // chain collecting codes and messages.
+  const codes: string[] = [];
+  const messages: string[] = [];
+  let cur: unknown = err;
+  for (let i = 0; i < 5 && cur && typeof cur === 'object'; i++) {
+    const e = cur as { code?: unknown; message?: unknown };
+    if (typeof e.code === 'string' && e.code) codes.push(e.code);
+    if (typeof e.message === 'string' && e.message) messages.push(e.message);
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  const msg = messages.join(' | ');
+  if (codes.includes('ENOTFOUND') || codes.includes('EAI_AGAIN') || /getaddrinfo|ENOTFOUND/i.test(msg)) {
+    return 'DNS 解析失败 — 检查域名拼写或内网 IP';
+  }
+  if (codes.includes('ECONNREFUSED')) return '连接被拒绝 — 端口未开放或服务未启动';
+  if (codes.includes('ETIMEDOUT')) return '连接超时（网络慢或地址不可达）';
+  if (
+    /CERTIFICATE_VERIFY_FAILED|certificate verify failed|certificate has expired|certificate is not yet valid|self[- ]signed|unable to verify the first certificate|unable to get local issuer|UNABLE_TO_VERIFY_LEAF_SIGNATURE/i.test(msg)
+  ) {
+    return 'TLS 证书校验失败 — 证书不受信任（自签/过期/链不完整）';
+  }
+  if (codes.includes('EPROTO') || /TLS|SSL|wrong version number|unexpected eof|handshake/i.test(msg)) {
+    return `TLS 握手失败（加密协商被中断）— 常见于：部署机代理/中间盒拦截、DNS 解析到非公网 IP（fake-ip）、服务端协议不匹配｜detail: ${msg.slice(0, 220)}`;
+  }
+  if (codes.includes('ECONNRESET') || codes.includes('EPIPE') || /socket hang up/i.test(msg)) {
+    return '连接被重置 — 网络不稳定或服务端主动断开';
+  }
+  return `连接失败: ${msg.slice(0, 120) || 'unknown error'}`;
+}
+
+// Non-public address segments (port of plugin _FAKE_IP_HINTS): when DNS is
+// hijacked by a proxy, resolution lands in these ranges and the visible error
+// looks like a TLS failure while the root cause is on the deployment host.
+const IP_SEGMENT_HINTS = [
+  { match: (ip) => ip.startsWith('198.18.') || ip.startsWith('198.19.'), label: 'fake-ip 段（代理/Clash 常用，非公网）' },
+  {
+    match: (ip) => ip.startsWith('::ffff:198.18.') || ip.startsWith('::ffff:198.19.'),
+    label: 'fake-ip 段（v4 映射，代理 DNS 劫持典型）',
+  },
+  { match: (ip) => ip.startsWith('fdfe:') || ip.startsWith('fc') || ip.startsWith('fd'), label: 'IPv6 ULA 私有段（非公网）' },
+  {
+    match: (ip) => /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|127\.|169\.254\.)/.test(ip),
+    label: '内网/保留段（非公网）',
+  },
+];
+
+/** Resolve the hostname and diagnose non-public segments (fake-ip / ULA /
+ * private) — the classic "proxy DNS hijack" fingerprint. IP literals get a
+ * plain segment note (no DNS was involved); domains get the full
+ * "DNS may be hijacked by the proxy" diagnosis. Returns '' when public or
+ * when the lookup itself fails (the base error already covers that). */
+export async function resolveIpHint(url: string): Promise<string> {
+  try {
+    const host = new URL(url).hostname;
+    if (!host) return '';
+    const { default: net } = await import('node:net');
+    const describe = (ips: string[]) => {
+      const labels = [
+        ...new Set(ips.map((ip) => IP_SEGMENT_HINTS.find((h) => h.match(ip))?.label).filter((l): l is string => !!l)),
+      ];
+      return labels.length > 0 ? labels.join('；') : '';
+    };
+    // IP literal: no DNS involved — only state the segment.
+    if (net.isIP(host) !== 0) {
+      const note = describe([host]);
+      return note ? `该 IP 属于${note}` : '';
+    }
+    const dns = await import('node:dns');
+    const infos = await dns.promises.lookup(host, { all: true });
+    const ips = infos.slice(0, 3).map((i) => i.address);
+    if (ips.length === 0) return '';
+    const note = describe(ips);
+    if (!note) return '';
+    return `解析到 ${ips.join('/')} — ${note}：域名部署机的 DNS 可能被代理劫持，检查系统代理/DNS 设置（服务端证书本身可能没问题）`;
+  } catch {
+    return '';
+  }
+}
+
+async function probeOnce(name: BackendName, url: string, timeoutMs: number): Promise<ProbeResult> {
   const spec = PROBE_PATHS[name];
   const target = new URL(spec.path, url.replace(/\/+$/, '')).toString();
   const controller = new AbortController();
@@ -336,27 +475,125 @@ export async function probeBackend(
       body: spec.body,
     });
     const latencyMs = Date.now() - startedAt;
-    if (name === 'higress-gateway') {
-      // 404 means the AI route is missing, not that the gateway is down.
-      if (res.status === 404) {
-        return { ok: false, status: 404, latencyMs, error: 'AI route not found (gateway up, route missing)' };
-      }
-      return { ok: true, status: res.status, latencyMs };
+    if (name === 'higress-gateway' && res.status === 404) {
+      // 404 = the gateway answered, but the AI route is missing.
+      return { ok: true, httpOk: false, status: 404, latencyMs, error: '网关在线，AI 路由缺失（HTTP 404）' };
     }
-    if (name === 'higress-console') {
-      return { ok: true, status: res.status, latencyMs };
-    }
-    if (!res.ok) {
-      return { ok: false, status: res.status, latencyMs, error: `HTTP ${res.status}` };
-    }
-    return { ok: true, status: res.status, latencyMs };
+    return { ok: true, httpOk: res.status < 400, status: res.status, latencyMs };
   } catch (err) {
-    return {
-      ok: false,
-      latencyMs: Date.now() - startedAt,
-      error: err instanceof Error && err.name === 'AbortError' ? 'timeout' : err instanceof Error ? err.message : 'Unknown error',
-    };
+    const timedOut = err instanceof Error && err.name === 'AbortError';
+    let error = classifyProbeError(err, timedOut);
+    const hint = await resolveIpHint(url);
+    if (hint) error = `${error}｜${hint}`;
+    return { ok: false, httpOk: false, latencyMs: Date.now() - startedAt, error };
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function probeBackend(
+  name: BackendName,
+  url: string,
+  timeoutMs = 5000,
+): Promise<ProbeResult> {
+  const first = await probeOnce(name, url, timeoutMs);
+  if (first.ok) return first;
+  // v0.4.92 port: a one-off network-layer blip should not fail a row — retry
+  // once after 500ms. Connected results (including 401/403) are never retried.
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return probeOnce(name, url, timeoutMs);
+}
+
+/** Convert a probe result into a UI row (plugin config_test row semantics). */
+export function toProbeRow(url: string, r: ProbeResult): ProbeRow {
+  if (r.ok) {
+    const detail =
+      r.error ??
+      (r.httpOk
+        ? `HTTP ${r.status}，正常`
+        : r.status === 401 || r.status === 403
+          ? `已连通，HTTP ${r.status}（需鉴权）`
+          : `已连通，HTTP ${r.status}（状态异常）`);
+    return { url, ok: true, httpOk: r.httpOk, ms: r.latencyMs, detail };
+  }
+  return { url, ok: false, httpOk: false, ms: null, detail: r.error ?? '不可达' };
+}
+
+// ---------------------------------------------------------------------------
+// Effective-address election (port of plugin selfcheck._select_and_mark)
+// ---------------------------------------------------------------------------
+
+const HYSTERESIS_MIN_MS = 100;
+const HYSTERESIS_RATIO = 0.3;
+
+/** Latency-based fastest-wins + debounce hysteresis: the challenger must be
+ * faster by max(100ms, 30% of the current) before switching; a dead current
+ * switches immediately; nobody reachable → cache untouched. Returns the
+ * effective url (null when nothing is eligible). */
+export function selectAndMark(name: BackendName, rows: ProbeRow[]): string | null {
+  const eligible = rows.filter((r) => r.ok && r.httpOk && r.ms != null);
+  if (eligible.length === 0) return null;
+  const best = eligible.reduce((a, b) => ((a.ms ?? 0) <= (b.ms ?? 0) ? a : b));
+  const current = workingEntry(name)?.url;
+  const curRow = current ? eligible.find((r) => r.url === current) : undefined;
+  if (curRow && best.url !== curRow.url) {
+    const gap = (curRow.ms ?? 0) - (best.ms ?? 0);
+    if (gap <= Math.max(HYSTERESIS_MIN_MS, HYSTERESIS_RATIO * (curRow.ms ?? 0))) {
+      // Keep the current one (touched: it was verified reachable this round).
+      markWorking(name, curRow.url, curRow.ms ?? undefined);
+      return curRow.url;
+    }
+  }
+  markWorking(name, best.url, best.ms ?? undefined);
+  return best.url;
+}
+
+/** True when `tested` equals the SAVED config-file list for the backend
+ * (plugin config_test "applied" comparison). An empty saved list never
+ * applies — draft testing must never rewrite the effective cache. */
+export function listMatchesSaved(name: BackendName, tested: string[]): boolean {
+  const cfg = readConfigSync()?.backends[name];
+  if (!cfg) return false;
+  const saved = [cfg.internal, cfg.external]
+    .filter((v): v is string => !!v && v.trim() !== '')
+    .map((v) => v.trim());
+  if (saved.length === 0) return false;
+  const t = tested.map((u) => u.trim()).filter(Boolean);
+  if (t.length !== saved.length) return false;
+  return saved.every((u) => t.includes(u));
+}
+
+// ---------------------------------------------------------------------------
+// Re-probe + re-elect (port of plugin refresh_effective)
+// ---------------------------------------------------------------------------
+
+export interface RefreshResult {
+  effective: Partial<Record<BackendName, string>>;
+  switched: Partial<Record<BackendName, boolean>>;
+}
+
+/** Probe every candidate of the given backends and re-elect the effective
+ * address. Used by the background re-rank loop (address-probe.ts) and the
+ * post-save re-probe. */
+export async function refreshEffective(
+  names: BackendName[] = BACKEND_NAMES,
+  timeoutMs = 4000,
+): Promise<RefreshResult> {
+  const effective: RefreshResult['effective'] = {};
+  const switched: RefreshResult['switched'] = {};
+  await Promise.all(
+    names.map(async (name) => {
+      const candidates = backendCandidatesSync(name);
+      if (candidates.length === 0) return;
+      const prev = workingEntry(name)?.url ?? null;
+      const results = await Promise.all(candidates.map((url) => probeBackend(name, url, timeoutMs)));
+      const rows = candidates.map((url, i) => toProbeRow(url, results[i]));
+      const picked = selectAndMark(name, rows);
+      if (picked) {
+        effective[name] = picked;
+        if (prev && prev !== picked) switched[name] = true;
+      }
+    }),
+  );
+  return { effective, switched };
 }

--- a/src/lib/backend-config.ts
+++ b/src/lib/backend-config.ts
@@ -396,7 +396,7 @@ export function classifyProbeError(err: unknown, timedOut: boolean): string {
   if (codes.includes('ENOTFOUND') || codes.includes('EAI_AGAIN') || /getaddrinfo|ENOTFOUND/i.test(msg)) {
     return 'DNS 解析失败 — 检查域名拼写或内网 IP';
   }
-  if (codes.includes('ECONNREFUSED')) return '连接被拒绝 — 端口未开放或服务未启动';
+  if (codes.includes('ECONNREFUSED')) return '连接被拒绝 — 端口未开放或服务未启动（公网地址若确认端口开放，亦可能为中间盒/DPI RST 拦截）';
   if (codes.includes('ETIMEDOUT')) return '连接超时（网络慢或地址不可达）';
   if (
     /CERTIFICATE_VERIFY_FAILED|certificate verify failed|certificate has expired|certificate is not yet valid|self[- ]signed|unable to verify the first certificate|unable to get local issuer|UNABLE_TO_VERIFY_LEAF_SIGNATURE/i.test(msg)
@@ -407,7 +407,7 @@ export function classifyProbeError(err: unknown, timedOut: boolean): string {
     return `TLS 握手失败（加密协商被中断）— 常见于：部署机代理/中间盒拦截、DNS 解析到非公网 IP（fake-ip）、服务端协议不匹配｜detail: ${msg.slice(0, 220)}`;
   }
   if (codes.includes('ECONNRESET') || codes.includes('EPIPE') || /socket hang up/i.test(msg)) {
-    return '连接被重置 — 网络不稳定或服务端主动断开';
+    return '连接被重置(RST) — 常见于：中间盒/DPI 拦截（SNI+TLS 栈指纹）、服务端主动断开、网络不稳定';
   }
   return `连接失败: ${msg.slice(0, 120) || 'unknown error'}`;
 }

--- a/src/lib/backend-names.ts
+++ b/src/lib/backend-names.ts
@@ -1,0 +1,45 @@
+// Pure data shared between the server-side backend-config module and
+// client components (the setup page). Kept dependency-free on purpose:
+// this file is importable from the browser bundle, while backend-config.ts
+// uses node:fs and must stay server-only.
+
+export type BackendName =
+  | 'controller'
+  | 'matrix'
+  | 'minio'
+  | 'higress-gateway'
+  | 'higress-console'
+  | 'sglang';
+
+export const BACKEND_NAMES: BackendName[] = [
+  'controller',
+  'matrix',
+  'minio',
+  'higress-gateway',
+  'higress-console',
+  'sglang',
+];
+
+/** Backends that must be reachable for the dashboard to be usable at all
+ * (login + data plane). Others are optional feature backends. */
+export const REQUIRED_BACKENDS: BackendName[] = ['controller', 'matrix'];
+
+/** Embedded topology defaults (same constants the server-side infrastructure
+ * probe uses). Used only for the first-launch auto-detect banner. */
+export const EMBEDDED_DEFAULTS: Record<BackendName, string | undefined> = {
+  controller: 'http://agentteams-controller:8090',
+  matrix: 'http://agentteams-controller:6167',
+  minio: 'http://agentteams-controller:9000',
+  'higress-gateway': 'http://aigw-local.agentteams.io:8080',
+  'higress-console': 'http://agentteams-controller:8001',
+  sglang: undefined,
+};
+
+export const BACKEND_LABELS: Record<BackendName, string> = {
+  controller: 'AgentTeams Controller',
+  matrix: 'Matrix 服务器',
+  minio: 'MinIO 文件存储',
+  'higress-gateway': 'Higress AI 网关',
+  'higress-console': 'Higress Console',
+  sglang: 'SGLang 推理服务（可选）',
+};

--- a/src/lib/dashboard-session.test.ts
+++ b/src/lib/dashboard-session.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createHmac, randomBytes } from 'crypto';
+import { createHmac, randomBytes } from 'node:crypto';
 import {
   SESSION_COOKIE_NAME,
   __resetSessionStoreForTests,

--- a/src/lib/dashboard-session.ts
+++ b/src/lib/dashboard-session.ts
@@ -20,7 +20,7 @@
 //
 // Reference implementation: git d9182c4^:src/lib/auth-local.ts (deleted 7/3).
 
-import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 
 export const SESSION_COOKIE_NAME = 'at_dash_sess';
 const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days

--- a/src/lib/minio-client.ts
+++ b/src/lib/minio-client.ts
@@ -1,4 +1,5 @@
 import * as Minio from 'minio';
+import { pickBackendUrl } from '@/lib/backend-config';
 
 export interface MinioConfig {
   endPoint: string;
@@ -44,7 +45,12 @@ function resolveMinioHost(endpointHost: string): string {
 }
 
 export function getMinioConfigFromEnv(): MinioConfig | null {
-  const endpoint = process.env.AGENTTEAMS_FS_ENDPOINT || process.env.AGENTTEAMS_MINIO_ENDPOINT || '';
+  // F1: first-launch config file (dual address + failover) wins over env.
+  const endpoint =
+    pickBackendUrl('minio') ||
+    process.env.AGENTTEAMS_FS_ENDPOINT ||
+    process.env.AGENTTEAMS_MINIO_ENDPOINT ||
+    '';
   const accessKey =
     process.env.AGENTTEAMS_FS_ACCESS_KEY || process.env.AGENTTEAMS_MINIO_USER || '';
   const secretKey =

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,10 @@ export const runtime = 'nodejs';
 const PUBLIC_PATHS = [
   '/api/agentteams/setup/ensure-ai',
   '/api/agentteams/setup/status',
+  // F1 backend setup: the pre-login first-launch flow must be reachable
+  // before any session exists. Writes are token-gated (pre-login one-shot)
+  // or level-3 session-gated (post-login) inside the route itself.
+  '/api/agentteams/setup/backends',
 ];
 
 const USER_NAME_HEADER = 'x-agentteams-user';


### PR DESCRIPTION

# feat(setup): first-launch backend configuration, shared multi-user mode, and SA-less L2 login

## What

Makes the dashboard deployable standalone in any environment, by three changes:

1. **First-launch backend setup** — a pre-login setup page collects the backend addresses (Controller / Matrix / MinIO / Higress / SGLang, internal + external each), tests them per address, and persists a config file (`DASHBOARD_CONFIG_FILE`) that takes precedence over env. The runtime then **fails over across candidates** (transport error → one same-address retry at 300 ms → next candidate) and **re-ranks in the background** on an adaptive 30 s / 120 s / 300 s schedule (latency-fastest wins, with `max(100 ms, 30 %)` hysteresis so a flapping address cannot thrash). A broken environment is recoverable from the login page itself: "Cannot log in? Backend setup" (`?setup=1`) — no SSH file surgery needed.
2. **Shared multi-user mode** (`DASHBOARD_SHARED_MODE=1`) — for one instance serving several people: only admin (L1) sessions may save the backend config (L2 save → 403), the pre-login setup token is read from env only and never written to the volume, and **every config write is audited** with actor + level + changed fields. Config updates merge per backend (a partial save can no longer wipe the other backends' addresses).
3. **SA-less login** — team members (L2) log in with **their own Matrix account and password only**. The level probe uses the user's own Matrix token against the Controller (`GET /api/v1/status` — the Controller only accepts L2 Matrix tokens, so a 200 is the proof of identity) plus `GET /api/v1/teams` for self-scoped teams; no server-side ServiceAccount token and no pasted credentials are required. Team admins (L1) verify once more with the admin password (when `AGENTTEAMS_AUTH_TOKEN` is set) or by pasting a controller token in the login form.

Also: installer opt-out of the setup-token gate (`DASHBOARD_SETUP_TOKEN_ENFORCE=0`), backend-tab settings (per-backend test buttons, "in effect" badge, switch banner), SGLang health tile, and a batch of login-path fixes (see How).

## Why

- A plain `docker run` in a fresh environment used to open on the login page with no way to enter backend addresses, and a wrong/changed environment permanently locked the UI (the pre-login write path was one-shot). Standalone deployments — each user running their own instance against a shared backend cluster — are the target form and were unusable.
- Multi-user instances had an unreviewed gap: any logged-in user could rewrite all backend addresses (redirecting everyone's data plane), the setup token was persisted to the volume, and config writes were unaudited.
- L2 accounts had to depend on a server-side super credential just to be recognized as a level; the plugin workbench model proves the alternative (the user's own Matrix token as identity, admin token optional for L1 only).

## How

1. **Config layer** (`src/lib/backend-config.ts`) — file > env > embedded defaults, per-backend internal/external candidate lists, probe results cached with a 60 s TTL, node-builtin lazy loads (jsdom-safe).
2. **Setup routes** (`/api/agentteams/setup/backends` + `/test`) — pre-login reachable, gated per data sensitivity: the anonymous GET returns only `{configured, setupTokenRequired, embedded}` (no saved URLs / effective topology); candidates + effective require an authenticated session or the setup token (`?token=`, the same owner gate as the pre-login write — the `?setup=1` reconfigure page prefills the saved addresses once the token is entered). Writes: no config yet → first-launch write; config exists → pre-login writes need the setup token (repeatable override, `mode: first-launch|update`) or 403; post-login L1 reconfigures from settings. The connectivity probe (`/test`) is on the same door as the config write — pre-login callers must hold the setup token, so it is not an unauthenticated fetch proxy — and the SSRF filter additionally denies the cloud metadata sentinel (169.254.169.254) in all modes; `DASHBOARD_ALLOWED_HOSTS` stays available as a strict allowlist. `DASHBOARD_SETUP_TOKEN_ENFORCE=0` removes the pre-login gate (no token generated/printed/persisted, UI hides the field, startup log records the open state — trusted-LAN only). Shared mode: token from env only, otherwise the pre-login path stays closed.
3. **Failover + re-rank** (`src/lib/proxy-helper.ts`, `src/lib/address-probe.ts`, `instrumentation.ts`) — candidate selection working-first → internal → external → env; HTTP responses (including 4xx/5xx) are returned as-is and only `<400` marks an address working; all-candidates-down → 502 with per-address error classes (DNS / refused / timeout / TLS-cert ≠ TLS-handshake / other, plus a fake-IP-range hint for DNS-poisoned environments). Standalone-only background re-ranker with re-entrancy guard.
4. **Login** (`src/app/api/agentteams/login/route.ts`) — three-source level confirmation: server `AGENTTEAMS_AUTH_TOKEN` → controller token pasted at login (validated against the Controller before use) → own-Matrix-token probe. Console-track failures (bad gateway URL, etc.) no longer 502 the whole login endpoint — each track falls through independently. Error text distinguishes TCP RST/REFUSED from timeout (DPI vs network). `/api/v1/teams` called without a trailing slash (Gin 404s on one — this was silently breaking L1 token verification and L2 team scoping).
5. **Shared mode + audit** — `DASHBOARD_SHARED_MODE` switch (L1-only save), per-backend merge in `updateConfig`, config-write audit rows (actor, level, changed fields, source IP), startup warning when a shared instance still carries the SA env.
6. **UI** — setup page (per-backend × per-address test buttons, dual addresses, reconfigure mode), login page "Cannot log in? Backend setup" entry, settings → backends tab (visible per deployment mode, save semantics as above), SGLang tile.
7. **Docs** — README (EN + zh-CN) Docker section rewritten for the three deployment forms with the full `DASHBOARD_*` env table; `.env.example` entries for every new variable.

### New / changed env

| Variable | Required | Effect |
|---|---|---|
| `DASHBOARD_SESSION_SECRET` | **yes** (new) | Session-cookie HMAC secret. Missing/short → login fails closed. Generate once, keep stable across rebuilds. |
| `DASHBOARD_CONFIG_FILE` | no | Backend config file (default `/data/agentteams-dashboard/config.json`); file > env. |
| `DASHBOARD_SETUP_TOKEN` | no (standalone auto-generates + prints once; shared mode: env is the only source) | Pre-login setup write gate. |
| `DASHBOARD_SETUP_TOKEN_ENFORCE` | no (`0` = gate off) | Installer opt-out of the pre-login token. |
| `DASHBOARD_SHARED_MODE` | no (`1` = multi-user) | L1-only config save, env-only setup token, audited writes. |
| `DASHBOARD_ALLOWED_HOSTS` | no | SSRF filter for the setup connectivity probe. |
| `AGENTTEAMS_AUTH_TOKEN` | no | Enables the L1 admin-password login path; in shared mode the only admin credential source. |

### Backwards compatibility

- **Breaking for docker deployments:** `DASHBOARD_SESSION_SECRET` is now required — containers started without it cannot create login sessions (fail closed).
- First-launch page replaces the login page while nothing is configured (standalone only; embedded auto-detection is unchanged).
- The written config file now takes precedence over `AGENTTEAMS_*_URL` env values.
- Shared mode is opt-in; standalone behavior for a single user is the plugin-equivalent model (any logged-in user of that instance can save config).
- No client-visible API changes beyond the new `/api/agentteams/setup/backends*` routes.

## Tests

- New/updated suites: `login` 25/25, `setup backends` 25/25, `backend-config` 41/41, `shared-mode` 16/16, plus failover/re-rank/probe units.
- Full suite: **295 failed / 1050 passed** vs baseline `302 failed / 1013 passed` — zero new failures, 37 pre-existing failures recovered (test-environment directives for node-builtin imports under jsdom). Remaining failures are pre-existing container-environment artifacts (React 19 `act` under production builds, jsdom/vite externalization on node v25), identical to the pre-branch baseline.
- Live verification on two topologies: a shared two-user deployment (L2 Matrix-only login, L1 admin-password login, `?setup=1` reconfiguration, L2 save → 403, audit rows with diff, token-free installer mode) and a standalone single-user deployment (token-free first launch, Matrix-only login, config save without token, address failover observed within one 30 s re-rank cycle, SGLang health tile live data).

## Non-goals (follow-ups)

- Stateless/static deployment form (browser-local config + stateless reverse proxy) — separate effort.
- MinIO credential entry in the UI (env for now).
- SGLang models in the model selector — separate PR (branch `feat/worker-model-sglang`).
- Upstream `GET /api/v1/me` self-scope endpoint — would make the L1 dual-credential confirmation structural instead of env-based.

---

# feat(setup)：首启后端配置、共享多用户模式、L2 零凭据登录

## What（做了什么）

让 dashboard 可在任意环境独立部署，三项改动：

1. **首启后端配置**——登录前 setup 页采集后端地址（Controller / Matrix / MinIO / Higress / SGLang，各内网+外网双地址）、逐地址测试，并持久化配置文件（`DASHBOARD_CONFIG_FILE`，文件优先于 env）。运行时候选集**故障切换**（传输层错误 → 同址重试 1 次 300 ms → 切下一候选）+ 后台按 30 s / 120 s / 300 s 自适应周期**自动重排**（延迟最快者胜，带 `max(100 ms, 30 %)` 滞回，防止抖动地址来回切换）。坏环境从登录页自身即可恢复：「无法登录？后端配置」（`?setup=1`）——无需 SSH 改文件。
2. **共享多用户模式**（`DASHBOARD_SHARED_MODE=1`）——一台实例服务多人的场景：仅管理员（L1）会话可保存后端配置（L2 保存 → 403）；pre-login setup token 只从 env 读取、永不写入卷；**每次配置写都审计**（actor + 级别 + 变更字段）。配置更新按 backend 合并（部分保存不再清空其他后端的地址）。
3. **无 SA 依赖登录**——团队成员（L2）用**自己的 Matrix 账号+密码**即可登录。级别确认用用户自己的 Matrix token 探测 Controller（`GET /api/v1/status`——Controller 只收 L2 Matrix token，故 200 本身即身份实证）+ `GET /api/v1/teams` 取自 scope 团队；不需要服务端 ServiceAccount token，不需要粘贴任何凭据。团队管理员（L1）再多一步验证：admin 密码（需设置 `AGENTTEAMS_AUTH_TOKEN`）或在登录表单粘贴 controller token。

其他：installer 可免除 setup token 门（`DASHBOARD_SETUP_TOKEN_ENFORCE=0`）、settings 后端 tab（逐后端测试按钮、"在生效" badge、切换横幅）、SGLang 健康卡、一批登录路径修复（见 How）。

## Why（为什么）

- 全新环境里裸 `docker run` 过去直接落在登录页、没有任何入口填后端地址；地址错或环境变更后 UI 被永久锁死（pre-login 写路径是一次性的）。独立部署（每个用户自己一台实例连共享后端集群）是目标形态，此前不可用。
- 多用户实例存在未审缺口：任何登录用户可重写全部后端地址（重定向所有人的数据面）、setup token 落盘、配置写无审计。
- L2 账号要靠服务端超级凭据才能被认出级别；插件工作台模型证明了替代路径（用户自己的 Matrix token 即身份，admin token 仅 L1 可选通道）。

## How（怎么做）

1. **配置层**（`src/lib/backend-config.ts`）——文件 > env > 内嵌默认；每后端内网/外网候选列表；探针结果 60 s TTL 缓存；node builtin 懒加载（jsdom 安全）。
2. **Setup 路由**（`/api/agentteams/setup/backends` + `/test`）——public pre-login、门控：无配置 → 一次性首启写；配置已存在 → pre-login 写需 setup token（可重复覆盖，`mode: first-launch|update`）否则 403；登录后 L1 从 settings 重配。`DASHBOARD_SETUP_TOKEN_ENFORCE=0` 解除 pre-login 门（不生成/打印/落盘 token，UI 隐藏字段，启动日志记录开放状态——仅限可信 LAN）。共享模式：token 仅来自 env，否则 pre-login 路径保持关闭。
3. **故障切换 + 重排**（`src/lib/proxy-helper.ts`、`src/lib/address-probe.ts`、`instrumentation.ts`）——候选选择 working 优先 → 内网 → 外网 → env；HTTP 响应（含 4xx/5xx）原样返回，仅 `<400` 标记地址 working；全部不可达 → 502 带逐地址错误分类（DNS / 拒绝 / 超时 / TLS 证书 ≠ TLS 握手 / 其他，另有 DNS 污染环境的 fake-IP 段提示）。仅 standalone 跑后台重排器，带防重入。
4. **登录**（`src/app/api/agentteams/login/route.ts`）——级别确认三源：服务端 `AGENTTEAMS_AUTH_TOKEN` → 登录页粘贴 controller token（先向 Controller 验证再用）→ 自己 Matrix token 探针。Console 轨失败（网关 URL 错等）不再 502 整个登录端点——各轨独立 fall through。错误文案区分 TCP RST/REFUSED 与超时（DPI vs 网络）。`/api/v1/teams` 调用不带尾斜杠（Gin 对尾斜杠 404——此前静默断掉 L1 token 验证与 L2 团队 scope）。
5. **共享模式 + 审计**——`DASHBOARD_SHARED_MODE` 开关（保存仅 L1）、`updateConfig` 按 backend 合并、配置写审计行（actor、级别、变更字段、来源 IP）、共享实例仍带 SA env 时启动警告。
6. **UI**——setup 页（每后端 × 每地址测试按钮、双地址、reconfigure 模式）、登录页「无法登录？后端配置」入口、settings → 后端 tab（按部署形态可见，保存语义同上）、SGLang 卡。
7. **文档**——README（EN + zh-CN）Docker 段按三种部署形态重写、含完整 `DASHBOARD_*` env 表；`.env.example` 每个新变量均有条目。

### 新增 / 变更的 env

| 变量 | 必填 | 作用 |
|---|---|---|
| `DASHBOARD_SESSION_SECRET` | **是**（新增） | 会话 cookie HMAC 密钥。缺失/过短 → 登录 fail closed。生成一次，容器重建保持同一值。 |
| `DASHBOARD_CONFIG_FILE` | 否 | 后端配置文件（默认 `/data/agentteams-dashboard/config.json`）；文件 > env。 |
| `DASHBOARD_SETUP_TOKEN` | 否（standalone 自动生成并打一次日志；共享模式：env 是唯一来源） | pre-login setup 写入门禁。 |
| `DASHBOARD_SETUP_TOKEN_ENFORCE` | 否（`0` = 门关闭） | installer 免除 pre-login token。 |
| `DASHBOARD_SHARED_MODE` | 否（`1` = 多用户） | 保存仅 L1、setup token 仅 env、写操作审计。 |
| `DASHBOARD_ALLOWED_HOSTS` | 否 | setup「测试连接」探针的 SSRF 过滤。 |
| `AGENTTEAMS_AUTH_TOKEN` | 否 | 启用 L1 admin 密码登录路径；共享模式下唯一的 admin 凭据来源。 |

### 向后兼容

- **对 docker 部署 breaking：** `DASHBOARD_SESSION_SECRET` 新必填——不带它启动的容器无法创建登录会话（fail closed）。
- 未配置时首启页替代登录页（仅 standalone；embedded 自动探测行为不变）。
- 写出的配置文件现在优先于 `AGENTTEAMS_*_URL` env 值。
- 共享模式为 opt-in；standalone 单用户行为=插件等价模型（该实例的登录用户均可保存配置）。
- 除新增 `/api/agentteams/setup/backends*` 路由外，无客户端可见 API 变更。

## Tests（测试）

- 新增/更新套件：`login` 25/25、`setup backends` 38/38（含 PR 安全审查的 10 个新用例：匿名 GET 无拓扑 / `?token=` prefill / 错误 token / probe 门控四态 / metadata 哨兵拒绝）、`backend-config` 41/41、`shared-mode` 16/16，另有 failover/重排/探针单测。
- 全量套件：**295 failed / 1060 passed**，基线 `302 failed / 1013 passed`——零新增失败，47 个既有失败被恢复（jsdom 下 node builtin 导入的测试环境指令 + 安全门控测试）。其余失败为既有容器环境产物（React 19 生产构建下 `act` 缺失、node v25 的 jsdom/vite 外化），与本分支前基线完全一致。
- 双拓扑实机验证：共享双用户部署（L2 纯 Matrix 登录、L1 admin 密码登录、`?setup=1` 重配置、L2 保存 → 403、带 diff 的审计行、免 token 安装模式）+ standalone 单用户部署（免 token 首启、纯 Matrix 登录、免 token 保存配置、30 s 重排周期内观察到地址实切、SGLang 健康卡活数据）。

## Non-goals（不做项 / 后续）

- 无状态/静态部署形态（浏览器本地配置 + 无状态反代）——单独工作项。
- MinIO 凭据 UI（暂留 env）。
- 模型选择器的 SGLang 模型层——单独 PR（分支 `feat/worker-model-sglang`）。
- 上游 `GET /api/v1/me` self-scope 端点——把 L1 双凭据确认变成结构性方案（替代 env 依赖）。
