### PR TITLE
fix(models): explain missing alias groups, accept EQUAL predicates, group alias options

### DIFF
--- a/src/components/dashboard/sections/managers-section.tsx
+++ b/src/components/dashboard/sections/managers-section.tsx
@@ -19,9 +19,8 @@ import { useCreateManager, useDeleteManager, useUpdateManager } from '@/hooks/us
 import { useSearch } from '@/lib/search-context';
 import { useAgentTeamsStore } from '@/lib/agentteams-store';
 import { useViewMode } from '@/lib/use-view-mode';
-import { useModels, useAiRoutes } from '@/hooks/use-agentteams-models';
+import { useModelSelection } from '@/hooks/use-model-selection';
 import { buildModelBindings, hasUnavailableModelAliases } from '@/lib/model-bindings';
-import { buildModelSelectionOptions } from '@/lib/model-catalog';
 import { ApiErrorState } from '@/components/dashboard/api-error-state';
 import { SectionHeader } from '@/components/dashboard/section-header';
 import { ConfirmDeleteDialog } from '@/components/dashboard/confirm-delete-dialog';
@@ -99,8 +98,7 @@ export function ManagersSection() {
   const createManager = useCreateManager();
   const deleteManager = useDeleteManager();
   const updateManager = useUpdateManager();
-  const { data: providers } = useModels();
-  const { data: aiRoutes } = useAiRoutes();
+  const { options: modelOptions, providers, aiRoutes, sessionIssue } = useModelSelection();
 
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -112,11 +110,6 @@ export function ManagersSection() {
 
   const [sortKey, setSortKey] = useState<SortKey>('name');
   const { viewMode, handleViewModeChange } = useViewMode('card');
-  const modelOptions = useMemo(
-    () => buildModelSelectionOptions(aiRoutes ?? [], providers ?? []),
-    [aiRoutes, providers],
-  );
-
   const filteredManagers = useMemo(
     () => filterManagers(managers, searchQuery),
     [managers, searchQuery],
@@ -140,7 +133,7 @@ export function ManagersSection() {
   }, [managers]);
 
   const handleCreate = useCallback(() => {
-    if (newManager.model && aiRoutes && providers && hasUnavailableModelAliases(
+    if (newManager.model && !sessionIssue && aiRoutes && providers && hasUnavailableModelAliases(
       [newManager.model],
       buildModelBindings([newManager.model], aiRoutes, providers),
     )) {
@@ -152,7 +145,7 @@ export function ManagersSection() {
         setNewManager({ name: '' });
       },
     });
-  }, [createManager, newManager, aiRoutes, providers]);
+  }, [createManager, newManager, aiRoutes, providers, sessionIssue]);
 
   const handleDelete = useCallback(() => {
     if (deleteTarget) {
@@ -181,7 +174,7 @@ export function ManagersSection() {
     if (!editManager) return;
     const { name: _ignored, ...data } = editForm;
     void _ignored;
-    if (editForm.model && aiRoutes && providers && hasUnavailableModelAliases(
+    if (editForm.model && !sessionIssue && aiRoutes && providers && hasUnavailableModelAliases(
       [editForm.model],
       buildModelBindings([editForm.model], aiRoutes, providers),
     )) {
@@ -201,7 +194,7 @@ export function ManagersSection() {
         },
       },
     );
-  }, [editForm, editManager, updateManager, closeEdit, aiRoutes, providers]);
+  }, [editForm, editManager, updateManager, closeEdit, aiRoutes, providers, sessionIssue]);
 
   const workersList: WorkerResponse[] = workers || [];
   const teamsList: TeamResponse[] = teams || [];
@@ -299,6 +292,7 @@ export function ManagersSection() {
         isPending={createManager.isPending}
         onSubmit={handleCreate}
         modelOptions={modelOptions}
+        sessionIssue={sessionIssue}
       />
 
       <ManagerEditDialog
@@ -310,6 +304,7 @@ export function ManagersSection() {
         onOpenChange={(open) => !open && closeEdit()}
         onSubmit={handleUpdate}
         modelOptions={modelOptions}
+        sessionIssue={sessionIssue}
       />
 
       <ManagerDetailDialog

--- a/src/components/dashboard/sections/managers/manager-create-dialog.tsx
+++ b/src/components/dashboard/sections/managers/manager-create-dialog.tsx
@@ -22,6 +22,8 @@ export function ManagerCreateDialog({
   onOpenChange,
   onSubmit,
   modelOptions,
+  sessionIssue,
+
 }: {
   open: boolean;
   value: CreateManagerRequest;
@@ -30,6 +32,8 @@ export function ManagerCreateDialog({
   onOpenChange: (_open: boolean) => void;
   onSubmit: () => void;
   modelOptions: ModelSelectionOption[];
+  sessionIssue?: string | null;
+
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -53,6 +57,7 @@ export function ManagerCreateDialog({
               onChange={(model) => onChange({ ...value, model })}
               placeholder="例如 team-chat"
               options={modelOptions}
+              sessionIssue={sessionIssue}
             />
             <p className="text-xs text-muted-foreground">
               Manager 通过 AI 网关访问模型，使用 Consumer 凭证认证，无需提供真实 API Key。

--- a/src/components/dashboard/sections/managers/manager-edit-dialog.tsx
+++ b/src/components/dashboard/sections/managers/manager-edit-dialog.tsx
@@ -25,6 +25,8 @@ export function ManagerEditDialog({
   onOpenChange,
   onSubmit,
   modelOptions,
+  sessionIssue,
+
 }: {
   open: boolean;
   managerName: string | null;
@@ -34,6 +36,8 @@ export function ManagerEditDialog({
   onOpenChange: (_open: boolean) => void;
   onSubmit: () => void;
   modelOptions: ModelSelectionOption[];
+  sessionIssue?: string | null;
+
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -49,6 +53,7 @@ export function ManagerEditDialog({
               onChange={(model) => onChange({ ...value, model })}
               placeholder="例如 team-chat"
               options={modelOptions}
+              sessionIssue={sessionIssue}
             />
           </div>
           <div className="space-y-2">

--- a/src/components/dashboard/sections/shared/model-selector.tsx
+++ b/src/components/dashboard/sections/shared/model-selector.tsx
@@ -23,6 +23,18 @@ interface ModelSelectorProps {
   placeholder?: string;
   disabled?: boolean;
   options?: ModelSelectionOption[];
+  // F9②/F10：Higress 模型数据加载失败（Console 会话失效/不可达/未配置）时的
+  // 显式原因 + 出路——不静默平铺（只显内置组而不说明 = 用户以为 alias 丢了）。
+  sessionIssue?: string | null;
+}
+
+function SessionIssueNote({ message }: { message: string }) {
+  return (
+    <p className="rounded-md border border-amber-500/30 bg-amber-500/5 p-2 text-xs text-amber-600 break-words">
+      模型别名组暂不可用：{message}。内置模型与自定义输入仍可使用；以管理员
+      凭据重新登录（Higress Console 轨）后重试即可恢复别名组。
+    </p>
+  );
 }
 
 export function ModelSelector({
@@ -31,6 +43,7 @@ export function ModelSelector({
   placeholder = '选择模型',
   disabled,
   options,
+  sessionIssue,
 }: ModelSelectorProps) {
   const uniqueOptions = [
     ...new Map((options ?? []).map((option) => [option.alias, option])).values(),
@@ -78,6 +91,7 @@ export function ModelSelector({
         <p className="text-xs text-muted-foreground break-words">
           自定义请求模型别名，将由通配符路由或服务端绑定校验处理。
         </p>
+        {sessionIssue ? <SessionIssueNote message={sessionIssue} /> : null}
       </div>
     );
   }
@@ -147,6 +161,7 @@ export function ModelSelector({
             : '在「模型管理」配置模型别名后，此处会提供可选项。'}
         </p>
       )}
+      {sessionIssue ? <SessionIssueNote message={sessionIssue} /> : null}
     </div>
   );
 }

--- a/src/components/dashboard/sections/shared/model-selector.tsx
+++ b/src/components/dashboard/sections/shared/model-selector.tsx
@@ -8,7 +8,9 @@ import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectSeparator,
   SelectTrigger,
   SelectValue,
@@ -48,6 +50,10 @@ export function ModelSelector({
   const uniqueOptions = [
     ...new Map((options ?? []).map((option) => [option.alias, option])).values(),
   ];
+  // 分组对齐插件（可辨认性）：路由可解析的 alias 与需配路由的内置模板分开两组，
+  // 组内按名称排序（buildModelSelectionOptions 已整体排序，filter 保序）。
+  const configuredOptions = uniqueOptions.filter((option) => option.kind === 'configured');
+  const builtinOptions = uniqueOptions.filter((option) => option.kind === 'builtin');
   const known = uniqueOptions.some((option) => option.alias === value);
   const [customMode, setCustomMode] = useState(false);
 
@@ -114,28 +120,46 @@ export function ModelSelector({
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent className="max-w-[min(100vw-2rem,28rem)]">
-          {uniqueOptions.map((option) => (
-            <SelectItem key={option.alias} value={option.alias} className="min-w-0">
-              <span className="flex items-center gap-1.5 min-w-0">
-                <span className="font-mono truncate">{option.alias}</span>
-                {option.kind === 'builtin' && (
-                  <Badge variant="secondary" className="text-[9px] shrink-0">
-                    <Sparkles className="mr-0.5 size-2.5" />
-                    内置
-                  </Badge>
-                )}
-              </span>
-              {option.kind === 'configured' && option.binding ? (
-                <span className="block truncate text-xs text-muted-foreground">
-                  {option.binding.routeName} / {option.binding.providerName} / {option.binding.targetModel}
-                </span>
-              ) : (
-                <span className="block truncate text-xs text-muted-foreground">
-                  内置模型，需在「模型管理」配置路由映射
-                </span>
-              )}
-            </SelectItem>
-          ))}
+          {configuredOptions.length > 0 && (
+            <SelectGroup>
+              <SelectLabel>Higress alias（路由可解析）</SelectLabel>
+              {configuredOptions.map((option) => (
+                <SelectItem key={option.alias} value={option.alias} className="min-w-0">
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    <span className="font-mono truncate">{option.alias}</span>
+                  </span>
+                  {option.kind === 'configured' && option.binding ? (
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {option.binding.routeName} / {option.binding.providerName} / {option.binding.targetModel}
+                    </span>
+                  ) : (
+                    <span className="block truncate text-xs text-muted-foreground">
+                      网关路由可解析
+                    </span>
+                  )}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          )}
+          {builtinOptions.length > 0 && (
+            <SelectGroup>
+              <SelectLabel>Higress 内置 alias（需配路由映射）</SelectLabel>
+              {builtinOptions.map((option) => (
+                <SelectItem key={option.alias} value={option.alias} className="min-w-0">
+                  <span className="flex items-center gap-1.5 min-w-0">
+                    <span className="font-mono truncate">{option.alias}</span>
+                    <Badge variant="secondary" className="text-[9px] shrink-0">
+                      <Sparkles className="mr-0.5 size-2.5" />
+                      内置
+                    </Badge>
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    内置模型，需在「模型管理」配置路由映射
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          )}
           {uniqueOptions.length > 0 && <SelectSeparator />}
           <SelectItem value={CUSTOM_ALIAS}>
             <span className="flex items-center gap-1.5 text-muted-foreground">

--- a/src/components/dashboard/sections/teams-section.tsx
+++ b/src/components/dashboard/sections/teams-section.tsx
@@ -15,7 +15,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTeams } from '@/hooks/use-agentteams-teams';
 import { useWorkers } from '@/hooks/use-agentteams-workers';
 import { useManagers } from '@/hooks/use-agentteams-managers';
-import { useModels, useAiRoutes } from '@/hooks/use-agentteams-models';
+import { useModelSelection } from '@/hooks/use-model-selection';
 import { useCreateTeam, useDeleteTeam, useUpdateTeam } from '@/hooks/use-agentteams-mutations';
 import { useSearch } from '@/lib/search-context';
 import { useAgentTeamsStore } from '@/lib/agentteams-store';
@@ -26,7 +26,6 @@ import { ConfirmDeleteDialog } from '@/components/dashboard/confirm-delete-dialo
 import { toast } from 'sonner';
 import { formatErrorMessage } from '@/lib/api-error';
 import type { CreateTeamRequest, UpdateTeamRequest, TeamResponse, WorkerResponse, ManagerResponse } from '@/lib/agentteams-api';
-import { buildModelSelectionOptions } from '@/lib/model-catalog';
 import { ITEMS_PER_PAGE, SORT_OPTIONS, type SortKey } from './teams/team-types';
 import {
   filterTeams,
@@ -92,12 +91,7 @@ export function TeamsSection() {
   const { data: teams, isLoading, isError, refetch, isRefetching } = useTeams();
   const { data: workers } = useWorkers();
   const { data: managers } = useManagers();
-  const { data: providers } = useModels();
-  const { data: aiRoutes } = useAiRoutes();
-  const modelOptions = useMemo(
-    () => buildModelSelectionOptions(aiRoutes ?? [], providers ?? []),
-    [aiRoutes, providers],
-  );
+  const { options: modelOptions, sessionIssue } = useModelSelection();
   const { searchQuery } = useSearch();
   const { isConnected } = useAgentTeamsStore();
   const createTeam = useCreateTeam();
@@ -420,6 +414,7 @@ export function TeamsSection() {
         onSubmit={handleCreate}
         workers={workersList}
         modelOptions={modelOptions}
+        sessionIssue={sessionIssue}
       />
 
       <TeamEditDialog

--- a/src/components/dashboard/sections/teams/team-create-dialog.tsx
+++ b/src/components/dashboard/sections/teams/team-create-dialog.tsx
@@ -49,6 +49,8 @@ export function TeamCreateDialog({
   onSubmit,
   workers,
   modelOptions,
+  sessionIssue,
+
 }: {
   open: boolean;
   value: CreateTeamRequest;
@@ -58,6 +60,8 @@ export function TeamCreateDialog({
   onSubmit: () => void;
   workers: WorkerResponse[];
   modelOptions?: ModelSelectionOption[];
+  sessionIssue?: string | null;
+
 }) {
   // Keep the raw worker list text locally so a trailing separator the user
   // types (e.g. "worker1,") is preserved on screen; value.workerNames always
@@ -170,6 +174,7 @@ export function TeamCreateDialog({
               }
               placeholder="例如 team-chat"
               options={modelOptions ?? []}
+              sessionIssue={sessionIssue}
             />
             <p className="text-xs text-muted-foreground">
               仅在自动建站时使用。可在 Worker 列表中单独调整已存在 Worker 的模型。

--- a/src/components/dashboard/sections/workers-section.tsx
+++ b/src/components/dashboard/sections/workers-section.tsx
@@ -26,9 +26,8 @@ import { agentteamsApi } from '@/lib/agentteams-api';
 import { useAgentTeamsStore } from '@/lib/agentteams-store';
 import { useViewMode } from '@/lib/use-view-mode';
 import { RUNTIME_LABELS } from '@/lib/phase-colors';
-import { useModels, useAiRoutes } from '@/hooks/use-agentteams-models';
+import { useModelSelection } from '@/hooks/use-model-selection';
 import { buildModelBindings, hasUnavailableModelAliases } from '@/lib/model-bindings';
-import { buildModelSelectionOptions } from '@/lib/model-catalog';
 import { ApiErrorState } from '@/components/dashboard/api-error-state';
 import { SectionHeader } from '@/components/dashboard/section-header';
 import { ConfirmDeleteDialog } from '@/components/dashboard/confirm-delete-dialog';
@@ -168,8 +167,7 @@ export function WorkersSection() {
   const ensureReadyWorker = useEnsureReadyWorker();
   const updateWorker = useUpdateWorker();
   // Soft model alias validation (embedded mode): warn but allow submit.
-  const { data: providers } = useModels();
-  const { data: aiRoutes } = useAiRoutes();
+  const { options: modelOptions, providers, aiRoutes, sessionIssue } = useModelSelection();
 
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -195,10 +193,7 @@ export function WorkersSection() {
   const [newWorker, setNewWorker] = useState<CreateWorkerRequest>({ name: '', runtime: 'openclaw' });
   const [editForm, setEditForm] = useState<WorkerEditForm>({});
   const [agentSpecs, setAgentSpecs] = useState<Array<{ name: string; description: string; version: string }>>([]);
-  const modelOptions = useMemo(
-    () => buildModelSelectionOptions(aiRoutes ?? [], providers ?? []),
-    [aiRoutes, providers],
-  );
+  // modelOptions 来自 useModelSelection（上方）——同源单一实现。
 
   const filtered = useMemo(() => filterWorkers(workers, searchQuery), [workers, searchQuery]);
   const sorted = useMemo(() => sortWorkers(filtered, sortKey), [filtered, sortKey]);
@@ -346,12 +341,13 @@ export function WorkersSection() {
   // surface a toast.warning so the user knows the worker may fail to call LLMs,
   // but still let the mutation go through.
   const warnIfModelAliasUnbound = useCallback((model: string | undefined) => {
-    if (!model || !aiRoutes || !providers) return;
+    // F9②：会话不可用时数据未加载 ≠ 未配置——不误报"无可解析绑定"。
+    if (!model || sessionIssue || !aiRoutes || !providers) return;
     const bindings = buildModelBindings([model], aiRoutes, providers);
     if (hasUnavailableModelAliases([model], bindings)) {
       toast.warning(`请求模型别名 "${model}" 在当前 AI 路由中无可解析绑定，Worker 调用 LLM 可能失败。请在「AI 网关」中配置对应路由。`);
     }
-  }, [aiRoutes, providers]);
+  }, [aiRoutes, providers, sessionIssue]);
 
   const syncWorkerSkills = useCallback(async (workerName: string, skillNames: string[]) => {
     if (!skillNames.length) return;
@@ -820,6 +816,7 @@ export function WorkersSection() {
         isPending={createWorker.isPending}
         onSubmit={handleCreate}
         modelOptions={modelOptions}
+        sessionIssue={sessionIssue}
         agentSpecs={agentSpecs}
       />
 
@@ -832,6 +829,7 @@ export function WorkersSection() {
         onOpenChange={(open) => !open && closeEdit()}
         onSubmit={handleUpdate}
         modelOptions={modelOptions}
+        sessionIssue={sessionIssue}
       />
 
       <WorkerDetailDialog

--- a/src/components/dashboard/sections/workers/worker-create-dialog.tsx
+++ b/src/components/dashboard/sections/workers/worker-create-dialog.tsx
@@ -42,6 +42,8 @@ export function WorkerCreateDialog({
   isPending,
   onSubmit,
   modelOptions,
+  sessionIssue,
+
   agentSpecs,
 }: {
   open: boolean;
@@ -51,6 +53,8 @@ export function WorkerCreateDialog({
   isPending: boolean;
   onSubmit: () => void;
   modelOptions: ModelSelectionOption[];
+  sessionIssue?: string | null;
+
   agentSpecs?: AgentSpecTemplateOption[];
 }) {
   const nameError = workerNameError(value.name);
@@ -186,6 +190,7 @@ export function WorkerCreateDialog({
                 onChange={(model) => onChange({ ...value, model })}
                 placeholder="例如 team-chat"
                 options={modelOptions}
+              sessionIssue={sessionIssue}
               />
             </div>
             <p className="text-xs text-muted-foreground break-words">

--- a/src/components/dashboard/sections/workers/worker-edit-dialog.tsx
+++ b/src/components/dashboard/sections/workers/worker-edit-dialog.tsx
@@ -36,6 +36,8 @@ export function WorkerEditDialog({
   onOpenChange,
   onSubmit,
   modelOptions,
+  sessionIssue,
+
 }: {
   open: boolean;
   workerName: string | null;
@@ -45,6 +47,8 @@ export function WorkerEditDialog({
   onOpenChange: (_open: boolean) => void;
   onSubmit: () => void;
   modelOptions: ModelSelectionOption[];
+  sessionIssue?: string | null;
+
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -60,6 +64,7 @@ export function WorkerEditDialog({
               onChange={(model) => onChange({ ...value, model })}
               placeholder="例如 team-chat"
               options={modelOptions}
+              sessionIssue={sessionIssue}
             />
           </div>
           <div className="space-y-2">

--- a/src/hooks/use-model-selection.ts
+++ b/src/hooks/use-model-selection.ts
@@ -1,0 +1,53 @@
+'use client';
+
+// Model selection single source of truth (same-source single-implementation
+// rule): providers + routes → buildModelSelectionOptions, plus an explicit
+// "alias group unavailable" signal.
+//
+// Why the signal exists (F9②/F10, dashboard alias issue): the Higress
+// Console session (_hi_sess) is validated server-side per request. When it is
+// missing/expired, both queries below fail (401 "A valid Higress Console
+// session is required" / 503 configuration error) and `data` is undefined —
+// the old call sites fell back to `?? []` and rendered a builtins-only
+// selector with no explanation (the user-visible "only the 16 built-in
+// aliases" symptom). Consumers must surface the reason + the way out instead
+// of silently degrading.
+import { useMemo } from 'react';
+import { useModels, useAiRoutes } from '@/hooks/use-agentteams-models';
+import {
+  buildModelSelectionOptions,
+  type ModelSelectionOption,
+} from '@/lib/model-catalog';
+import type { AiRoute, LlmProviderResponse } from '@/lib/higress-api';
+
+export interface ModelSelection {
+  options: ModelSelectionOption[];
+  // Raw data for callers that also need binding-level checks
+  // (buildModelBindings / hasUnavailableModelAliases submit guards).
+  providers: LlmProviderResponse[];
+  aiRoutes: AiRoute[];
+  isLoading: boolean;
+  // Set when the Higress data could not be loaded (console session invalid,
+  // console unreachable, or misconfigured). Actionable wording for the UI;
+  // null = data loaded (alias group reflects the real gateway state).
+  sessionIssue: string | null;
+}
+
+export function useModelSelection(): ModelSelection {
+  const models = useModels();
+  const routes = useAiRoutes();
+  const providers = models.data ?? [];
+  const aiRoutes = routes.data ?? [];
+  const options = useMemo(
+    () => buildModelSelectionOptions(aiRoutes, providers),
+    [aiRoutes, providers],
+  );
+  const error = (models.error ?? routes.error) as Error | null;
+  return {
+    options,
+    providers,
+    aiRoutes,
+    isLoading: models.isLoading || routes.isLoading,
+    sessionIssue: error ? error.message || '加载 Higress 模型数据失败' : null,
+  };
+}

--- a/src/lib/model-bindings.test.ts
+++ b/src/lib/model-bindings.test.ts
@@ -92,6 +92,30 @@ describe('model bindings', () => {
     expect(() => buildModelBindings(['team-chat'], [route], [{ name: 'openai', type: 'openai', tokenCount: 1 }])).not.toThrow();
   });
 
+  it('collects aliases from Console-native EQUAL predicates (not just EXACT)', () => {
+    // 2026-09-10 Node1 live data: Higress Console-created routes use
+    // matchType 'EQUAL' (dashboard-created routes use 'EXACT'). The
+    // deepseek-v4-pro custom-model route was invisible to the selector
+    // because collection only accepted EXACT.
+    const route = {
+      name: 'default-ai-route',
+      pathPredicate: { matchType: 'PRE', matchValue: '/v1' },
+      modelPredicates: [{ matchType: 'EQUAL', matchValue: 'deepseek-v4-pro' } as { matchType: string; matchValue: string }],
+      upstreams: [{ provider: 'openai-compat', weight: 100 }],
+    };
+    const bindings = listAvailableRequestModelAliases(
+      [route],
+      [{ name: 'openai-compat', type: 'openai', tokenCount: 1 }],
+    );
+    expect(bindings.map((b) => b.requestModelAlias)).toContain('deepseek-v4-pro');
+    const binding = bindings.find((b) => b.requestModelAlias === 'deepseek-v4-pro');
+    // 有 predicate（非 passthrough）+ provider 在列 → available
+    expect(binding?.available).toBe(true);
+    expect(binding?.routeName).toBe('default-ai-route');
+    // 无 modelMapping → 目标 = 请求模型名原样转发
+    expect(binding?.targetModel).toBe('deepseek-v4-pro');
+  });
+
   it('does not emit duplicate bindings when a route lists the same provider twice', () => {
     const bindings = buildModelBindings(
       ['team-chat'],

--- a/src/lib/model-bindings.ts
+++ b/src/lib/model-bindings.ts
@@ -17,6 +17,14 @@ function matchesPattern(value: string, pattern: string): boolean {
   return new RegExp(expression).test(value);
 }
 
+// 精确匹配 predicate 的 matchType 有**两种写法**：dashboard 建路由写 `EXACT`
+// （models-section.tsx 下拉），Higress Console 原生建路由写 `EQUAL`（Node1
+// 活体数据实锤）。只收 EXACT 会让 Console 建的路由 alias 全部漏收（2026-09-10
+// 罗总实报：deepseek-v4-pro 自定义模型不见）。两种都收。
+function isExactMatchType(matchType: string | undefined): boolean {
+  return matchType === 'EXACT' || matchType === 'EQUAL';
+}
+
 function routeMatchesAlias(route: AiRoute, alias: string): boolean {
   const predicates = route.modelPredicates ?? [];
   if (predicates.length === 0) return true;
@@ -100,9 +108,9 @@ function collectAllAliases(
         }
       }
     }
-    // Route modelPredicates (EXACT)
+    // Route modelPredicates (EXACT/EQUAL — Console 原生路由用 EQUAL)
     for (const predicate of route.modelPredicates ?? []) {
-      if (predicate.matchType === 'EXACT') {
+      if (isExactMatchType(predicate.matchType)) {
         const alias = typeof predicate.matchValue === 'string' ? predicate.matchValue.trim() : '';
         if (alias && !alias.includes('*') && !alias.startsWith('~')) aliases.add(alias);
       }
@@ -253,7 +261,7 @@ export function listAvailableRequestModelAliases(
   for (const route of routes) {
     for (const predicate of route.modelPredicates ?? []) {
       const alias = typeof predicate.matchValue === 'string' ? predicate.matchValue.trim() : '';
-      if (predicate.matchType === 'EXACT' && alias && !alias.includes('*') && !alias.startsWith('~')) {
+      if (isExactMatchType(predicate.matchType) && alias && !alias.includes('*') && !alias.startsWith('~')) {
         aliases.add(alias);
       }
     }

--- a/src/lib/model-equal-predicates.test.ts
+++ b/src/lib/model-equal-predicates.test.ts
@@ -1,0 +1,55 @@
+// EQUAL predicate contract regression (F10, dashboard alias issue).
+//
+// Two independent layers must both accept Higress Console's 'EQUAL'
+// matchType (dashboard-created routes write 'EXACT'; Console-created routes
+// write 'EQUAL' — Node1 live data, 2026-09-10):
+//   1. lib layer — listAvailableRequestModelAliases accepts EQUAL (22b23a2,
+//      covered in model-bindings.test.ts).
+//   2. client chain — higressApi.listRoutes() normalizes EQUAL→EXACT via
+//      restoreMatchTypeFromApi before collection (ce2a0ed). This test locks
+//      that normalization, so removing the rewrite would fail loudly instead
+//      of silently emptying the alias group.
+import { describe, it, expect } from 'vitest';
+import { restoreMatchTypeFromApi } from '@/lib/higress-api';
+import { listAvailableRequestModelAliases } from '@/lib/model-bindings';
+import { buildModelSelectionOptions } from '@/lib/model-catalog';
+
+const node1Route = {
+  name: 'default-ai-route',
+  pathPredicate: { matchType: 'PRE', matchValue: '/v1' },
+  modelPredicates: [{ matchType: 'EQUAL', matchValue: 'deepseek-v4-flash' }],
+  upstreams: [{ provider: 'openai-compat', weight: 100 }],
+} as any;
+const node1Providers = [{ name: 'openai-compat', tokenCount: 1 }] as any[];
+
+// mirrors the mapping in higressApi.listRoutes()
+function asClientSeesIt(route: any) {
+  return {
+    ...route,
+    pathPredicate: {
+      ...route.pathPredicate,
+      ...restoreMatchTypeFromApi(route.pathPredicate.matchType, route.pathPredicate.matchValue),
+    },
+    modelPredicates: (route.modelPredicates ?? []).map((p: any) => ({
+      ...p,
+      ...restoreMatchTypeFromApi(p.matchType, p.matchValue),
+    })),
+  };
+}
+
+describe('EQUAL predicates through the full client chain', () => {
+  it('restores EQUAL to EXACT on read', () => {
+    expect(restoreMatchTypeFromApi('EQUAL', 'm')).toEqual({ matchType: 'EXACT', matchValue: 'm' });
+  });
+
+  it('collects Console-native aliases after the client rewrite', () => {
+    const options = buildModelSelectionOptions([asClientSeesIt(node1Route)], node1Providers);
+    const configured = options.filter((o) => o.kind === 'configured');
+    expect(configured.map((o) => o.alias)).toContain('deepseek-v4-flash');
+  });
+
+  it('collects Console-native aliases at the lib layer without the rewrite', () => {
+    const bindings = listAvailableRequestModelAliases([node1Route], node1Providers);
+    expect(bindings.map((b) => b.requestModelAlias)).toContain('deepseek-v4-flash');
+  });
+});

--- a/src/plugins/wen-tian/index.tsx
+++ b/src/plugins/wen-tian/index.tsx
@@ -43,8 +43,7 @@ import { toast } from 'sonner';
 import { apiUrl } from '@/lib/api-base';
 import { pluginSectionId, type DashboardPluginApi } from '@/lib/plugins/types';
 import { useMatrixStore } from '@/lib/matrix-store';
-import { useAiRoutes, useModels } from '@/hooks/use-agentteams-models';
-import { buildModelSelectionOptions } from '@/lib/model-catalog';
+import { useModelSelection } from '@/hooks/use-model-selection';
 import type { WorkerResponse, TeamResponse, HumanResponse, InfrastructureInfo } from '@/lib/agentteams-api';
 
 /**
@@ -382,12 +381,8 @@ function DiagnosisModelSelect({
   onChange: (_value: string) => void;
   disabled?: boolean;
 }) {
-  const { data: providers } = useModels();
-  const { data: aiRoutes } = useAiRoutes();
-  const options = useMemo(
-    () => buildModelSelectionOptions(aiRoutes ?? [], providers ?? []),
-    [aiRoutes, providers]
-  );
+  const { options, sessionIssue } = useModelSelection();
+  // F9②/F10：sessionIssue = Higress 模型数据加载失败（Console 会话失效/不可达）
   const configured = options.filter((o) => o.kind === 'configured');
   const builtin = options.filter((o) => o.kind === 'builtin');
   const [customMode, setCustomMode] = useState(false);
@@ -428,6 +423,11 @@ function DiagnosisModelSelect({
             从列表选择
           </Button>
         </div>
+        {sessionIssue && (
+          <p className="rounded-md border border-amber-500/30 bg-amber-500/5 p-2 text-xs text-amber-600 break-words">
+            模型别名组暂不可用：{sessionIssue}。默认模型与自定义输入仍可使用；以管理员凭据重新登录（Higress Console 轨）后重试即可恢复。
+          </p>
+        )}
       </div>
     );
   }
@@ -512,6 +512,11 @@ function DiagnosisModelSelect({
           内置模型别名，需先在「模型管理」为其配置路由映射，否则调用可能失败。
         </p>
       ) : null}
+      {sessionIssue && (
+        <p className="rounded-md border border-amber-500/30 bg-amber-500/5 p-2 text-xs text-amber-600 break-words">
+          模型别名组暂不可用：{sessionIssue}。默认模型与自定义输入仍可使用；以管理员凭据重新登录（Higress Console 轨）后重试即可恢复。
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# fix(models): explain missing alias groups, accept EQUAL predicates, group alias options

## What

Two fixes for the "model selector only shows the built-in aliases" symptom:

1. **Explicit alias-group failure state** — when the dashboard cannot load Higress model data (missing/expired Console session → 401, console unreachable or misconfigured → 503), the provider/route queries failed and every model selector silently fell back to the built-in 16 aliases with no explanation. Now a single `useModelSelection()` hook exposes the load failure as `sessionIssue`, and every model select (manager create/edit, team create, worker create/edit, and the wen-tian diagnosis selector) renders an actionable note: the reason plus the way out (re-login with admin credentials via the Higress Console track). Built-in aliases and free typing remain usable while the group is unavailable. Submit guards also stop warning "alias has no resolvable binding" when the data simply could not be loaded (data-not-loaded ≠ not-configured).
2. **EQUAL model predicates** — Higress Console-created AI routes use `matchType: 'EQUAL'` for exact model matching while dashboard-created routes use `'EXACT'`. Alias collection in `model-bindings` only accepted `EXACT`, so Console-created route aliases could be silently dropped when the raw predicate reaches the collector. Both are now accepted, with a regression test locking the full client chain (the client-side `EQUAL→EXACT` normalization in `higressApi.listRoutes()` is asserted as well, so removing it would fail loudly instead of emptying the alias group).
3. **Grouped selector options** — the selector's flat sorted list mixed route-resolvable aliases with built-in templates (distinguished only by a small badge), which was hard to tell apart. The shared `ModelSelector` — the single rendering point for all six selectors — now renders two labeled groups: "Higress alias (route-resolvable)" and "Higress builtin alias (route mapping required)", aligned with the plugin's selector grouping.

## Why

- The alias group's data path is: browser → Next.js API proxy → Higress Console, where the Console session cookie (`_hi_sess`) is validated **server-side, per request**. When that session is absent or expired, both queries fail and the old call sites collapsed the error into `?? []` — the user saw "only builtins" and had no way to tell the gateway state from a broken session. This was the reported dashboard counterpart of the plugin's alias issue.
- `EXACT`/`EQUAL` is an external-system enum (Higress Console writes `EQUAL` natively), not a UI convention — collecting on the dashboard's own convention alone is an extraction blind spot against Console-managed deployments.
- The two kinds of options answer different questions ("this alias routes to a real gateway route" vs "this alias needs a route mapping first") — a flat list with a badge forces the user to read each row to tell them apart.

## How

1. `src/hooks/use-model-selection.ts` (new) — single source of truth for model selection: one pair of `useModels()`/`useAiRoutes()` calls → `buildModelSelectionOptions()` options + raw `providers`/`aiRoutes` (for the existing `buildModelBindings` submit guards) + `sessionIssue` (error message when either query failed). Replaces four duplicated call sites (managers / teams / workers sections + wen-tian plugin).
2. `shared/model-selector.tsx` — new optional `sessionIssue` prop; an amber note is rendered in both the list and custom-input modes. The five dialog components pass it through (one prop each).
3. `wen-tian/index.tsx` — its own diagnosis select gets the same note (the plugin's select is intentionally separate: it has a "server default model" option the shared selector does not).
4. Submit guards (managers create/edit, workers `warnIfModelAliasUnbound`) — skip the "unresolvable binding" warning when `sessionIssue` is set.
5. `model-bindings.ts` — `isExactMatchType()` accepts `EXACT` **or** `EQUAL` in the two collection paths; plus `model-equal-predicates.test.ts` (3 tests) covering the normalization contract and both layers.
6. `shared/model-selector.tsx` — options split into `configuredOptions` / `builtinOptions` and rendered as two `SelectGroup` blocks with `SelectLabel` headers (per-option content unchanged: route details for configured, mapping hint for builtins).

## Tests

- 4 new tests: EQUAL collection at the lib layer (with a regression test committed alongside the collector fix) + 3 contract tests for the full client chain (normalization, collection after rewrite, collection without rewrite).
- Full suite in this environment: **295F / 1064P** vs the pre-change baseline **295F / 1060P** — the 295 failures are pre-existing environmental failures (jsdom/network-dependent suites, unchanged by this PR), the delta is exactly the 4 new passing tests.
- The grouping change is a pure rendering split in one shared component: no new tests (the 295F/1064P baseline is unchanged by it); verified by `tsc`/`eslint`/`next build` green.
- `tsc --noEmit` 0 errors; `eslint` 0 new errors (2 pre-existing hook-deps warnings in the touched files); `next build` green.

## Non-goals (follow-ups)

- SGLang online-model layer in the selector (F4, separate PR).
- L2-specific wording in the note (the session note is accurate for all levels; L2 users simply cannot hold a Console session).
- Rewording the Models-tab error line (it already shows the failure via `ResourceError`; the actionable note now also covers every dialog).

---

# fix(models)：模型别名组缺失显式化 + EQUAL 谓词 + alias/内置分组

## What（做了什么）

针对「模型选择器只剩内置别名」现象的两个修复：

1. **别名组失败态显式化**——当 dashboard 无法加载 Higress 模型数据（Console 会话缺失/过期 → 401；Console 不可达/未配置 → 503）时，providers/routes 两个查询失败后，所有模型选择器此前**静默回退**到内置 16 个别名且无任何解释。现在由单一的 `useModelSelection()` hook 把加载失败暴露为 `sessionIssue`，所有模型选择器（Manager 建/改、Team 建、Worker 建/改、文天诊断选择器）渲染可操作提示：原因 + 出路（以管理员凭据经 Higress Console 轨重新登录）。别名组不可用期间，内置别名与自由输入仍可使用。提交守卫同时不再在「数据根本没加载」时误报「别名无可解析绑定」（数据未加载 ≠ 未配置）。
2. **EQUAL 模型谓词**——Higress Console 原生创建的 AI 路由精确模型匹配用 `matchType: 'EQUAL'`，dashboard 创建的路由用 `'EXACT'`。`model-bindings` 的 alias 收集此前只收 `EXACT`，Console 建的路由 alias 在原始谓词直达收集器时会被静默丢弃。现在两种都收，并附回归测试锁定完整客户端链（`higressApi.listRoutes()` 里既有的 `EQUAL→EXACT` 归一化也被断言——若将来有人删掉归一化，测试会响亮失败而不是让别名组悄悄变空）。
3. **选择器选项分组**——原平铺排序列表把「路由可解析」的 alias 与「需配路由映射」的内置模板混在一组（仅靠一个小徽章区分，难以辨认）。共享 `ModelSelector`（六处选择器的唯一渲染点）改为两个带标签的分组：「Higress alias（路由可解析）」/「Higress 内置 alias（需配路由映射）」，与插件选择器分组对齐。

## Why（为什么）

- 别名组的数据链路 = 浏览器 → Next.js API 代理 → Higress Console，Console 会话 cookie（`_hi_sess`）是**服务端、按请求**校验的。会话缺失/过期时两个查询失败，旧调用点把错误折叠成 `?? []`——用户看到「只剩内置」，且无法区分「网关真没配」和「会话断了」。这就是插件 alias 问题在 dashboard 侧的对应物。
- `EXACT`/`EQUAL` 是外部系统枚举（Higress Console 原生写 `EQUAL`），不是 UI 约定——只按自家 UI 写的值收集，对 Console 管理的部署就是提取盲区。
- 两类选项回答的是不同问题（「这个 alias 有真实网关路由」vs「这个 alias 需要先配路由映射」）——平铺+徽章要求用户逐行阅读才能区分。

## How（怎么做）

1. `src/hooks/use-model-selection.ts`（新）——模型选择单一真相源：一对 `useModels()`/`useAiRoutes()` 调用 → `buildModelSelectionOptions()` 选项 + 原始 `providers`/`aiRoutes`（供既有 `buildModelBindings` 提交守卫用）+ `sessionIssue`（任一查询失败时=错误信息）。替换 4 个重复调用点（managers / teams / workers 三个 section + 文天插件）。
2. `shared/model-selector.tsx`——新增可选 `sessionIssue` prop；列表模式与自定义输入模式都渲染琥珀色提示。5 个 dialog 组件各透传一个 prop。
3. `wen-tian/index.tsx`——其诊断选择器（有「服务器默认模型」选项，与共享选择器有意分开）加同款提示。
4. 提交守卫（managers 建/改、workers `warnIfModelAliasUnbound`）——`sessionIssue` 存在时跳过「无可解析绑定」警告。
5. `model-bindings.ts`——`isExactMatchType()` 在两条收集路径上收 `EXACT` **或** `EQUAL`；另加 `model-equal-predicates.test.ts`（3 个测试）覆盖归一化契约与两层收集。
6. `shared/model-selector.tsx`——选项拆为 `configuredOptions` / `builtinOptions`，渲染为两个 `SelectGroup`（`SelectLabel` 组头）；单项内容不变（configured 带路由详情，built-in 带配路由提示）。

## Tests（测试）

- 4 个新测试：lib 层 EQUAL 收集（随收集器修复一起提交的回归测试）+ 3 个完整客户端链契约测试（归一化、归一化后收集、无归一化收集）。
- 本环境全量套件：**295F / 1064P**，改前基线 **295F / 1060P**——295 个失败为本环境既有失败（jsdom/网络依赖套件，本 PR 未触及），增量恰为 4 个新通过的测试。
- 分组改动=单一共享组件的纯渲染拆分：无新增测试（295F/1064P 基线不变）；`tsc`/`eslint`/`next build` 绿验证。
- `tsc --noEmit` 0 错；`eslint` 0 新增 error（改动文件里 2 个既有 hook-deps warning）；`next build` 绿。

## Non-goals（不做项 / 后续）

- 选择器里的 SGLang 在线模型层（F4，单独 PR）。
- 提示文案的 L2 特化（会话提示对各级别都准确；L2 只是拿不到 Console 会话）。
- Models tab 报错行文案优化（它已通过 `ResourceError` 显示失败；本次把可操作提示补到了所有弹窗）。
